### PR TITLE
Fix/backtest sanity checks

### DIFF
--- a/darts/models/forecasting_model.py
+++ b/darts/models/forecasting_model.py
@@ -279,10 +279,9 @@ class ForecastingModel(ABC):
                         forecast_horizon = n.forecast_horizon
                     else:
                         forecast_horizon = signature(self.backtest).parameters['forecast_horizon'].default
-                    
                     raise_if_not(n.start + training_series.freq() * forecast_horizon in training_series,
-                                '`start` timestamp is too late in the series to make any predictions with'
-                                '`trim_to_series` set to `True`.', logger)
+                                 '`start` timestamp is too late in the series to make any predictions with'
+                                 '`trim_to_series` set to `True`.', logger)
                 else:
                     raise_if_not(n.start in training_series, '`start` timestamp is not in the series.', logger)
                 raise_if(n.start == training_series.end_time(), '`start` timestamp is the last timestamp of the'

--- a/darts/tests/test_backtesting.py
+++ b/darts/tests/test_backtesting.py
@@ -77,6 +77,10 @@ class BacktestingTestCase(unittest.TestCase):
         NaiveDrift().backtest(linear_series, None, start=pd.Timestamp('20000216'), forecast_horizon=3)
         NaiveDrift().backtest(linear_series, None, pd.Timestamp('20000217'), forecast_horizon=3, trim_to_series=False)
 
+        # Using forecast_horizon default value
+        NaiveDrift().backtest(linear_series, None, start=pd.Timestamp('20000216'))
+        NaiveDrift().backtest(linear_series, None, pd.Timestamp('20000217'), trim_to_series=False)
+
         # univariate model + multivariate series
         with self.assertRaises(AssertionError):
             NaiveDrift().backtest(linear_series_multi, None, pd.Timestamp('20000201'), 3)

--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -9,6 +9,7 @@ from typing import List, Callable, TypeVar
 from IPython import get_ipython
 from tqdm import tqdm
 from tqdm.notebook import tqdm as tqdm_notebook
+from functools import wraps
 
 logger = get_logger(__name__)
 
@@ -110,6 +111,7 @@ def _with_sanity_checks(*sanity_check_methods: str) -> Callable[[Callable[[A, B]
             ...
     """
     def decorator(method_to_sanitize: Callable[[A, B], T]) -> Callable[[A, B], T]:
+        @wraps(method_to_sanitize)
         def sanitized_method(self, *args: A, **kwargs: B) -> T:
             for sanity_check_method in sanity_check_methods:
                 getattr(self, sanity_check_method)(*args, **kwargs)


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #186.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create 
a draft and ask for comments. -->
Modified the sanity checks to use either the provided forecast_horizon parameter or the default value.
Also made a small improvement to the `_with_sanity_checks()` decorator

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->
Had to move `_backtest_sanity_checks()`'s definition after `backtest()` for `signature(self.backtest)` to work, which is a little less nice. We should be able to undo that once we address https://github.com/unit8co/darts/pull/125#discussion_r489286538

<!--Thank you for contributing to darts! -->