### PR TITLE
Fix/TorchForecastingModel.predict_from_dataset

### DIFF
--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -518,7 +518,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                 while sum(map(lambda t: t.shape[1], batch_prediction)) < n:
                     roll_size = min(self.output_chunk_length, self.input_chunk_length)
                     batch = torch.roll(batch, -roll_size, 1)
-                    batch[:, -roll_size:, :] = out[:, :roll_size, :]
+                    batch[:, -roll_size:, :] = out[:, -roll_size:, :]
                     # take only last part of the output sequence where needed
                     out = self.model(batch)[:, self.first_prediction_index:, :]
                     batch_prediction.append(out)


### PR DESCRIPTION
Fixed rolling of input in predict function when input_chunk_length > output_chunk_length.

Behavior before:
![download-1](https://user-images.githubusercontent.com/42946363/120691381-ae21d480-c4a6-11eb-8355-d20a3a1f4d05.png)

Behavior after:
![download](https://user-images.githubusercontent.com/42946363/120691400-b4b04c00-c4a6-11eb-9ac0-1aa5c23f4388.png)

For LSTM with input_chunk_length=5, output_chunk_length=10.
