### PR TITLE
Fix/future covariates loader

### DIFF
--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -637,7 +637,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         Optional[Sequence[TimeSeries]]
             Covariates required to predict horizons up to `self.output_chunk_length`, or `None` if the model
             does not require covariates.
-        Optional[torch.Tensor]
+        Optional[Sequence[TimeSeries]]
             Covariates required to predict horizons beyond `self.output_chunk_length`, or `None` if the model
             does require future covariates either because it does not require covariates at all or because
             `n <= self.output_chunk_length`.

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -638,7 +638,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
                 # get first timestamp that lies in the future of target series
                 first_pred_time = target_series.end_time() + target_series.freq()
-                print(first_pred_time)
                 
                 # check whether future covariates are available and separate them if they are
                 if covariate_series.end_time() >= first_pred_time:
@@ -683,7 +682,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         #cov_future = torch.cat(cov_future_arr, dim=0) if len(cov_future_arr) > 0 else None
         cov_past_arr = None if len(cov_past_arr) == 0 else cov_past_arr
         cov_future_arr = None if len(cov_future_arr) == 0 else cov_future_arr
-        print(cov_future_arr)
+
         return in_past_arr, cov_past_arr, cov_future_arr
 
     def untrained_model(self):

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -542,11 +542,11 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                     # update covariates to include next `roll_size` predictions into the future
                     if len(cov_future.shape) == 3 and self.input_chunk_length >= roll_size:
                         batch[:, -roll_size:, self.output_dim:] = (
-                            cov_future[0, prediction_length-roll_size:prediction_length , :]
+                            cov_future[:, prediction_length-roll_size:prediction_length , :]
                         )
                     elif len(cov_future.shape) == 3:
                         batch[:, :, self.output_dim:] = (
-                            cov_future[0, prediction_length-self.input_chunk_length:prediction_length , :]
+                            cov_future[:, prediction_length-self.input_chunk_length:prediction_length , :]
                         )
 
                     # take only last part of the output sequence where needed
@@ -638,6 +638,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
                 # get first timestamp that lies in the future of target series
                 first_pred_time = target_series.end_time() + target_series.freq()
+                print(first_pred_time)
                 
                 # check whether future covariates are available and separate them if they are
                 if covariate_series.end_time() >= first_pred_time:
@@ -682,6 +683,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         #cov_future = torch.cat(cov_future_arr, dim=0) if len(cov_future_arr) > 0 else None
         cov_past_arr = None if len(cov_past_arr) == 0 else cov_past_arr
         cov_future_arr = None if len(cov_future_arr) == 0 else cov_future_arr
+        print(cov_future_arr)
         return in_past_arr, cov_past_arr, cov_future_arr
 
     def untrained_model(self):

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -555,11 +555,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
                     # update target input to include next `roll_size` predictions
                     if self.input_chunk_length >= roll_size:
-<<<<<<< HEAD
                         input_series[:, -roll_size:, :self.output_dim] = out[:, :roll_size, :] 
-=======
-                        batch[:, -roll_size:, :self.output_dim] = out[:, :roll_size, :]
->>>>>>> develop
                     else:
                         input_series[:, :, :self.output_dim] = out[:, -self.input_chunk_length:, :]
 
