### PR TITLE
Feature/dummy index

### DIFF
--- a/darts/models/auto_arima.py
+++ b/darts/models/auto_arima.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from .forecasting_model import ExtendedForecastingModel
 from ..timeseries import TimeSeries
-from ..logging import get_logger
+from ..logging import get_logger, raise_if
 
 logger = get_logger(__name__)
 
@@ -56,3 +56,10 @@ class AutoARIMA(ExtendedForecastingModel):
     @property
     def min_train_series_length(self) -> int:
         return 30
+
+    def _supports_dummy_index(self) -> bool:
+        raise_if(self.trend and self.trend != "c",
+            "'trend' is not None. Dummy indexing is not supported in that case.",
+            logger
+        )
+        return True

--- a/darts/models/auto_arima.py
+++ b/darts/models/auto_arima.py
@@ -34,9 +34,9 @@ class AutoARIMA(ExtendedForecastingModel):
         autoarima_kwargs
             Keyword arguments for the pmdarima.txt AutoARIMA model
         """
-
         super().__init__()
         self.model = PmdAutoARIMA(*autoarima_args, **autoarima_kwargs)
+        self.trend = self.model.trend
 
     def __str__(self):
         return 'Auto-ARIMA'

--- a/darts/models/forecasting_model.py
+++ b/darts/models/forecasting_model.py
@@ -62,12 +62,16 @@ class ForecastingModel(ABC):
         self.training_series = series
         self._fit_called = True
 
-        if hasattr(self, "trend"):
-            raise_if(
-                self.trend and self.trend != "c" and self.training_series.has_dummy_index,
-                "'trend' is not None. Dummy indexing is not supported in that case.",
-                logger
-            )
+        if series.has_dummy_index:
+            self._supports_dummy_index()
+
+    def _supports_dummy_index(self) -> bool:
+        """ Checks if the forecasting model supports a dummy index.
+
+        By default, returns True. Needs to be overwritten by models that do not support
+        dummy indexing and raise meaningful exception.
+        """
+        return True
 
     @abstractmethod
     def predict(self, n: int) -> TimeSeries:

--- a/darts/models/forecasting_model.py
+++ b/darts/models/forecasting_model.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 
 from ..timeseries import TimeSeries
-from ..logging import get_logger, raise_log, raise_if_not
+from ..logging import get_logger, raise_log, raise_if_not, raise_if
 from ..utils import (
     _build_tqdm_iterator,
     _with_sanity_checks,
@@ -61,6 +61,13 @@ class ForecastingModel(ABC):
                      .format(len(series), str(self), self.min_train_series_length))
         self.training_series = series
         self._fit_called = True
+
+        if hasattr(self, "trend"):
+            raise_if(
+                self.trend and self.trend != "c" and self.training_series.has_dummy_index,
+                "'trend' is not None. Dummy indexing is not supported in that case.",
+                logger
+            )
 
     @abstractmethod
     def predict(self, n: int) -> TimeSeries:

--- a/darts/models/varima.py
+++ b/darts/models/varima.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 from .forecasting_model import ExtendedForecastingModel
 from ..timeseries import TimeSeries
-from ..logging import get_logger
+from ..logging import get_logger, raise_if
 
 logger = get_logger(__name__)
 
@@ -83,3 +83,10 @@ class VARIMA(ExtendedForecastingModel):
     @property
     def min_train_series_length(self) -> int:
         return 30
+
+    def _supports_dummy_index(self) -> bool:
+        raise_if(self.trend and self.trend != "c",
+            "'trend' is not None. Dummy indexing is not supported in that case.",
+            logger
+        )
+        return True

--- a/darts/tests/test_local_forecasting_models.py
+++ b/darts/tests/test_local_forecasting_models.py
@@ -48,8 +48,10 @@ try:
     from ..models import AutoARIMA
     models.append((AutoARIMA(), 13.7))
     extended_models.append(AutoARIMA())
+    PMDARIMA_AVAILABLE = True
 except ImportError:
     logger.warning('pmdarima not installed - will be skipping AutoARIMA tests')
+    PMDARIMA_AVAILABLE = False
 
 try:
     from ..models import TCNModel
@@ -141,6 +143,7 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
         with self.assertRaises(ValueError):
             varima.fit(series=ts)
 
-        autoarima = AutoARIMA(trend="t")
-        with self.assertRaises(ValueError):
-            autoarima.fit(series=ts)
+        if PMDARIMA_AVAILABLE:
+            autoarima = AutoARIMA(trend="t")
+            with self.assertRaises(ValueError):
+                autoarima.fit(series=ts)

--- a/darts/tests/test_local_forecasting_models.py
+++ b/darts/tests/test_local_forecasting_models.py
@@ -37,6 +37,7 @@ multivariate_models = [
 
 extended_models = [ARIMA()]
 
+
 try:
     from ..models import Prophet
     models.append((Prophet(), 13.5))
@@ -131,3 +132,15 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
                 model.fit(self.ts_gaussian, exog=self.ts_gaussian[:-1])
             with self.assertRaises(ValueError):
                 model.fit(self.ts_gaussian[1:], exog=self.ts_gaussian[:-1])
+
+    def test_dummy_series(self):
+        values = np.random.uniform(low=-10, high=10, size=100)
+        ts = TimeSeries(pd.DataFrame({"V1": values}), dummy_index=True)
+
+        varima = VARIMA(trend="t")
+        with self.assertRaises(ValueError):
+            varima.fit(series=ts)
+
+        autoarima = AutoARIMA(trend="t")
+        with self.assertRaises(ValueError):
+            autoarima.fit(series=ts)

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -437,21 +437,56 @@ class TimeSeriesTestCase(DartsBaseTestClass):
         TimeSeries.from_times_and_values(pd.date_range('20130101', '20130102'), range(2), freq='D')
 
     def test_from_dataframe(self):
-        data_dict = {"Month": pd.date_range(start="20180501", end="20200301", freq="MS")}
-        data_dict["Values1"] = np.random.uniform(low=-10, high=10, size=len(data_dict["Month"]))
-        data_dict["Values2"] = np.random.uniform(low=0, high=1, size=len(data_dict["Month"]))
+        data_dict = {"Time": pd.date_range(start="20180501", end="20200301", freq="MS")}
+        data_dict["Values1"] = np.random.uniform(low=-10, high=10, size=len(data_dict["Time"]))
+        data_dict["Values2"] = np.random.uniform(low=0, high=1, size=len(data_dict["Time"]))
 
         data_pd1 = pd.DataFrame(data_dict)
         data_pd2 = data_pd1.copy()
-        data_pd2["Month"] = data_pd2["Month"].apply(lambda date: str(date))
-        data_pd3 = data_pd1.set_index("Month")
+        data_pd2["Time"] = data_pd2["Time"].apply(lambda date: str(date))
+        data_pd3 = data_pd1.set_index("Time")
 
-        data_darts1 = TimeSeries.from_dataframe(df=data_pd1, time_col="Month")
-        data_darts2 = TimeSeries.from_dataframe(df=data_pd2, time_col="Month")
+        data_darts1 = TimeSeries.from_dataframe(df=data_pd1, time_col="Time")
+        data_darts2 = TimeSeries.from_dataframe(df=data_pd2, time_col="Time")
         data_darts3 = TimeSeries.from_dataframe(df=data_pd3)
 
         self.assertEqual(data_darts1, data_darts2)
         self.assertEqual(data_darts1, data_darts3)
+
+    def test_create_with_dummy_index(self):
+        times = pd.date_range(start="20210312", periods=15, freq="MS")
+        values1 = np.random.uniform(low=-10, high=10, size=len(times))
+        values2 = np.random.uniform(low=0, high=1, size=len(times))
+
+        df1 = pd.DataFrame({"V1": values1, "V2": values2})
+        df2 = pd.DataFrame({"V1": values1, "V2": values2}, index=times)
+        series1 = pd.Series(values1)
+        series2 = pd.Series(values1, index=times)
+
+        with self.assertRaises(ValueError):
+            TimeSeries.create_with_dummy_index(df2)
+        with self.assertRaises(ValueError):
+            TimeSeries.create_with_dummy_index(series2)
+        ts_df1 = TimeSeries.create_with_dummy_index(df1)
+        ts_series1 = TimeSeries.create_with_dummy_index(series1)
+
+        self.assertEqual(
+            ts_df1,
+            TimeSeries(pd.DataFrame(
+                {"V1": values1, "V2": values2},
+                index=pd.date_range(start="19700101", periods=len(ts_df1), freq="S")
+                )
+            )
+        )
+
+        self.assertEqual(
+            ts_series1,
+            TimeSeries.from_times_and_values(
+                times=pd.date_range(start="19700101", periods=len(ts_series1), freq="S"),
+                values=values1
+            )
+        )
+
 
     def test_short_series_slice(self):
         seriesA, seriesB = self.series1.split_after(pd.Timestamp('20130108'))

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -453,22 +453,27 @@ class TimeSeriesTestCase(DartsBaseTestClass):
         self.assertEqual(data_darts1, data_darts2)
         self.assertEqual(data_darts1, data_darts3)
 
-    def test_create_with_dummy_index(self):
+    def test_create_dummy_index(self):
         times = pd.date_range(start="20210312", periods=15, freq="MS")
         values1 = np.random.uniform(low=-10, high=10, size=len(times))
         values2 = np.random.uniform(low=0, high=1, size=len(times))
 
         df1 = pd.DataFrame({"V1": values1, "V2": values2})
         df2 = pd.DataFrame({"V1": values1, "V2": values2}, index=times)
+        df2 = pd.DataFrame({"V1": values1, "V2": values2, "Time": times})
         series1 = pd.Series(values1)
         series2 = pd.Series(values1, index=times)
 
         with self.assertRaises(ValueError):
-            TimeSeries.create_with_dummy_index(df2)
+            TimeSeries(df2, dummy_index=True)
         with self.assertRaises(ValueError):
-            TimeSeries.create_with_dummy_index(series2)
-        ts_df1 = TimeSeries.create_with_dummy_index(df1)
-        ts_series1 = TimeSeries.create_with_dummy_index(series1)
+            TimeSeries(series2, dummy_index=True)
+        ts_df1 = TimeSeries(df1, dummy_index=True)
+        ts_series1 = TimeSeries(series1, dummy_index=True)
+
+        self.assertTrue(ts_df1.has_dummy_index)
+        self.assertTrue(ts_series1.has_dummy_index)
+        self.assertFalse(TimeSeries(df2).has_dummy_index)
 
         self.assertEqual(
             ts_df1,

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -487,7 +487,6 @@ class TimeSeriesTestCase(DartsBaseTestClass):
             )
         )
 
-
     def test_short_series_slice(self):
         seriesA, seriesB = self.series1.split_after(pd.Timestamp('20130108'))
         self.assertEqual(len(seriesA), 8)

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -528,19 +528,6 @@ class TimeSeriesTestCase(DartsBaseTestClass):
             )
         )
 
-    def test_plot_with_dummy_index(self):
-        values1 = np.random.uniform(low=-10, high=10, size=20)
-        values2 = np.random.uniform(low=0, high=1, size=20)
-        df1 = pd.DataFrame({"V1": values1})
-        df2 = pd.DataFrame({"V1": values1, "V2": values2})
-
-        ts_df1 = TimeSeries(df1, dummy_index=True)
-        ts_df2 = TimeSeries(df2, dummy_index=True)
-
-        import matplotlib.pyplot as plt
-        print(ts_df1.plot())
-        plt.show()
-
     def test_short_series_slice(self):
         seriesA, seriesB = self.series1.split_after(pd.Timestamp('20130108'))
         self.assertEqual(len(seriesA), 8)

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -871,7 +871,15 @@ class TimeSeries:
                 kwargs['figure'] = plt.gcf()
                 if 'label' in kwargs:
                     kwargs['label'] = label + '_' + str(i)
-            self.univariate_component(i).pd_series().plot(*args, **kwargs)
+            if self.has_dummy_index:
+                x_ticks = [f"Step {i}" for i in range(len(self))]
+                plot_series = pd.Series(
+                    data=self.univariate_component(i).pd_series().values,
+                    index=x_ticks
+                )
+                plot_series.plot(*args, **kwargs)
+            else:
+                self.univariate_component(i).pd_series().plot(*args, **kwargs)
         x_label = self.time_index().name
         if x_label is not None and len(x_label) > 0:
             plt.xlabel(x_label)

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -772,6 +772,19 @@ class TimeSeries:
             df.columns = columns
         return TimeSeries(df, freq, fill_missing_dates)
 
+    @staticmethod
+    def create_with_dummy_index(df: Union[pd.DataFrame, pd.Series]) -> 'TimeSeries':
+        raise_if_not(
+            isinstance(df.index, pd.RangeIndex),
+            "'df' index must be RangeIndex, not DateTimeIndex or other."
+        )
+        dummy_df = df.copy()
+        dummy_df.index = pd.date_range(start="19700101", periods=len(df), freq="S")
+        if isinstance(dummy_df, pd.Series):
+            dummy_df = pd.DataFrame(dummy_df)
+
+        return TimeSeries(df=dummy_df)
+
     def plot(self,
              new_plot: bool = False,
              *args,

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -872,7 +872,7 @@ class TimeSeries:
                 if 'label' in kwargs:
                     kwargs['label'] = label + '_' + str(i)
             if self.has_dummy_index:
-                x_ticks = [f"Step {i}" for i in range(len(self))]
+                x_ticks = np.arange(len(self))
                 plot_series = pd.Series(
                     data=self.univariate_component(i).pd_series().values,
                     index=x_ticks

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -774,6 +774,23 @@ class TimeSeries:
 
     @staticmethod
     def create_with_dummy_index(df: Union[pd.DataFrame, pd.Series]) -> 'TimeSeries':
+        """
+        Returns a TimeSeries built from a data frame or series with a dummy time index.
+
+        Some longitudinal series might not be measured at certain time stamps but in steps. Others
+        might not be a time series at all but autocorrelated analysis is still appropriate.
+        In these instances an artificial time index is needed for Darts TimeSeries.
+
+        Parameters
+        ----------
+        df
+            A `pandas.DataFrame` or `pandas.Series` without DateTimeIndex.
+
+        Returns
+        -------
+        TimeSeries
+            A TimeSeries constructed from the input.
+        """
         raise_if_not(
             isinstance(df.index, pd.RangeIndex),
             "'df' index must be RangeIndex, not DateTimeIndex or other."

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -43,8 +43,9 @@ class TimeSeries:
             Optionally, a boolean value indicating whether to fill missing dates with NaN values
             in case the frequency of `series` cannot be inferred.
         dummy_index
-            Optionally, if no date time index is present or even available. Creates a dummy index to be
-            compatible with the Darts package.
+            Optionally, if no date time index is present, this flag will instruct Darts to build a
+            dummy time index in order to obtain a valid TimeSeries. This option can be used in cases
+            where the time index doesn't matter.
         """
 
         raise_if_not(isinstance(df, pd.DataFrame), "Data must be provided in form of a pandas.DataFrame instance",
@@ -66,7 +67,7 @@ class TimeSeries:
                 ),
                 logger
             )
