### PR TITLE
restore compatibility with Python 3.6

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.8, 3.9]
         flavour: ['core', 'all']
 
     steps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         flavour: ['core', 'all', 'pmdarima', 'torch', 'fbprophet']
 
     steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 [![PyPI version](https://badge.fury.io/py/u8darts.svg)](https://badge.fury.io/py/u8darts)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/unit8co/darts/darts%20release%20workflow/master)
-![Supported versions](https://img.shields.io/badge/python-3.7+-blue.svg)
+![Supported versions](https://img.shields.io/badge/python-3.6+-blue.svg)
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/unit8/darts?label=docker&sort=date)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/u8darts)
 ![GitHub Release Date](https://img.shields.io/github/release-date/unit8co/darts)
@@ -28,7 +28,7 @@ on multiple time series.
 
 ## Install
 
-We recommend to first setup a clean Python environment for your project with at least Python 3.7 using your favorite tool ([conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html "conda-env"), [venv](https://docs.python.org/3/library/venv.html), [virtualenv](https://virtualenv.pypa.io/en/latest/) with or without [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)).
+We recommend to first setup a clean Python environment for your project with at least Python 3.6 using your favorite tool ([conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html "conda-env"), [venv](https://docs.python.org/3/library/venv.html), [virtualenv](https://virtualenv.pypa.io/en/latest/) with or without [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)).
 
 Once your environment is set up you can install darts using pip:
 
@@ -149,10 +149,10 @@ If that's not possible, first follow the official instructions to install
 and [torch](https://pytorch.org/get-started/locally/), then skip to 
 [Install darts](#install-darts)
 
-To create a conda environment for Python 3.7
+To create a conda environment for Python 3.9
 (after installing [conda](https://docs.conda.io/en/latest/miniconda.html)):
 
-    conda create --name <env-name> python=3.7
+    conda create --name <env-name> python=3.9
 
 Don't forget to activate your virtual environment
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
           'darts': ['py.typed'],
       },
       zip_safe=False,
-      python_requires='>=3.7',
+      python_requires='>=3.6',
       classifiers=[
             'Intended Audience :: Science/Research',
             'Intended Audience :: Developers',
@@ -56,6 +56,7 @@ setup(
             'Operating System :: Unix',
             'Operating System :: MacOS',
             'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',

--- a/setup_u8darts.py
+++ b/setup_u8darts.py
@@ -50,7 +50,7 @@ setup(
           'darts': ['py.typed'],
       },
       zip_safe=False,
-      python_requires='>=3.7',
+      python_requires='>=3.6',
       classifiers=[
             'Intended Audience :: Science/Research',
             'Intended Audience :: Developers',
@@ -62,6 +62,7 @@ setup(
             'Operating System :: Unix',
             'Operating System :: MacOS',
             'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
In an earlier PR I removed compatibility with Python 3.6 in order to follow Numpy 1.20+ recommendation. However due to some issues with Python 3.9 on MacOS, I had to restore Numpy 1.19.5, and so I'm restoring Python 3.6 compatibility here.