@@ -607,7 +603,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
     def _prepare_predict_timeseries(self, n: int, series, covariates):
         """
-<<<<<<< HEAD
         Creates 3 lists with `TimeSeries` instances required to produce model predictions. 
         `tgt_past_arr` contains target series, which will be predicted into the future.
         `cov_past_arr` contains covariates with the same time indices as the target series, if the model
@@ -616,15 +611,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         If the model is required to produce the forecast over multiple iterations, i.e. if 
         `n > self.output_chunk_length`, and if it was trained with covariates, then `cov_future_arr` will
         contain the future covariates up to `n - self.output_chunk_length` time steps into the future.
-=======
-        Creates a torch tensor `in_past` from `TimeSeriesInferenceDataset` instance for initial input to model
-        which includes the target series and covariate series if the model was trained with covariates.
-        Only past covariates are included, even if more are provided.
-
-        If the model is required to produce the forecast over multiple iterations, i.e. if
-        `n > self.output_chunk_length`, and if it was trained with covariates, then `cov_future` will
-        contain the future covariates up to `n` time steps into the future.
->>>>>>> develop
 
         Parameters
         ----------
@@ -637,7 +623,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
         Returns
         -------
-<<<<<<< HEAD
         Sequence[TimeSeries]
             Past target series which are going to be predicted into the future, and which will used as
             input to the model.
@@ -645,12 +630,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             Covariates required to predict horizons up to `self.output_chunk_length`, or `None` if the model
             does not require covariates.
         Optional[torch.Tensor]
-=======
-        torch.Tensor of shape `(len(input_series_dataset), self.input_chunk_length, target.width + covariates.width)`
-            Initial input to model which contains the input target sereis and the matching past covariates,
-            if available
-        Optional[torch.Tensor] of shape `(len(input_series_dataset), n, covariates.width)`
->>>>>>> develop
             Covariates required to predict horizons beyond `self.output_chunk_length`, or `None` if the model
             does require future covariates either because it does not require covariates at all or because
             `n <= self.output_chunk_length`.

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -632,7 +632,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             # TODO: e.g. by taking their latest common timestamp.
 
             in_past = target_series[-self.input_chunk_length:]
-            #in_past = torch.from_numpy(in_past).float().to(self.device)
 
             if covariate_series is not None:
 
@@ -647,10 +646,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
                 # keep only the last covariates that the model can use as input
                 cov_past = cov_past[-self.input_chunk_length:]
-
-                # create torch tensor
-                #cov_past = torch.from_numpy(cov_past).float().to(self.device)
-                #cov_past = cov_past.view(1, self.input_chunk_length, -1)
                 cov_past_arr.append(cov_past)
 
                 # handle future covariates
@@ -666,20 +661,12 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                     cov_future = covariate_series.drop_before(first_pred_time - covariate_series.freq())
                     cov_future = cov_future[:n - self.output_chunk_length]
 
-
-                    #cov_future = torch.from_numpy(cov_future).float().to(self.device)
-                    #cov_future = cov_future.view(1, n - self.output_chunk_length, -1)
                     cov_future_arr.append(cov_future)
 
-
-            #in_past = in_past.view(1, self.input_chunk_length, -1)
             in_past_arr.append(in_past)
             
 
         # concatenate tensors to include multiple time series in one batch
-        #in_past = torch.cat(in_past_arr, dim=0)
-        #cov_past = torch.cat(cov_past_arr, dim=0) if len(cov_past_arr) > 0 else None
-        #cov_future = torch.cat(cov_future_arr, dim=0) if len(cov_future_arr) > 0 else None
         cov_past_arr = None if len(cov_past_arr) == 0 else cov_past_arr
         cov_future_arr = None if len(cov_future_arr) == 0 else cov_future_arr
 

--- a/darts/tests/test_datasets.py
+++ b/darts/tests/test_datasets.py
@@ -19,19 +19,21 @@ class DatasetTestCase(DartsBaseTestClass):
 
     def test_simple_inference_dataset(self):
         # one target series
-        ds = SimpleInferenceDataset(series=self.target1)
+        ds = SimpleInferenceDataset(series=self.target1, input_chunk_length=len(self.target1))
         self.assertEqual(ds[0], (self.target1, None, None))
 
         # two target series
-        ds = SimpleInferenceDataset(series=[self.target1, self.target2])
+        ds = SimpleInferenceDataset(series=[self.target1, self.target2],
+                                    input_chunk_length=max(len(self.target1), len(self.target2)))
         self.assertEqual(ds[1], (self.target2, None, None))
 
         # fail if covariates do not have same size
         with self.assertRaises(ValueError):
-            ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates_past=[self.cov1])
+            ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates=[self.cov1])
 
         # with covariates
-        ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates_past=[self.cov1, self.cov2])
+        ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates=[self.cov1, self.cov2],
+                                    input_chunk_length=max(len(self.target1), len(self.target2)))
         self.assertEqual(ds[1], (self.target2, self.cov2, None))
 
     def test_sequential_dataset(self):

--- a/darts/tests/test_datasets.py
+++ b/darts/tests/test_datasets.py
@@ -20,19 +20,19 @@ class DatasetTestCase(DartsBaseTestClass):
     def test_simple_inference_dataset(self):
         # one target series
         ds = SimpleInferenceDataset(series=self.target1)
-        self.assertEqual(ds[0], (self.target1, None))
+        self.assertEqual(ds[0], (self.target1, None, None))
 
         # two target series
         ds = SimpleInferenceDataset(series=[self.target1, self.target2])
-        self.assertEqual(ds[1], (self.target2, None))
+        self.assertEqual(ds[1], (self.target2, None, None))
 
         # fail if covariates do not have same size
         with self.assertRaises(ValueError):
-            ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates=[self.cov1])
+            ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates_past=[self.cov1])
 
         # with covariates
-        ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates=[self.cov1, self.cov2])
-        self.assertEqual(ds[1], (self.target2, self.cov2))
+        ds = SimpleInferenceDataset(series=[self.target1, self.target2], covariates_past=[self.cov1, self.cov2])
+        self.assertEqual(ds[1], (self.target2, self.cov2, None))
 
     def test_sequential_dataset(self):
         # one target series

--- a/darts/tests/test_global_forecasting_models.py
+++ b/darts/tests/test_global_forecasting_models.py
@@ -55,6 +55,20 @@ if TORCH_AVAILABLE:
         time_covariates = scaler_dt.fit_transform(year_series.stack(month_series))
         time_covariates_train, time_covariates_val = time_covariates[:-36], time_covariates[-36:]
 
+        # an artificial time series that is highly dependent on covariates
+        ts_length = 400
+        split_ratio = 0.6
+        sine_1_ts = tg.sine_timeseries(length=ts_length)
+        sine_2_ts = tg.sine_timeseries(length=ts_length, value_frequency=0.05)
+        sine_3_ts = tg.sine_timeseries(length=ts_length, value_frequency=0.003, value_amplitude=5)
+        linear_ts = tg.linear_timeseries(length=ts_length, start_value=3, end_value=8)
+
+        covariates = sine_3_ts.stack(sine_2_ts).stack(linear_ts)
+        covariates_past, _ = covariates.split_after(split_ratio)
+
+        target = sine_1_ts + sine_2_ts + linear_ts + sine_3_ts
+        target_past, target_future = target.split_after(split_ratio)
+
         def test_single_ts(self):
             for model_cls, kwargs, err in models_cls_kwargs_errs:
                 model = model_cls(input_chunk_length=IN_LEN, output_chunk_length=OUT_LEN, random_state=0, **kwargs)
@@ -110,7 +124,6 @@ if TORCH_AVAILABLE:
                 self.assertTrue(mape_err < err, 'Model {} produces errors too high (several time '
                                                 'series with covariates). Error = {}'.format(model_cls, mape_err))
 
-                
                 # when model is fit using 1 training and 1 covariate series, time series args are optional
                 model = model_cls(input_chunk_length=IN_LEN, output_chunk_length=OUT_LEN, **kwargs)
                 model.fit(series=self.ts_pass_train, covariates=self.time_covariates_train)
@@ -125,36 +138,47 @@ if TORCH_AVAILABLE:
         def test_future_covariates(self):
             # models with future covariates should produce better predictions over a long forecasting horizon
             # than a model trained with no covariates
-            ts_length = 400
-            split_ratio = 0.6
-            sine_1_ts = tg.sine_timeseries(length=ts_length)
-            sine_2_ts = tg.sine_timeseries(length=ts_length, value_frequency=0.05)
-            sine_3_ts = tg.sine_timeseries(length=ts_length, value_frequency=0.003, value_amplitude=5)
-            linear_ts = tg.linear_timeseries(length=ts_length, start_value=3, end_value=8)
-
-
-            covariates = sine_3_ts.stack(sine_2_ts).stack(linear_ts)
-            covariates_past, covariates_future = covariates.split_after(split_ratio)
-
-            target = sine_1_ts + sine_2_ts + linear_ts + sine_3_ts
-            target_past, target_future = target.split_after(split_ratio)
             model = TCNModel(input_chunk_length=50, output_chunk_length=5, n_epochs=20, random_state=0)
 
-            model.fit(series=target_past)
+            model.fit(series=self.target_past)
             long_pred_no_cov = model.predict(n=160)
 
             model = TCNModel(input_chunk_length=50, output_chunk_length=5, n_epochs=20, random_state=0)
-            model.fit(series=target_past, covariates=covariates_past)
-            long_pred_with_cov = model.predict(n=160, covariates=covariates)
-            self.assertTrue(mape(target_future, long_pred_no_cov) > mape(target_future, long_pred_with_cov),
+            model.fit(series=self.target_past, covariates=self.covariates_past)
+            long_pred_with_cov = model.predict(n=160, covariates=self.covariates)
+            self.assertTrue(mape(self.target_future, long_pred_no_cov) > mape(self.target_future, long_pred_with_cov),
                             'Models with future covariates should produce better predictions.')
 
             # models can predict up to self.output_chunk_length points beyond the last future covariate...
-            model.predict(n=165, covariates=covariates)
+            model.predict(n=165, covariates=self.covariates)
 
             # ... not more
             with self.assertRaises(ValueError):
                 model.predict(n=166, series=self.ts_pass_train)
+
+        def test_batch_predictions(self):
+            # predicting multiple time series at once needs to work for arbitrary batch sizes
+            # univariate case
+            targets_univar = [self.target_past, self.target_past[:60], self.target_past[:80]]
+            self._batch_prediction_test_helper_function(targets_univar)
+
+            # multivariate case
+            targets_multivar = [tgt.stack(tgt) for tgt in targets_univar]
+            self._batch_prediction_test_helper_function(targets_multivar)
+
+        def _batch_prediction_test_helper_function(self, targets):
+            epsilon = 1e-5
+            model = TCNModel(input_chunk_length=50, output_chunk_length=10, n_epochs=10, random_state=0)
+            model.fit(series=targets[0], covariates=self.covariates_past)
+            preds_default = model.predict(n=160, series=targets,
+                                          covariates=[self.covariates] * len(targets), batch_size=None)
+
+            for batch_size in range(1, 5):
+                preds = model.predict(n=160, series=targets,
+                                      covariates=[self.covariates] * len(targets), batch_size=batch_size)
+
+                for i in range(len(targets)):
+                    self.assertLess(sum(sum((preds[i] - preds_default[i]).values())), epsilon)
 
         def test_predict_from_dataset_unsupported_input(self):
             # an exception should be thrown if an unsupported type is passed

--- a/darts/tests/test_global_forecasting_models.py
+++ b/darts/tests/test_global_forecasting_models.py
@@ -167,7 +167,7 @@ if TORCH_AVAILABLE:
             self._batch_prediction_test_helper_function(targets_multivar)
 
         def _batch_prediction_test_helper_function(self, targets):
-            epsilon = 1e-5
+            epsilon = 1e-4
             model = TCNModel(input_chunk_length=50, output_chunk_length=10, n_epochs=10, random_state=0)
             model.fit(series=targets[0], covariates=self.covariates_past)
             preds_default = model.predict(n=160, series=targets,

--- a/darts/utils/data/simple_inference_dataset.py
+++ b/darts/utils/data/simple_inference_dataset.py
@@ -29,6 +29,13 @@ class SimpleInferenceDataset(TimeSeriesInferenceDataset):
         `n > self.output_chunk_length`, and if covariates were provided, then `cov_future` will
         be equal to the future covariates up to `n - self.output_chunk_length` time steps into the future.
 
+        The parameter `input_chunk_length` is necessary to determine the minimum length for all `tgt_past`
+        and `cov_past` time series.
+        Parameters `n` and `output_chunk_length` are necessary to determine whether `cov_future` is necessary
+        (or can be set to `None`) and to determine the required length for `cov_future`.
+        It is important for the 3 emitted time series to have the same length across data points because
+        they will be cast to tensors later on.
+
         Parameters
         ----------
         series

--- a/darts/utils/data/simple_inference_dataset.py
+++ b/darts/utils/data/simple_inference_dataset.py
@@ -66,9 +66,6 @@ class SimpleInferenceDataset(TimeSeriesInferenceDataset):
                      'All input series must have length >= `input_chunk_length` ({}).'.format(
                      self.input_chunk_length))
 
-        # TODO: here we could be smart and handle cases where target and covariates do not have same time axis.
-        # TODO: e.g. by taking their latest common timestamp.
-
         tgt_past = target_series[-self.input_chunk_length:]
 
         cov_past = cov_future = None
@@ -99,4 +96,3 @@ class SimpleInferenceDataset(TimeSeriesInferenceDataset):
                 cov_future = cov_future[:self.n - self.output_chunk_length]
 
         return tgt_past, cov_past, cov_future
-

--- a/darts/utils/data/simple_inference_dataset.py
+++ b/darts/utils/data/simple_inference_dataset.py
@@ -11,26 +11,92 @@ from ...logging import raise_if_not
 
 
 class SimpleInferenceDataset(TimeSeriesInferenceDataset):
+
     def __init__(self,
                  series: Union[TimeSeries, Sequence[TimeSeries]],
-                 covariates_past: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-                 covariates_future: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None):
+                 covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+                 n: int = 1,
+                 input_chunk_length: int = 12,
+                 output_chunk_length: int = 1):
+        """
+        Creates a dataset from lists of target series and corresponding covariate series and emits
+        3-tuples of (tgt_past, cov_past, cov_future), all `TimeSeries` instances.
+        `tgt_past` corresponds to the target series, which will be predicted into the future.
+        `cov_past` is equal to the covariates with the same time index as the target series if covariates
+        are provided, otherwise a value of `None` will be emitted.
+        Both `tgt_past` and `cov_past` will be `input_chunk_length` long.
+        If the model is required to produce the forecast over multiple iterations, i.e. if
+        `n > self.output_chunk_length`, and if covariates were provided, then `cov_future` will
+        be equal to the future covariates up to `n - self.output_chunk_length` time steps into the future.
+
+        Parameters
+        ----------
+        series
+            The target series that are to be predicted into the future.
+        covariates
+            Optionally, the corresponding covariates that are used for predictions. This argument is required
+            if the model was trained with covariates.
+        n
+            The number of time steps after the end of the training time series for which to produce predictions.
+        input_chunk_length
+            The length of the time series the model takes as input.
+        output_chunk_length
+            The length of the model predictions after one call to its `forward` function.
+    """
+
         super().__init__()
         self.series = [series] if isinstance(series, TimeSeries) else series
-        self.covariates_past = [covariates_past] if isinstance(covariates_past, TimeSeries) else covariates_past
-        self.covariates_future = [covariates_future] if isinstance(covariates_future, TimeSeries) else covariates_future
+        self.covariates = [covariates] if isinstance(covariates, TimeSeries) else covariates
+        self.n = n
+        self.input_chunk_length = input_chunk_length
+        self.output_chunk_length = output_chunk_length
 
-        raise_if_not((covariates_past is None or len(series) == len(covariates_past)) and
-                     (covariates_future is None or len(series) == len(covariates_future)),
+        raise_if_not((covariates is None or len(series) == len(covariates)),
                      'The number of target series must be equal to the number of covariates.')
 
     def __len__(self):
         return len(self.series)
 
     def __getitem__(self, idx: int) -> Tuple[TimeSeries, Optional[TimeSeries], Optional[TimeSeries]]:
-        cov_past_output = None if self.covariates_past is None else self.covariates_past[idx]
-        cov_future_output = None if self.covariates_future is None else self.covariates_future[idx]
 
-        return self.series[idx], cov_past_output, cov_future_output
+        target_series = self.series[idx]
+        covariate_series = None if self.covariates is None else self.covariates[idx]
 
+        raise_if_not(len(target_series) >= self.input_chunk_length,
+                     'All input series must have length >= `input_chunk_length` ({}).'.format(
+                     self.input_chunk_length))
+
+        # TODO: here we could be smart and handle cases where target and covariates do not have same time axis.
+        # TODO: e.g. by taking their latest common timestamp.
+
+        tgt_past = target_series[-self.input_chunk_length:]
+
+        cov_past = cov_future = None
+        if covariate_series is not None:
+
+            # get first timestamp that lies in the future of target series
+            first_pred_time = target_series.end_time() + target_series.freq()
+
+            # isolate past covariates and add them to array
+            if covariate_series.end_time() >= first_pred_time:
+                cov_past = covariate_series.drop_after(first_pred_time)
+            else:
+                cov_past = covariate_series
+            cov_past = cov_past[-self.input_chunk_length:]
+
+            # check whether future covariates are required
+            if self.n > self.output_chunk_length:
+
+                # check that enough future covariates are available
+                last_required_future_covariate_ts = (
+                    target_series.end_time() + (self.n - self.output_chunk_length) * target_series.freq()
+                )
+                raise_if_not(covariate_series.end_time() >= last_required_future_covariate_ts,
+                             'All covariates must be known `n - output_chunk_length` time steps into the future')
+
+                # isolate necessary future covariates and add them to array
+                cov_future = covariate_series.drop_before(first_pred_time - covariate_series.freq())
+                cov_future = cov_future[:self.n - self.output_chunk_length]
+
+        return tgt_past, cov_past, cov_future
 

--- a/darts/utils/data/simple_inference_dataset.py
+++ b/darts/utils/data/simple_inference_dataset.py
@@ -13,15 +13,24 @@ from ...logging import raise_if_not
 class SimpleInferenceDataset(TimeSeriesInferenceDataset):
     def __init__(self,
                  series: Union[TimeSeries, Sequence[TimeSeries]],
-                 covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None):
+                 covariates_past: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+                 covariates_future: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None):
         super().__init__()
         self.series = [series] if isinstance(series, TimeSeries) else series
-        self.covariates = [covariates] if isinstance(covariates, TimeSeries) else covariates
-        raise_if_not(covariates is None or len(series) == len(covariates),
+        self.covariates_past = [covariates_past] if isinstance(covariates_past, TimeSeries) else covariates_past
+        self.covariates_future = [covariates_future] if isinstance(covariates_future, TimeSeries) else covariates_future
+
+        raise_if_not((covariates_past is None or len(series) == len(covariates_past)) and
+                     (covariates_future is None or len(series) == len(covariates_future)),
                      'The number of target series must be equal to the number of covariates.')
 
     def __len__(self):
         return len(self.series)
 
-    def __getitem__(self, idx: int) -> Tuple[TimeSeries, Optional[TimeSeries]]:
-        return (self.series[idx], None) if self.covariates is None else (self.series[idx], self.covariates[idx])
+    def __getitem__(self, idx: int) -> Tuple[TimeSeries, Optional[TimeSeries], Optional[TimeSeries]]:
+        cov_past_output = None if self.covariates_past is None else self.covariates_past[idx]
+        cov_future_output = None if self.covariates_future is None else self.covariates_future[idx]
+
+        return self.series[idx], cov_past_output, cov_future_output
+
+

--- a/darts/utils/data/timeseries_dataset.py
+++ b/darts/utils/data/timeseries_dataset.py
@@ -16,8 +16,8 @@ logger = get_logger(__name__)
 class TimeSeriesInferenceDataset(ABC, Sequence):
     def __init__(self):
         """
