### PR TITLE
Proposal for preprocessing pipeline

### DIFF
--- a/darts/preprocessing/base_transformer.py
+++ b/darts/preprocessing/base_transformer.py
@@ -1,0 +1,32 @@
+
+from typing import TypeVar, Generic, Callable
+from darts.logging import raise_if_not, get_logger
+
+logger = get_logger(__name__)
+T = TypeVar('T')
+
+
+class BaseTransformer(Generic[T]):
+    def __init__(self):
+        self.validators = [
+            lambda x: True
+        ]
+
+    def add_validator(self, validator: Callable[[T], bool]):
+        self.validators.append(validator)
+        return self
+
+    def validate(self, data: T) -> bool:
+        for validator in self.validators:
+            raise_if_not(validator(data), "Validation failed", logger)
+        return True
+
+    def transform(self, data: T, *args, **kwargs) -> T:
+        return data
+
+    def inverse_transform(self, data: T, *args, **kwargs) -> T:
+        return data
+
+    def __call__(self, data: T, *args, **kwargs):
+        self.validate(data)
+        return self.transform(data, *args, **kwargs)

--- a/darts/preprocessing/pipeline.py
+++ b/darts/preprocessing/pipeline.py
@@ -1,0 +1,30 @@
+
+from typing import TypeVar, Generic
+from darts.preprocessing.base_transformer import BaseTransformer
+
+logger = get_logger(__name__)
+T = TypeVar('T')
+
+
+class Pipeline(Generic[T]):
+    def __init__(self):
+        pass
+
+    def add_transformer(self, transformer: BaseTransformer[T]) -> 'Pipeline':
+        pass
+
+    # ? validator as separate class or as just callable ?
+    def add_validator(self, validator) -> 'Pipeline':
+        pass
+
+    def resolve(self, inverse: bool = False) -> 'Pipeline':
+        pass
+
+    def resolve_n_steps(self, n: int) -> 'Pipeline':
+        pass
+
+    def set_data(data: T) -> 'Pipeline':
+        pass
+
+    def get_data(self) -> T:
+        pass

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -967,6 +967,9 @@ class TimeSeries:
         inferred_frequency = observed_frequencies.pop()
         return series.resample(inferred_frequency).asfreq(fill_value=None)
 
