### PR TITLE
Fix model retraining  for TorchForecastingModel

### DIFF
--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -582,8 +582,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         iterator = _build_tqdm_iterator(
             range(self.current_epoch + 1, self.current_epoch + train_num_epochs + 1),
             verbose=verbose,
-            initial=self.current_epoch,
-            total=self.current_epoch + train_num_epochs
         )
 
         for epoch in iterator:

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -26,9 +26,10 @@ from ..utils.data.simple_inference_dataset import SimpleInferenceDataset
 from ..logging import raise_if_not, get_logger, raise_log, raise_if
 from .forecasting_model import GlobalForecastingModel
 
-CHECKPOINTS_FOLDER = os.path.join('.darts', 'checkpoints')
-RUNS_FOLDER = os.path.join('.darts', 'runs')
-UNTRAINED_MODELS_FOLDER = os.path.join('.darts', 'untrained_models')
+DEFAULT_DARTS_FOLDER = '.darts'
+CHECKPOINTS_FOLDER = 'checkpoints'
+RUNS_FOLDER = 'runs'
+UNTRAINED_MODELS_FOLDER = 'untrained_models'
 
 logger = get_logger(__name__)
 
@@ -105,7 +106,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                  lr_scheduler_kwargs: Optional[Dict] = None,
                  loss_fn: nn.modules.loss._Loss = nn.MSELoss(),
                  model_name: str = "torch_model_run",  # TODO: uid
-                 work_dir: str = os.getcwd(),
+                 work_dir: str = os.path.join(os.getcwd(), '.darts'),
                  log_tensorboard: bool = False,
                  nr_epochs_val_period: int = 10,
                  torch_device_str: Optional[str] = None):
@@ -706,7 +707,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         """
 
         if work_dir is None:
-            work_dir = os.getcwd()
+            work_dir = os.path.join(os.getcwd(), DEFAULT_DARTS_FOLDER)
 
         checkpoint_dir = _get_checkpoint_folder(work_dir, model_name)
 

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -608,8 +608,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                 tb_writer.add_scalar("training/loss_total", total_loss / (batch_idx + 1), epoch)
                 tb_writer.add_scalar("training/learning_rate", self._get_learning_rate(), epoch)
 
-            self._save_model(False, _get_checkpoint_folder(self.work_dir, self.model_name), epoch)
             self.current_epoch = epoch
+            self._save_model(False, _get_checkpoint_folder(self.work_dir, self.model_name), epoch)
 
             if epoch % self.nr_epochs_val_period == 0:
                 training_loss = total_loss / len(train_loader)

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -568,7 +568,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         best_loss = np.inf
 
         iterator = _build_tqdm_iterator(
-            range(self.current_epoch + 1, self.current_epoch + train_num_epochs + 1), verbose)
+            range(self.current_epoch + 1, self.current_epoch + train_num_epochs + 1), verbose,
+            initial=self.current_epoch + 1)
 
         for epoch in iterator:
             total_loss = 0


### PR DESCRIPTION
Before, it wasn't very easy to train already trained model for more epochs. This fix brings new parameter, `epochs`, to `fit()` and `fit_from_dataset()` methods that allows for further training your model.