-            self._df.index = self.create_dummy_index()
+            self._df.index = self._create_dummy_index()
             self.has_dummy_index = True
         self._df.columns = self._clean_df_columns(df.columns)
 
@@ -734,6 +735,10 @@ class TimeSeries:
         fill_missing_dates
             Optionally, a boolean value indicating whether to fill missing dates with NaN values
             in case the frequency of `series` cannot be inferred.
+        dummy_index
+            Optionally, if no date time index is present, this flag will instruct Darts to build a
+            dummy time index in order to obtain a valid TimeSeries. This option can be used in cases
+            where the time index doesn't matter.
 
         Returns
         -------
@@ -768,6 +773,10 @@ class TimeSeries:
         fill_missing_dates
             Optionally, a boolean value indicating whether to fill missing dates with NaN values
             in case the frequency of `series` cannot be inferred.
+        dummy_index
+            Optionally, if no date time index is present, this flag will instruct Darts to build a
+            dummy time index in order to obtain a valid TimeSeries. This option can be used in cases
+            where the time index doesn't matter.
 
         Returns
         -------
@@ -823,7 +832,7 @@ class TimeSeries:
             df.columns = columns
         return TimeSeries(df, freq, fill_missing_dates)
 
-    def create_dummy_index(self, start="19700101", freq="S") -> 'TimeSeries':
+    def _create_dummy_index(self, start="19700101", freq="S") -> 'TimeSeries':
         """
         Returns a pd.DatetimeIndex. Used to attach a time index to a data frame.
 


### PR DESCRIPTION
### Summary

This new function allows the creation of a darts.TimeSeries from any `pd.DataFrame` or `pd.Series` if no time stamp is available. Might be useful for longitudinal data measured in steps. An artificial time stamp is added starting at 1970-01-01 00:00:00 with a frequency of 1 second.