### PR TITLE
Feat/strip nan function

### DIFF
--- a/darts/tests/test_timeseries_multivariate.py
+++ b/darts/tests/test_timeseries_multivariate.py
@@ -110,6 +110,15 @@ class TimeSeriesMultivariateTestCase(unittest.TestCase):
     def test_append_values(self):
         TimeSeriesTestCase.helper_test_append_values(self, self.series1)
 
+    def test_strip(self):
+        dataframe1 = pd.DataFrame({
+            "0": 2 * [np.nan] + list(range(7)) + [np.nan],
+            "1": [np.nan] + list(range(7)) + 2 * [np.nan]
+        }, index=self.times1)
+        series1 = TimeSeries(dataframe1)
+
+        self.assertTrue((series1.strip().time_index() == self.times1[1:-1]).all())
+
     """
     Testing new multivariate methods.
     """

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -438,6 +438,24 @@ class TimeSeries:
         time_index = self.time_index().intersection(other.time_index())
         return self.__getitem__(time_index)
 
+    def strip(self) -> 'TimeSeries':
+        """
+        Returns a TimeSeries slice of this time series, where NaN-only entries at the beginning and the end of the
+        series are removed. No entries after (and including) the first non-NaN entry and before (and including) the
+        last non-NaN entry are removed.
+
+        Returns
+        -------
+        TimeSeries
+            a new series based on the original where NaN-only entries at start and end have been removed
+        """
+
+        new_start_idx = self._df.first_valid_index()
+        new_end_idx = self._df.last_valid_index()
+        new_series = self._df.loc[new_start_idx:new_end_idx]
+
+        return TimeSeries(new_series, self.freq_str())
+
     # TODO: other rescale? such as giving a ratio, or a specific position? Can be the same function
     def rescale_with_value(self, value_at_first_step: float) -> 'TimeSeries':
         """


### PR DESCRIPTION
Problem:
Right now I'm working with multiple time series that start at different points in time. Time indices before the start of the actual series are often filled with NaN values. I was missing an easy way to cut the 'empty' beginning and end of a time series.

Solution:
I implemented a very simple method called `TimeSeries.strip()` which gets rid of all entries at the start and end of a time series that are nothing but NaNs. This was inspired by the python `string.strip` function.