### PR TITLE
torch model exception on cuda 'Tensor for argument #2 'mat1' is on CP…

### DIFF
--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -611,7 +611,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             for batch_tuple in iterator:
 
                 # at this point `input_series` contains both the past target series and past covariates
-                input_series = batch_tuple[0]
+                input_series = batch_tuple[0].to(self.device)
                 cov_future = batch_tuple[1] if len(batch_tuple) == 3 else None
 
                 # repeat prediction procedure for every needed sample


### PR DESCRIPTION
…U, but expected it to be on GPU'

while running the darts example 02-multi-time-series-and-covariates on cuda , it will report exception with the predict function.
after debug and test, we found the reason is in predict_from_dataset, 
#input_series = batch_tuple[0]  #missed opertion of to device. should be like below:
input_series = batch_tuple[0].to(self.device)

--------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-9-4b19890be2e4> in <module>
----> 1 pred = model_air.predict(tensor_n)
      2 
      3 series_air_scaled.plot(label='actual')
      4 pred.plot(label='forecast')
      5 plt.legend();

./darts/utils/torch.py in decorator(self, *args, **kwargs)
     63         with fork_rng():
     64             manual_seed(self._random_instance.randint(0, high=MAX_TORCH_SEED_VALUE))
---> 65             return decorated(self, *args, **kwargs)
     66     return decorator

./darts/models/torch_forecasting_model.py in predict(self, n, series, covariates, batch_size, verbose, n_jobs, roll_size, num_samples)
    519                                          self.is_recurrent)
    520         predictions = self.predict_from_dataset(n, dataset, verbose=verbose, batch_size=batch_size, n_jobs=n_jobs,
--> 521                                                 roll_size=roll_size, num_samples=num_samples)
    522         return predictions[0] if called_with_single_series else predictions
    523 

./darts/models/torch_forecasting_model.py in predict_from_dataset(self, n, input_series_dataset, batch_size, verbose, n_jobs, roll_size, num_samples)
    621                         batch_prediction = self._predict_batch_recurrent_model(n, input_series, cov_future)
    622                     else:
--> 623                         batch_prediction = self._predict_batch_block_model(n, input_series, cov_future, roll_size)
    624 
    625                     # bring predictions into desired format and drop unnecessary values

./darts/models/torch_forecasting_model.py in _predict_batch_block_model(self, n, input_series, cov_future, roll_size)
    650 
    651         batch_prediction = []
--> 652         out = self._produce_predict_output(input_series)[:, self.first_prediction_index:, :]
    653         batch_prediction.append(out[:, :roll_size, :])
    654         prediction_length = roll_size

./darts/models/torch_forecasting_model.py in _produce_predict_output(self, input)
    803 
    804     def _produce_predict_output(self, input):
--> 805         return self.model(input)
    806 
    807     def _evaluate_validation_loss(self, val_loader: DataLoader):

./python3.7/site-packages/torch/nn/modules/module.py in _call_impl(self, *input, **kwargs)
    887             result = self._slow_forward(*input, **kwargs)
    888         else:
--> 889             result = self.forward(*input, **kwargs)
    890         for hook in itertools.chain(
    891                 _global_forward_hooks.values(),

./darts/models/nbeats.py in forward(self, x)
    339         for stack in self.stacks_list:
    340             # compute stack output
--> 341             stack_residual, stack_forecast = stack(x)
    342 
    343             # add stack forecast to final output

./python3.7/site-packages/torch/nn/modules/module.py in _call_impl(self, *input, **kwargs)
    887             result = self._slow_forward(*input, **kwargs)
    888         else:
--> 889             result = self.forward(*input, **kwargs)
    890         for hook in itertools.chain(
    891                 _global_forward_hooks.values(),

./darts/models/nbeats.py in forward(self, x)
    213         for block in self.blocks_list:
    214             # pass input through block
--> 215             x_hat, y_hat = block(x)
    216 
    217             # add block forecast to stack forecast

./python3.7/site-packages/torch/nn/modules/module.py in _call_impl(self, *input, **kwargs)
    887             result = self._slow_forward(*input, **kwargs)
    888         else:
--> 889             result = self.forward(*input, **kwargs)
    890         for hook in itertools.chain(
    891                 _global_forward_hooks.values(),

./darts/models/nbeats.py in forward(self, x)
    133         # fully connected layer stack
    134         for layer in self.linear_layer_stack_list:
--> 135             x = self.relu(layer(x))
    136 
    137         # forked linear layers producing waveform generator parameters

./python3.7/site-packages/torch/nn/modules/module.py in _call_impl(self, *input, **kwargs)
    887             result = self._slow_forward(*input, **kwargs)
    888         else:
--> 889             result = self.forward(*input, **kwargs)
    890         for hook in itertools.chain(
    891                 _global_forward_hooks.values(),

./python3.7/site-packages/torch/nn/modules/linear.py in forward(self, input)
     92 
     93     def forward(self, input: Tensor) -> Tensor:
---> 94         return F.linear(input, self.weight, self.bias)
     95 
     96     def extra_repr(self) -> str:

./python3.7/site-packages/torch/nn/functional.py in linear(input, weight, bias)
   1751     if has_torch_function_variadic(input, weight):
   1752         return handle_torch_function(linear, (input, weight), input, weight, bias=bias)
-> 1753     return torch._C._nn.linear(input, weight, bias)
   1754 
   1755 

RuntimeError: Tensor for argument #2 'mat1' is on CPU, but expected it to be on GPU (while checking arguments for addmm)

<!-- Please mention an issue this pull request addresses. -->
Fixes #.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create 
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->