### PR TITLE
Added .to(self.device) to covariate data as well in predict function

### DIFF
--- a/darts/models/torch_forecasting_model.py
+++ b/darts/models/torch_forecasting_model.py
@@ -612,7 +612,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
                 # at this point `input_series` contains both the past target series and past covariates
                 input_series = batch_tuple[0].to(self.device)
-                cov_future = batch_tuple[1] if len(batch_tuple) == 3 else None
+                cov_future = batch_tuple[1].to(self.device) if len(batch_tuple) == 3 else None
 
                 # repeat prediction procedure for every needed sample
                 batch_predictions = []


### PR DESCRIPTION
Fixes #413.


### Summary

The _predict_batch_recurrent_model function uses torch.cat, which requires the concatenated data to be on the same device. The data of the input series was already moved to the selected device, but the covariate data wasn't. This patch moves the covariate data to the selected device as well.

Credits to @nielsmeima as well