### PR TITLE
Hotfix/preprocessing short timeseries

### DIFF
--- a/darts/preprocessing/scaler_wrapper.py
+++ b/darts/preprocessing/scaler_wrapper.py
@@ -67,7 +67,8 @@ class ScalerWrapper:
         assert self._fit_called, 'fit() must be called before transform()'
         return TimeSeries.from_times_and_values(series.time_index(),
                                                 self.transformer.transform(series.values().
-                                                                           reshape((-1, series.width))))
+                                                                           reshape((-1, series.width))),
+                                                series.freq())
 
     def fit_transform(self, series: TimeSeries) -> TimeSeries:
         """
@@ -99,4 +100,5 @@ class ScalerWrapper:
         """
         return TimeSeries.from_times_and_values(series.time_index(),
                                                 self.transformer.inverse_transform(series.values().
-                                                                                   reshape((-1, series.width))))
+                                                                                   reshape((-1, series.width))),
+                                                series.freq())

--- a/darts/tests/test_transformer.py
+++ b/darts/tests/test_transformer.py
@@ -52,4 +52,3 @@ class TransformerTestCase(unittest.TestCase):
         self.assertEqual(series1_recovered.width, self.series1.width)
         self.assertEqual(series2_recovered.width, self.series2.width)
         self.assertEqual(series3_recovered, series1_recovered[:1])
-

--- a/darts/tests/test_transformer.py
+++ b/darts/tests/test_transformer.py
@@ -1,4 +1,5 @@
 import unittest
+import logging
 
 import numpy as np
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
@@ -12,12 +13,18 @@ class TransformerTestCase(unittest.TestCase):
     series1 = tg.random_walk_timeseries(length=100) * 20 - 10.
     series2 = series1.stack(tg.random_walk_timeseries(length=100) * 20 - 100.)
 
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
+
     def test_scaling(self):
+        self.series3 = self.series1[:1]
         transformer1 = ScalerWrapper(MinMaxScaler(feature_range=(0, 2)))
         transformer2 = ScalerWrapper(StandardScaler())
 
         series1_tr1 = transformer1.fit_transform(self.series1)
         series1_tr2 = transformer2.fit_transform(self.series1)
+        series3_tr2 = transformer2.transform(self.series3)
 
         transformer3 = ScalerWrapper(MinMaxScaler(feature_range=(0, 2)))
         transformer4 = ScalerWrapper(StandardScaler())
@@ -39,7 +46,10 @@ class TransformerTestCase(unittest.TestCase):
         # test inverse transform
         series1_recovered = transformer2.inverse_transform(series1_tr2)
         series2_recovered = transformer3.inverse_transform(series2_tr3)
+        series3_recovered = transformer2.inverse_transform(series3_tr2)
         np.testing.assert_almost_equal(series1_recovered.values().flatten(), self.series1.values().flatten())
         np.testing.assert_almost_equal(series2_recovered.values().flatten(), self.series2.values().flatten())
         self.assertEqual(series1_recovered.width, self.series1.width)
         self.assertEqual(series2_recovered.width, self.series2.width)
+        self.assertEqual(series3_recovered, series1_recovered[:1])
+

--- a/darts/utils/missing_values.py
+++ b/darts/utils/missing_values.py
@@ -40,7 +40,7 @@ def fillna(ts: TimeSeries, fill: float = 0) -> TimeSeries:
         A TimeSeries, `ts` with all missing values set to `fill`.
     """
 
-    return TimeSeries.from_times_and_values(ts.time_index(), ts.pd_dataframe().fillna(value=fill))
+    return TimeSeries.from_times_and_values(ts.time_index(), ts.pd_dataframe().fillna(value=fill), ts.freq())
 
 
 def auto_fillna(ts: TimeSeries,
@@ -72,4 +72,4 @@ def auto_fillna(ts: TimeSeries,
     interpolate_kwargs['inplace'] = True
     ts_temp.interpolate(**interpolate_kwargs)
 
-    return TimeSeries.from_times_and_values(ts.time_index(), ts_temp.values)
+    return TimeSeries.from_times_and_values(ts.time_index(), ts_temp.values, ts.freq())


### PR DESCRIPTION
### Summary
This PR addresses issue #142 
- Fixes issue that occurred when trying to apply `ScalerWrapper` and missing values functions to `TimeSeries` instances shorter than length 3.
- Added new test case for `ScalerWrapper`
