### PR TITLE
Fix import preventing BlockRNN tests from running

### DIFF
--- a/darts/tests/test_block_RNN.py
+++ b/darts/tests/test_block_RNN.py
@@ -7,7 +7,7 @@ from ..logging import get_logger
 logger = get_logger(__name__)
 
 try:
-    from ..models.rnn_model import _BlockRNNModule, BlockRNNModel
+    from ..models.block_rnn_model import _BlockRNNModule, BlockRNNModel
     TORCH_AVAILABLE = True
 except ImportError:
     logger.warning('Torch not available. RNN tests will be skipped.')


### PR DESCRIPTION
Fixes skipping of BlockRNN tests (see test logs).