### PR TITLE
fix(readme): outdated instruction in contribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Before working on a contribution (a new feature or a fix) make sure you can't fi
 1. Create an issue, describe how you would attempt to solve it, and if possible wait for a discussion.
 2. Fork the repository.
 3. Clone the forked repository locally.
-4. Create a clean python env and install requirements with pip: `pip install -r requirements/main.txt -r requirements/dev.txt -r requirements/release.txt`
+4. Create a clean python env and install requirements with pip: `pip install -r requirements/dev-all.txt`
 5. Create a new branch:
     * Branch off from the **develop** branch.
     * Prefix the branch with the type of update you are making:

--- a/requirements/dev-all.txt
+++ b/requirements/dev-all.txt
@@ -1,0 +1,6 @@
+-r core.txt
+-r dev.txt
+-r fbprophet.txt
+-r pmdarima.txt
+-r release.txt
+-r torch.txt


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
### Summary

Contribute guidelines were outdated since last release. The instruction to install pip packages references `main.txt` which does not exists anymore in place of `core.txt` and the other optional dependencies.

### Other Information

I did not find a way with pip to use something like `requirements/*.txt` so I added a file that has all the dependencies. Another way to fix it would have been to list all dependencies in the pip command (an updated version of the current instruction). Feel free to let me know if you prefer that approach

Another open question is if we want by default for the dev environment to also install the optional dependencies. I would expect it to be the case, so all the project tests can be run locally.
