### PR TITLE
add .darts to ignored folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ examples/.ipynb_checkpoints/
 runs/
 .coverage
 htmlcov
-
+.darts
 docs_env


### PR DESCRIPTION
when running the notebooks a folder `.darts` get populated with checkpoints and tensorboard logs that shouldn't be included in VCS.