+    def transform(self, f: Callable[['TimeSeries'], 'TimeSeries'], *args, **kwargs) -> 'TimeSeries':
+        return f(self, *args, **kwargs)
+
     """
     Definition of some useful statistical methods.
     These methods rely on the Pandas implementation.

--- a/preprocess.md
+++ b/preprocess.md
@@ -110,9 +110,11 @@ pipeline = (Pipeline()
 
 pipeline = pipeline.resolve()
 train, val = pipeline.get_data()
-original_ts = pipeline.resolve(reverse=True).get_data()
+original_ts = pipeline.resolve(reverse=True).get_data()[0]
 ```
 
 ## Potential problems
-What about transformers without inverse - maybe storing input and returning it would work but then we have to say that trasformer works only for one list of input.
-Maybe overcomplicated
+* What about transformers without inverse - maybe storing input and returning it would work but then we have to say that trasformer works only for one list of input.
+* Maybe overcomplicated
+
+* In approach with lists of timeseries it really isn't (mathematically) `transform` anymore.

--- a/preprocess.md
+++ b/preprocess.md
@@ -1,0 +1,118 @@
+## Pipeline
+
+```python
+class Pipeline(Generic[T]):
+    def __init__(self):
+        pass
+    
+    # change from last time - passing args and kwargs to transformer
+    def add_transformer(self, transformer: BaseTransformer[T], *transformer_args, **transformer_kwargs) -> 'Pipeline':
+        pass
+
+    # ? validator as separate class or as just callable ?
+    def add_validator(self, validator) -> 'Pipeline':
+        pass
+
+    def resolve(self, inverse: bool = False) -> 'Pipeline':
+        pass
+
+    def resolve_n_steps(self, n: int) -> 'Pipeline':
+        pass
+
+    def set_data(data: T) -> 'Pipeline':
+        pass
+
+    def get_data(self) -> T:
+        pass
+```
+
+```python
+ts # timeseries we are working with
+transformers = [transformer_1, ..., transformer_n] # objects deriving from BaseTransformer
+common_validators = [all_positive, ...]
+```
+## init pipeline either like that
+```python
+pipeline = Pipeline(transformers, common_validators)
+```
+## or like that
+```python
+pipeline = Pipeline()
+for t in transformes:
+    pipeline = pipeline.add_transformer(t)
+for v in common_validators:
+    pipeline = pipeline.add_validator(v)
+```
+
+## use like that
+
+```python
+pipeline.set_data(ts)
+pipeline = pipeline.resolve_n_steps(1) # pipeline traversed using first trnasformation
+ts_transformed = pipeline.get_data() # ts after 1st transform
+pipeline = pipeline.resolve() # pipeline traversed to end (all transformations applied)
+pipeline = pipeline.resolve(inverse=True) # pipeline reverted to begining
+```
+
+## But
+Common pattern is first to split data, train/fit transformer on train part of data - apply all to train, test and val data.
+
+So maybe instead of transformers and pipeline working on
+`timeseries -> timeseries` making it `List[timeseries] -> List[timeseries]` would work better.
+
+
+```Python
+
+class BaseTransformer(Generic[T]):
+    def __init__(self, validators):
+        pass
+
+    def add_validator(self, validator: Callable[[T], bool]):
+        pass
+
+    def validate(self, data: List[T]) -> bool:
+        pass
+
+    def transform(self, data: T, *args, **kwargs) -> List[T]:
+        pass
+
+    def inverse_transform(self, data: List[T], *args, **kwargs) -> List[T]:
+        pass
+
+    def fit(self, data: T):
+        pass
+
+    # inverse whether to apply inverse transformation
+    # fit_on: index of data to fit on, -1 to skip fitting
+    def __call__(self, data: List[T], *args, inverse: bool = False, fit_on: int = -1, **kwargs) -> List[T]:
+        pass
+```
+
+```python
+# Changes to Pipeline
+class Pipeline(Generic[t])
+    def set_data(data: List[T]) -> 'Pipeline':
+        pass
+
+    def get_data(self) -> List[T]:
+        pass
+```
+
+then we could pass timeseries splitted in, next transformer could be fitted on train data, applied to all.
+Example
+```python
+splitter = Splitter(by='2019-01-01') # splitter would also have to be able to join timeseires as inverse_transform
+scaler = ScalerWrapperTransformer()
+pipeline = (Pipeline()
+    .add_tranformer(splitter)
+    .add_transformer(scaler, fit_on=0)
+    .set_data([ts]))
+
+pipeline = pipeline.resolve()
+train, val = pipeline.get_data()
+original_ts = pipeline.resolve(reverse=True).get_data()
+```
+
+## Potential problems
+What about transformers without inverse - maybe storing input and returning it would work but then we have to say that trasformer works only for one list of input.
+Maybe overcomplicated


### PR DESCRIPTION
Follow up on our discussion on preprocessing.

BaseTransformer stay the same as was shown - but of course please raise again any concerns/improvement.
transform in Timeseries also - again please raise any concerns/improvement.

New class Pipeline for managing transforms and validations. Pipeline is intended only for one object of timeseries - this way when we call inverse we are sure that state of transformer is for correct series. Pipeline can be traversed forward and maybe backward (sometimes transform may not have inverse we may have to be extra careful about it)

Interface of pipeline:
```
add_transformer - function that add transformer to pipeline, order of transformers are determined as an order that transformers were added,
add_validator - function that adds validator for each step
resolve - function that resolves pipeline (traverse path of transformations to the end either forward or backward
resolve_n_steps - same as resolve but traverse n step
set_data/get_data -setter/getter for data - getter would return data that we have at our current step of transformations
```

I left out implementations details as I feel like they are more appropriate to do after proposal in some form will be accepted.

Ping @TheMP @hrzn @endrjuskr @pennfranc @guillaumeraille @radujica @Droxef. I hope I included all interested.