### PR TITLE
Fix/docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:python-3.7.6
+FROM jupyter/base-notebook:python-3.9.5
 
 # By default base-notebook install latest python version and fix it in the pinned constraint
 # remove the file, change the python version and update packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN conda update --all -y --quiet \
 
 USER root
 
-RUN apt-get update && apt-get -y install curl && apt-get -y install apt-utils
-
-# to build prophet
-RUN apt-get -y install build-essential libc-dev
+# to build pystan
+RUN apt-get update \
+ && apt-get -y install build-essential \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER $NB_USER
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ RUN apt-get update \
 
 USER $NB_USER
 
-# u8ts specific deps
-RUN pip install pystan
 ADD . /home/jovyan/work
 
 WORKDIR /home/jovyan/work

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ ADD . /home/jovyan/work
 
 WORKDIR /home/jovyan/work
 
-RUN pip install .['all']
+RUN pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 FROM jupyter/base-notebook:python-3.9.5
 
-# By default base-notebook install latest python version and fix it in the pinned constraint
-# remove the file, change the python version and update packages
-
-#RUN rm $CONDA_DIR/conda-meta/pinned
-#RUN conda install python=3.6.8  -y --quiet && conda update --all -y --quiet && \
-#conda clean --all -f -y
-RUN conda install -c conda-forge ipywidgets -y --quiet
+RUN conda update --all -y --quiet \
+ && conda install -c conda-forge ipywidgets -y --quiet \
+ && conda clean --all -f -y
 
 USER root
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
 }
 
 plugins {
-    id "com.palantir.docker" version "0.26.0"
-    id "com.palantir.docker-run" version "0.26.0"
+    id "com.palantir.docker" version "0.27.0"
+    id "com.palantir.docker-run" version "0.27.0"
 }
 
 // needed for palantir plugin

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ for(String flavour : flavours) {
 }
 
 task installLocally(type:Exec) {
-    commandLine "pip", "install", ".[all]"
+    commandLine "pip", "install", "."
 }
 
 task pipInstall() {


### PR DESCRIPTION
The Docker build on release was failing because of a pystan>=3.

This is fixed by removing the manual `pip install pystan` command. At the same time, the Dockerfile was cleaned up and updated.