### PR TITLE
Added names to forecast components

### DIFF
--- a/darts/models/forecasting_model.py
+++ b/darts/models/forecasting_model.py
@@ -157,11 +157,17 @@ class ForecastingModel(ABC):
         time_index_length = len(points_preds) if isinstance(points_preds, np.ndarray) else len(points_preds[0])
         time_index = self._generate_new_dates(time_index_length, input_series=input_series)
 
+        columns = input_series.components
+        columns = pd.Index(["forecast_" + name for name in columns.values], name=columns.name)
+
         if isinstance(points_preds, np.ndarray):
-            return TimeSeries.from_times_and_values(time_index, points_preds, freq=input_series.freq_str)
+            return TimeSeries.from_times_and_values(time_index, points_preds,
+                                                    freq=input_series.freq_str,
+                                                    columns=columns)
 
         return TimeSeries.from_times_and_values(time_index, np.stack(points_preds, axis=2),
-                                                freq=input_series.freq_str)
+                                                freq=input_series.freq_str,
+                                                columns=columns)
 
     def _historical_forecasts_sanity_checks(self, *args: Any, **kwargs: Any) -> None:
         """Sanity checks for the historical_forecasts function

--- a/darts/tests/test_local_forecasting_models.py
+++ b/darts/tests/test_local_forecasting_models.py
@@ -84,6 +84,16 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
     ts_ice_heater = IceCreamHeaterDataset().load()
     ts_ice_heater_train, ts_ice_heater_val = ts_ice_heater.split_after(split_point=0.7)
 
+    def test_forecast_name(self):
+        values = self.ts_gaussian.univariate_values()[10:]
+        index = self.ts_gaussian.time_index[10:]
+        ts_named = TimeSeries.from_series(pd.Series(values, index=index, name="series"))
+
+        for model, _ in models:
+            model.fit(ts_named)
+            prediction = model.predict(self.forecasting_horizon)
+            self.assertEqual(prediction.columns.values[0], "forecast_series")
+
     def test_models_runnability(self):
         for model, _ in models:
             model.fit(self.ts_gaussian)


### PR DESCRIPTION
Forecasts are not assigned names for components.

### Summary

Assigns each component the name "forecast_" + original_name, in _build_forecast_series.