### PR TITLE
Add publishing docker image by gradle in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,15 +126,15 @@ jobs:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: "4-1. Publish hotfix docker image"
-        if: contains(github.event.head_commit.message, '#hotfix')
+      #check build.gradle file for explanation of next steps
+      - name: "4. Publish image with tag corresponding to current version"
         run: |
-          ./gradlew dockerTagsPush -P version=${{ steps.bump_dry.outputs.tag }}
+          ./gradlew dockerPushVersion -P version=${{ steps.bump_dry.outputs.tag }}
 
-      - name: "4-2. Publish non-hotfix docker image"
+      - name: "5. Publish image with tag 'latest' if not hotfix"
         if: ${{ !contains(github.event.head_commit.message, '#hotfix') }}
         run: |
-          ./gradlew dockerPush -P version=${{ steps.bump_dry.outputs.tag }}
+          ./gradlew dockerPushLatest
 
 
   deploy-docs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,10 @@ jobs:
           DRY_RUN: true
 
       - name: "3. Login to docker hub"
-        run: "echo '${{ secrets.DOCKER_HUB_TOKEN }}' | docker login --username ${{ secrets.DOCKER_HUB_USER }} --password-stdin"
+        run: docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN
+        env:
+          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: "4-1. Publish hotfix docker image"
         if: contains(github.event.head_commit.message, '#hotfix')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,22 +120,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: true
 
-      - name: "3. Determine docker tags"
-        run: echo ::set-env name=DOCKER_TAGS::$(echo latest, ${{ steps.bump_dry.outputs.tag }})
+      - name: "3. Login to docker hub"
+        run: "echo '${{ secrets.DOCKER_HUB_TOKEN }}' | docker login --username ${{ secrets.DOCKER_HUB_USER }} --password-stdin"
 
-      - name: "3-1. Determine docker tags for hotfix"
+      - name: "4-1. Publish hotfix docker image"
         if: contains(github.event.head_commit.message, '#hotfix')
-        run: echo ::set-env name=DOCKER_TAGS::$(echo ${{ steps.bump_dry.outputs.tag }})
+        run: |
+          ./gradlew dockerTagsPush -P version=${{ steps.bump_dry.outputs.tag }}
 
-      - name: "4. Build and publish docker to docker hub"
-        uses: elgohr/Publish-Docker-Github-Action@2.14
-        with:
-          name: unit8/darts
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          tags: "${{ env.DOCKER_TAGS }}"
-          cache: true
-          buildoptions: "--compress -q"
+      - name: "4-2. Publish non-hotfix docker image"
+        if: ${{ !contains(github.event.head_commit.message, '#hotfix') }}
+        run: |
+          ./gradlew dockerPush -P version=${{ steps.bump_dry.outputs.tag }}
+
 
   deploy-docs:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,14 @@ task build {
 // docker & docker run
 docker {
     name "unit8/darts"
-    //it will also automatically create image with tag 'latest'
-    tag version, "unit8/darts:${version}"
+
+    // ./gradlew dockerPushVersion will push image with tag ${version}
+    // ${version} is property passed from command line during workflow
+    tag "version", "unit8/darts:${version}"
+
+    // ./gradlew dockerPushLatest will push image with tag 'latest'
+    tag "latest", "unit8/darts:latest"
+
     dockerfile file("${project.rootDir}/Dockerfile")
     // needed files for docker and to build library
     files "README.md", "setup.py", "setup.cfg"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,8 @@ task build {
 // docker & docker run
 docker {
     name "unit8/darts"
-    tags version, "latest"
+    //it will also automatically create image with tag 'latest'
+    tag version, "unit8/darts:${version}"
     dockerfile file("${project.rootDir}/Dockerfile")
     // needed files for docker and to build library
     files "README.md", "setup.py", "setup.cfg"


### PR DESCRIPTION
Summary
* Refactored publishing docker image in release workflow
* Previously images were being published by github action
* Now they're published using gradle

Other Information
Workflow tested on mock repository in both possible cases (hotfix/non hotfix), but note that during tests different image (simple dockerfile) was being published on different repository (with different credentials).

