### PR TITLE
Fix PR workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   tests:


### PR DESCRIPTION
Fixes DARTS-170

### Summary

Change PR workflow so that all tests trigger on PR, and not after them.
This can prevent a failing develop branch.

PR created after discussion on #156 