### PR TITLE
Feat/missing value utilities

### DIFF
--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -69,6 +69,17 @@ def _get_values_or_raise(series_a: TimeSeries,
     return series_a_common.univariate_values(), series_b_common.univariate_values()
 
 
+def _remove_nan_union(array_a: np.ndarray,
+                      array_b: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Returnes the two inputs arrays where all elements are deleted that have an index that corresponds to
+    a NaN value in either of the two input arrays.
+    """
+
+    isnan_mask = np.logical_or(np.isnan(array_a), np.isnan(array_b))
+    return np.delete(array_a, isnan_mask), np.delete(array_b, isnan_mask)
+
+
 @multivariate_support
 def mae(series1: TimeSeries,
         series2: TimeSeries,
@@ -100,6 +111,7 @@ def mae(series1: TimeSeries,
     """
 
     y1, y2 = _get_values_or_raise(series1, series2, intersect)
+    y1, y2 = _remove_nan_union(y1, y2)
     return np.mean(np.abs(y1 - y2))
 
 
@@ -134,6 +146,7 @@ def mse(series1: TimeSeries,
     """
 
     y_true, y_pred = _get_values_or_raise(series1, series2, intersect)
+    y_true, y_pred = _remove_nan_union(y_true, y_pred)
     return np.mean((y_true - y_pred)**2)
 
 
@@ -202,6 +215,7 @@ def rmsle(series1: TimeSeries,
     """
 
     y1, y2 = _get_values_or_raise(series1, series2, intersect)
+    y1, y2 = _remove_nan_union(y1, y2)
     y1, y2 = np.log(y1 + 1), np.log(y2 + 1)
     return np.sqrt(np.mean((y1 - y2)**2))
 
@@ -283,6 +297,7 @@ def mape(actual_series: TimeSeries,
     """
 
     y_true, y_hat = _get_values_or_raise(actual_series, pred_series, intersect)
+    y_true, y_hat = _remove_nan_union(y_true, y_hat)
     raise_if_not((y_true != 0).all(), 'The actual series must be strictly positive to compute the MAPE.', logger)
     return 100. * np.mean(np.abs((y_true - y_hat) / y_true))
 
@@ -329,6 +344,7 @@ def smape(actual_series: TimeSeries,
     """
 
     y_true, y_hat = _get_values_or_raise(actual_series, pred_series, intersect)
+    y_true, y_hat = _remove_nan_union(y_true, y_hat)
     raise_if_not(np.logical_or(y_true != 0, y_hat != 0).all(),
                  'The actual series must be strictly positive to compute the sMAPE.', logger)
     return 200. * np.mean(np.abs((y_true - y_hat) / (np.abs(y_true) + np.abs(y_hat))))
@@ -431,6 +447,7 @@ def ope(actual_series: TimeSeries,
     """
 
     y_true, y_pred = _get_values_or_raise(actual_series, pred_series, intersect)
+    y_true, y_pred = _remove_nan_union(y_true, y_pred)
     y_true_sum, y_pred_sum = np.sum(y_true), np.sum(y_pred)
     raise_if_not(y_true_sum > 0, 'The series of actual value cannot sum to zero when computing OPE.', logger)
     return np.abs((y_true_sum - y_pred_sum) / y_true_sum) * 100.
@@ -474,6 +491,7 @@ def marre(actual_series: TimeSeries,
     """
 
     y_true, y_hat = _get_values_or_raise(actual_series, pred_series, intersect)
+    y_true, y_hat = _remove_nan_union(y_true, y_hat)
     raise_if_not(y_true.max() > y_true.min(), 'The difference between the max and min values must be strictly'
                  'positive to compute the MARRE.', logger)
     true_range = y_true.max() - y_true.min()
@@ -512,6 +530,7 @@ def r2_score(series1: TimeSeries,
     """
 
     y1, y2 = _get_values_or_raise(series1, series2, intersect)
+    y1, y2 = _remove_nan_union(y1, y2)
     ss_errors = np.sum((y1 - y2) ** 2)
     y_hat = y1.mean()
     ss_tot = np.sum((y1 - y_hat) ** 2)

--- a/darts/tests/test_metrics.py
+++ b/darts/tests/test_metrics.py
@@ -66,17 +66,28 @@ class MetricsTestCase(unittest.TestCase):
         self.assertAlmostEqual(metric(series22, series33, reduction=(lambda x: x[0]), **kwargs),
                                metric(self.series2, self.series3, reduction=(lambda x: x[0]), **kwargs))
 
+    def helper_test_nan(self, metric):
+        # univariate
+        non_nan_metric = metric(self.series1[:9] + 1, self.series2[:9])
+        nan_series1 = self.series1.copy()
+        nan_series1._df.iloc[-1] = np.nan
+        nan_metric = metric(nan_series1 + 1, self.series2)
+        self.assertEqual(non_nan_metric, nan_metric)
+        # multivariate (TODO)
+
     def test_r2(self):
         from sklearn.metrics import r2_score
         self.assertEqual(metrics.r2_score(self.series1, self.series0), 0)
         self.assertEqual(metrics.r2_score(self.series1, self.series2),
                          r2_score(self.series1.values(), self.series2.values()))
         self.helper_test_multivariate_duplication_equality(metrics.r2_score)
+        self.helper_test_nan(metrics.r2_score)
 
     def test_marre(self):
         self.assertAlmostEqual(metrics.marre(self.series1, self.series2),
                                metrics.marre(self.series1 + 100, self.series2 + 100))
         self.helper_test_multivariate_duplication_equality(metrics.marre)
+        self.helper_test_nan(metrics.marre)
 
     def test_season(self):
         with self.assertRaises(ValueError):
@@ -84,27 +95,34 @@ class MetricsTestCase(unittest.TestCase):
 
     def test_mse(self):
         self.helper_test_shape_equality(metrics.mse)
+        self.helper_test_nan(metrics.mse)
 
     def test_mae(self):
         self.helper_test_shape_equality(metrics.mae)
+        self.helper_test_nan(metrics.mae)
 
     def test_rmse(self):
         self.helper_test_multivariate_duplication_equality(metrics.rmse)
 
         self.assertAlmostEqual(metrics.rmse(self.series1.append(self.series2b), self.series2.append(self.series1b)),
                                metrics.mse(self.series12, self.series21, reduction=(lambda x: np.sqrt(np.mean(x)))))
+        self.helper_test_nan(metrics.rmse)
 
     def test_rmsle(self):
         self.helper_test_multivariate_duplication_equality(metrics.rmsle)
+        self.helper_test_nan(metrics.rmsle)
 
     def test_coefficient_of_variation(self):
         self.helper_test_multivariate_duplication_equality(metrics.coefficient_of_variation)
+        self.helper_test_nan(metrics.coefficient_of_variation)
 
     def test_mape(self):
         self.helper_test_multivariate_duplication_equality(metrics.mape)
+        self.helper_test_nan(metrics.mape)
 
     def test_smape(self):
         self.helper_test_multivariate_duplication_equality(metrics.smape)
+        self.helper_test_nan(metrics.smape)
 
     def test_mase(self):
         self.helper_test_multivariate_duplication_equality(metrics.mase, insample=self.series_train)
@@ -114,9 +132,11 @@ class MetricsTestCase(unittest.TestCase):
 
     def test_ope(self):
         self.helper_test_multivariate_duplication_equality(metrics.ope)
+        self.helper_test_nan(metrics.ope)
 
     def test_r2_score(self):
         self.helper_test_multivariate_duplication_equality(metrics.r2_score)
+        self.helper_test_nan(metrics.r2_score)
 
     def test_metrics_arguments(self):
         series00 = self.series0.stack(self.series0)

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -484,3 +484,23 @@ class TimeSeriesTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             series.map(ufunc_add)
+
+    def test_gaps(self):
+        times = pd.date_range('20130101', '20130110')
+        pd_series1 = pd.Series([1, 1] + 3 * [np.nan] + [1, 1, 1] + [np.nan] * 2, index=times)
+        pd_series2 = pd.Series([1, 1] + 3 * [np.nan] + [1, 1] + [np.nan] * 3, index=times)
+        pd_series3 = pd.Series([np.nan] * 10, index=times)
+        series1 = TimeSeries.from_series(pd_series1)
+        series2 = TimeSeries.from_series(pd_series2)
+        series3 = TimeSeries.from_series(pd_series3)
+
+        gaps1 = series1.gaps()
+        self.assertTrue((gaps1['gap_start'] == pd.DatetimeIndex([pd.Timestamp('20130103'),
+                                                                 pd.Timestamp('20130109')])).all())
+        self.assertTrue((gaps1['gap_end'] == pd.DatetimeIndex([pd.Timestamp('20130105'),
+                                                               pd.Timestamp('20130110')])).all())
+        self.assertEqual(gaps1['gap_size'].values.tolist(), [3, 2])
+        gaps2 = series2.gaps()
+        self.assertEqual(gaps2['gap_size'].values.tolist(), [3, 3])
+        gaps3 = series3.gaps()
+        self.assertEqual(gaps3['gap_size'].values.tolist(), [10])

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -504,3 +504,11 @@ class TimeSeriesTestCase(unittest.TestCase):
         self.assertEqual(gaps2['gap_size'].values.tolist(), [3, 3])
         gaps3 = series3.gaps()
         self.assertEqual(gaps3['gap_size'].values.tolist(), [10])
+
+    def test_longest_contiguous_slice(self):
+        times = pd.date_range('20130101', '20130111')
+        pd_series1 = pd.Series([1, 1] + 3 * [np.nan] + [1, 1, 1] + [np.nan] * 2 + [1], index=times)
+        series1 = TimeSeries.from_series(pd_series1)
+
+        self.assertEqual(len(series1.longest_contiguous_slice()), 3)
+        self.assertEqual(len(series1.longest_contiguous_slice(2)), 6)

--- a/darts/tests/test_timeseries_multivariate.py
+++ b/darts/tests/test_timeseries_multivariate.py
@@ -110,6 +110,15 @@ class TimeSeriesMultivariateTestCase(unittest.TestCase):
     def test_append_values(self):
         TimeSeriesTestCase.helper_test_append_values(self, self.series1)
 
+    def test_strip(self):
+        dataframe1 = pd.DataFrame({
+            "0": 2 * [np.nan] + list(range(7)) + [np.nan],
+            "1": [np.nan] + list(range(7)) + 2 * [np.nan]
+        }, index=self.times1)
+        series1 = TimeSeries(dataframe1)
+
+        self.assertTrue((series1.strip().time_index() == self.times1[1:-1]).all())
+
     """
     Testing new multivariate methods.
     """

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -438,6 +438,24 @@ class TimeSeries:
         time_index = self.time_index().intersection(other.time_index())
         return self.__getitem__(time_index)
 
+    def strip(self) -> 'TimeSeries':
+        """
+        Returns a TimeSeries slice of this time series, where NaN-only entries at the beginning and the end of the
+        series are removed. No entries after (and including) the first non-NaN entry and before (and including) the
+        last non-NaN entry are removed.
+
+        Returns
+        -------
+        TimeSeries
+            a new series based on the original where NaN-only entries at start and end have been removed
+        """
+
+        new_start_idx = self._df.first_valid_index()
+        new_end_idx = self._df.last_valid_index()
+        new_series = self._df.loc[new_start_idx:new_end_idx]
+
+        return TimeSeries(new_series, self.freq_str())
+
     # TODO: other rescale? such as giving a ratio, or a specific position? Can be the same function
     def rescale_with_value(self, value_at_first_step: float) -> 'TimeSeries':
         """


### PR DESCRIPTION
In this PR I include several additions I made that make it easier to handle time series objects with NaN values. This includes:
- TimeSeries.strip()
- TimeSeries.gaps()
- TimeSeries.longest_contiguous_slice(max_gap_size)
- NaN value support for metrics (which basically consists of masking indices where either of the two time series has a NaN value)

Branch name could have been better, sorry!