### PR TITLE
Feat/added random_state support to DeepAR predictions

### DIFF
--- a/darts/models/rnn_model.py
+++ b/darts/models/rnn_model.py
@@ -211,6 +211,7 @@ class RNNModel(TorchForecastingModel):
         else:
             return super()._compute_loss(output, target)
 
+    @random_method
     def _produce_predict_output(self, input, last_hidden_state=None):
         if self.likelihood:
             output, hidden = self.model(input, last_hidden_state)

--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -425,6 +425,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             tb_writer.flush()
             tb_writer.close()
 
+    @random_method
     def predict(self,
                 n: int,
                 series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,

--- a/darts/tests/test_probabilistic_rnn.py
+++ b/darts/tests/test_probabilistic_rnn.py
@@ -1,4 +1,3 @@
-from darts.utils import likelihood_models
 import numpy as np
 
 from .base_test_class import DartsBaseTestClass

--- a/darts/tests/test_probabilistic_rnn.py
+++ b/darts/tests/test_probabilistic_rnn.py
@@ -1,0 +1,40 @@
+from darts.utils import likelihood_models
+import numpy as np
+
+from .base_test_class import DartsBaseTestClass
+from ..utils import timeseries_generation as tg
+from ..logging import get_logger
+
+logger = get_logger(__name__)
+
+try:
+    from ..models.rnn_model import RNNModel
+    from darts.utils.likelihood_models import GaussianLikelihoodModel
+    TORCH_AVAILABLE = True
+except ImportError:
+    logger.warning('Torch not available. TCN tests will be skipped.')
+    TORCH_AVAILABLE = False
+
+
+if TORCH_AVAILABLE:
+    class ProbabilisticRNNModelTestCase(DartsBaseTestClass):
+
+        def test_fit_predict_determinism(self):
+            ts = tg.constant_timeseries(length=100, value=10)
+
+            # whether the first predictions of two models initiated with the same random state are the same
+            model = RNNModel(input_chunk_length=1, n_epochs=10, training_length=10, random_state=0,
+                             likelihood=GaussianLikelihoodModel())
+            model.fit(ts)
+            pred1 = model.predict(n=10, num_samples=2).values()
+
+            model = RNNModel(input_chunk_length=1, n_epochs=10, training_length=10, random_state=0,
+                             likelihood=GaussianLikelihoodModel())
+            model.fit(ts)
+            pred2 = model.predict(n=10, num_samples=2).values()
+
+            self.assertTrue((pred1 == pred2).all())
+
+            # test whether the next prediction of the same model is different
+            pred3 = model.predict(n=10, num_samples=2).values()
+            self.assertTrue((pred2 != pred3).any())

--- a/darts/utils/torch.py
+++ b/darts/utils/torch.py
@@ -62,5 +62,5 @@ def random_method(decorated: Callable[..., T]) -> Callable[..., T]:
 
         with fork_rng():
             manual_seed(self._random_instance.randint(0, high=MAX_TORCH_SEED_VALUE))
-            decorated(self, *args, **kwargs)
+            return decorated(self, *args, **kwargs)
     return decorator


### PR DESCRIPTION
I added `random_state` support to the appropriate methods invoked by `RNNModel` when instantiated with a likelihood model so that, while if the model produces `n` predictions they will all be pseudorandomly different from each other, if the same model is instantiated with the same `random_state` parameter, it will again produce the same `n` predictions.