### PR TITLE
Fix/nbeats gpu cpu

### DIFF
--- a/darts/models/nbeats.py
+++ b/darts/models/nbeats.py
@@ -32,8 +32,8 @@ class _TrendGenerator(nn.Module):
                  output_dim):
         super(_TrendGenerator, self).__init__()
         self.T = nn.Parameter(
-            torch.stack([(torch.arange(output_dim) / output_dim)**i for i in range(expansion_coefficient_dim)], 1)
-        )
+            torch.stack([(torch.arange(output_dim) / output_dim)**i for i in range(expansion_coefficient_dim)], 1),
+            False)
 
     def forward(self, x):
         return torch.matmul(x, self.T.float().T)
@@ -47,7 +47,8 @@ class _SeasonalityGenerator(nn.Module):
         half_minus_one = int(output_dim / 2 - 1)
         cos_vectors = [torch.cos(torch.arange(output_dim) * 2 * np.pi * i) for i in range(1, half_minus_one + 1)]
         sin_vectors = [torch.sin(torch.arange(output_dim) * 2 * np.pi * i) for i in range(1, half_minus_one + 1)]
-        self.S = nn.Parameter(torch.stack([torch.ones(output_dim)] + cos_vectors + sin_vectors, 1))
+        self.S = nn.Parameter(torch.stack([torch.ones(output_dim)] + cos_vectors + sin_vectors, 1),
+                              False)
 
     def forward(self, x):
         return torch.matmul(x, self.S.float().T)

--- a/darts/models/nbeats.py
+++ b/darts/models/nbeats.py
@@ -31,7 +31,9 @@ class _TrendGenerator(nn.Module):
                  expansion_coefficient_dim,
                  output_dim):
         super(_TrendGenerator, self).__init__()
-        self.T = torch.stack([(torch.arange(output_dim) / output_dim)**i for i in range(expansion_coefficient_dim)], 1)
+        self.T = nn.Parameter(
+            torch.stack([(torch.arange(output_dim) / output_dim)**i for i in range(expansion_coefficient_dim)], 1)
+        )
 
     def forward(self, x):
         return torch.matmul(x, self.T.float().T)
@@ -45,7 +47,7 @@ class _SeasonalityGenerator(nn.Module):
         half_minus_one = int(output_dim / 2 - 1)
         cos_vectors = [torch.cos(torch.arange(output_dim) * 2 * np.pi * i) for i in range(1, half_minus_one + 1)]
         sin_vectors = [torch.sin(torch.arange(output_dim) * 2 * np.pi * i) for i in range(1, half_minus_one + 1)]
-        self.S = torch.stack([torch.ones(output_dim)] + cos_vectors + sin_vectors, 1)
+        self.S = nn.Parameter(torch.stack([torch.ones(output_dim)] + cos_vectors + sin_vectors, 1))
 
     def forward(self, x):
         return torch.matmul(x, self.S.float().T)


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #298 

### Summary

The bug was caused by missing torch tensor registrations in `_TrendGenerator` and `_SeasonalityGenerator` blocks. Registering them via `nn.Parameter()` solved this issue.

### Detailed Information

The current implementation of NBEATS `_TrendGenerator` and `_SeasonalityGenerator` instantiate tensors (`self.T` and `self.S` respectively) which are not subsequently moved to the current device (since not correctly registered in these blocks). This works fine while training on CPU, but fails when we try using GPU, since those tensors are not moved. To correctly register these tensors such that calling `model.to(device)` will properly take care of them, I wrapped those tensors using `nn.Parameters()`.