-        Abstract class for a `TimeSeries` inference dataset. It contains 2-tuples of
-        `(input_target, input_covariate)` `TimeSeries`.
+        Abstract class for a `TimeSeries` inference dataset. It contains 3-tuples of
+        `(input_target, past_covariate, future_covariate)` `TimeSeries`.
         The emitted covariates are optional and can be `None`.
 
         It can be used as models' inputs, to obtain simple forecasts on each `TimeSeries`
@@ -36,7 +36,7 @@ class TimeSeriesInferenceDataset(ABC, Sequence):
         pass
 
     @abstractmethod
-    def __getitem__(self, idx: int) -> Tuple[TimeSeries, Optional[TimeSeries]]:
+    def __getitem__(self, idx: int) -> Tuple[TimeSeries, Optional[TimeSeries], Optional[TimeSeries]]:
         pass
 
 


### PR DESCRIPTION
My previous implementation of future covariates did not work in the general case for any predict batch size because as we iterate through batches of the input time series, we also need to iterate through future covariates. 
To solve this I adapted the `SimpleInferenceDataset` class to now return 3 values: target_series_past, covariates_past, covariates_future. The last two values are optional.

I also had to adapt the last part of the `predict_from_dataset` method where the `TimeSeries` predictions are created. This is because the current version on develop assumes that all time series that are being predicted fit in one batch. I had to make sure the indices of the time series in each batch are known so that the right time indices can be retrieved from the `SimpleInferenceDataset`.