### PR TITLE
Fix/ reintroduced n_rnn_layers parameter in RNNModel

### DIFF
--- a/darts/tests/test_block_RNN.py
+++ b/darts/tests/test_block_RNN.py
@@ -7,7 +7,7 @@ from ..logging import get_logger
 logger = get_logger(__name__)
 
 try:
-    from ..models.rnn_model import _RNNModule, BlockRNNModel
+    from ..models.rnn_model import _BlockRNNModule, BlockRNNModel
     TORCH_AVAILABLE = True
 except ImportError:
     logger.warning('Torch not available. RNN tests will be skipped.')
@@ -20,8 +20,8 @@ if TORCH_AVAILABLE:
         times = pd.date_range('20130101', '20130410')
         pd_series = pd.Series(range(100), index=times)
         series: TimeSeries = TimeSeries.from_series(pd_series)
-        module = _RNNModule('RNN', input_size=1, output_chunk_length=1, hidden_dim=25,
-                            num_layers=1, num_layers_out_fc=[], dropout=0)
+        module = _BlockRNNModule('RNN', input_size=1, output_chunk_length=1, hidden_dim=25,
+                                 num_layers=1, num_layers_out_fc=[], dropout=0)
 
         def test_creation(self):
             with self.assertRaises(ValueError):
@@ -39,7 +39,7 @@ if TORCH_AVAILABLE:
 
             # Test fit-save-load cycle
             model2 = BlockRNNModel(input_chunk_length=1, output_chunk_length=1,
-                              model='LSTM', n_epochs=3, model_name='unittest-model-lstm')
+                                   model='LSTM', n_epochs=3, model_name='unittest-model-lstm')
             model2.fit(self.series)
             model_loaded = model2.load_from_checkpoint(model_name='unittest-model-lstm', best=False)
             pred1 = model2.predict(n=6)


### PR DESCRIPTION
Quickie:  For some reason I removed the option to have more than one layer in the rnn module in the new `RNNModel` class. I simply reintroduced the parameter.

I also took care of some renaming that slipped past my attention.