### PR TITLE
fix(build.gradle): omit files from coverage check report depending on…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ task installLocally(type:Exec) {
 
 // Tests
 void coverageTestSteps(flavour) {
-    def omits = ["darts/models/auto_arima.py", "darts/models/prophet.py", "darts/models/rnn_model.py", "darts/models/tcn_model.py", "darts/models/torch_forecasting_model.py"]
+    def omits = ["darts/models/auto_arima.py", "darts/models/prophet.py", "darts/models/rnn_model.py", "darts/models/tcn_model.py", "darts/models/torch_forecasting_model.py", "darts/utils/torch.py"]
     switch(flavour) {
         case "pmdarima":
         omits -= "darts/models/auto_arima.py"
@@ -94,6 +94,7 @@ void coverageTestSteps(flavour) {
         omits -= "darts/models/rnn_model.py"
         omits -= "darts/models/tcn_model.py"
         omits -= "darts/models/torch_forecasting_model.py"
+        omits -= "darts/utils/torch.py"
         case "all":
         omits = []
     }

--- a/build.gradle
+++ b/build.gradle
@@ -83,12 +83,26 @@ task installLocally(type:Exec) {
 }
 
 // Tests
-void coverageTestSteps() {
+void coverageTestSteps(flavour) {
+    def omits = ["darts/models/auto_arima.py", "darts/models/prophet.py", "darts/models/rnn_model.py", "darts/models/tcn_model.py"]
+    switch(flavour) {
+        case "pmdarima":
+        omits -= "darts/models/auto_arima.py"
+        case "fbprophet":
+        omits -= "darts/models/prophet.py"
+        case "torch":
+        omits -= "darts/models/rnn_model.py"
+        omits -= "darts/models/tcn_model.py"
+        case "all":
+        omits = []
+    }
+    omits = omits.join(",") + "," + "darts/tests*,*__init__.py"
+
     exec {
-        commandLine "coverage", "run", "-m", "unittest"
+        commandLine "coverage", "run", "--source=darts/", "-m", "unittest"
     }
     exec {
-        commandLine "coverage", "report", "-m", "--fail-under=80", "--omit='darts/tests*,*__init__.py'"
+        commandLine "coverage", "report", "-m", "--fail-under=80", "--omit=$omits"
     }
 }
 
@@ -113,7 +127,7 @@ void createPipRelatedTask(String flavour) {
         dependsOn pip_core
         dependsOn pip_dev
         doLast {
-            coverageTestSteps()
+            coverageTestSteps(flavour)
         }
    }
 
@@ -141,7 +155,7 @@ task unitTest_all(type: Exec) {
 task coverageTest_all() {
     dependsOn pip_core, pip_dev, pip_fbprophet, pip_pmdarima, pip_torch
     doLast {
-        coverageTestSteps()
+        coverageTestSteps("all")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ task installLocally(type:Exec) {
 
 // Tests
 void coverageTestSteps(flavour) {
-    def omits = ["darts/models/auto_arima.py", "darts/models/prophet.py", "darts/models/rnn_model.py", "darts/models/tcn_model.py"]
+    def omits = ["darts/models/auto_arima.py", "darts/models/prophet.py", "darts/models/rnn_model.py", "darts/models/tcn_model.py", "darts/models/torch_forecasting_model.py"]
     switch(flavour) {
         case "pmdarima":
         omits -= "darts/models/auto_arima.py"
@@ -93,6 +93,7 @@ void coverageTestSteps(flavour) {
         case "torch":
         omits -= "darts/models/rnn_model.py"
         omits -= "darts/models/tcn_model.py"
+        omits -= "darts/models/torch_forecasting_model.py"
         case "all":
         omits = []
     }

--- a/build.gradle
+++ b/build.gradle
@@ -83,28 +83,12 @@ task installLocally(type:Exec) {
 }
 
 // Tests
-void coverageTestSteps(flavour) {
-    def omits = ["darts/models/auto_arima.py", "darts/models/prophet.py", "darts/models/rnn_model.py", "darts/models/tcn_model.py", "darts/models/torch_forecasting_model.py", "darts/utils/torch.py"]
-    switch(flavour) {
-        case "pmdarima":
-        omits -= "darts/models/auto_arima.py"
-        case "fbprophet":
-        omits -= "darts/models/prophet.py"
-        case "torch":
-        omits -= "darts/models/rnn_model.py"
-        omits -= "darts/models/tcn_model.py"
-        omits -= "darts/models/torch_forecasting_model.py"
-        omits -= "darts/utils/torch.py"
-        case "all":
-        omits = []
-    }
-    omits = omits.join(",") + "," + "darts/tests*,*__init__.py"
-
+void coverageTestSteps() {
     exec {
         commandLine "coverage", "run", "--source=darts/", "-m", "unittest"
     }
     exec {
-        commandLine "coverage", "report", "-m", "--fail-under=80", "--omit=$omits"
+        commandLine "coverage", "report", "-m", "--fail-under=80"
     }
 }
 
@@ -123,22 +107,10 @@ void createPipRelatedTask(String flavour) {
         commandLine "python", "-m", "unittest"
    }
 
-   taskName = "coverageTest_" + flavour;
-   task (taskName) {
-        dependsOn(taskArgument)
-        dependsOn pip_core
-        dependsOn pip_dev
-        doLast {
-            coverageTestSteps(flavour)
-        }
-   }
-
    taskName = "test_" + flavour;
    String taskArgument1 = "unitTest_" + flavour;
-   String taskArgument2= "coverageTest_" + flavour;
    task (taskName) {
         dependsOn(taskArgument1)
-        dependsOn(taskArgument2)
         dependsOn lint
    }
 }
@@ -157,7 +129,7 @@ task unitTest_all(type: Exec) {
 task coverageTest_all() {
     dependsOn pip_core, pip_dev, pip_fbprophet, pip_pmdarima, pip_torch
     doLast {
-        coverageTestSteps("all")
+        coverageTestSteps()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ void coverageTestSteps() {
         commandLine "coverage", "run", "--source=darts/", "-m", "unittest"
     }
     exec {
-        commandLine "coverage", "report", "-m", "--fail-under=80"
+        commandLine "coverage", "report", "-m", "--fail-under=80", "--omit=darts/tests*,*__init__.py"
     }
 }
 


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes coverage tests failing with some flavors of the installation. See #181.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create 
a draft and ask for comments. -->

Not a very clean solution at all (hence the draft pull request), but seems to work at least locally to exclude some files from the report (and coverage % calculation) depending on the flavour installed.

I couldn't come up with a way to omit files depending on their dependency to the flavour installed, other than naming them each in the `build.gradle` file. Would welcome any suggestion !