### PR TITLE
feat(pipeline): getter for Pipeline._invertible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Darts is still in an early development phase and we cannot always guarantee back
 ## [Unreleased](https://github.com/unit8co/darts/tree/develop)
 
 [Full Changelog](https://github.com/unit8co/darts/compare/0.5.0...develop)
+### For users of the library:
+**Added:**
+- `Pipeline.invertible()` a getter which returns whether the pipeline is invertible or not.
 
 ## [0.5.0](https://github.com/unit8co/darts/tree/0.5.0) (2020-11-09)
 

--- a/darts/dataprocessing/pipeline.py
+++ b/darts/dataprocessing/pipeline.py
@@ -126,6 +126,15 @@ class Pipeline:
         return data
     
     def invertible(self) -> bool:
+        """
+        Returns whether the pipeline is invertible or not.
+        A pipeline is invertible if all transformers in the pipeline are themselves invertible.
+
+        Returns
+        -------
+        bool
+            True if the pipeline is invertible, False otherwise
+        """
         return self._invertible
 
     def __getitem__(self, key: Union[int, slice]) -> 'Pipeline':

--- a/darts/dataprocessing/pipeline.py
+++ b/darts/dataprocessing/pipeline.py
@@ -124,6 +124,9 @@ class Pipeline:
         for transformer in reversed(self._transformers):
             data = transformer.inverse_transform(data)
         return data
+    
+    def invertible(self) -> bool:
+        return self._invertible
 
     def __getitem__(self, key: Union[int, slice]) -> 'Pipeline':
         """


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Adds a simple getter for `Pipeline._invertible` to allow writing `if pipeline.invertible(): …` (cleaner than accessing `_invertible` from outside the `Pipeline` class)