### PR TITLE
Fixed DeprecationWarnings from tests.

### DIFF
--- a/darts/models/theta.py
+++ b/darts/models/theta.py
@@ -210,11 +210,11 @@ class FourTheta(ForecastingModel):
         self.fitted_values = None
         self.normalization = normalization
 
-        raise_if_not(model_mode in ModelMode,
+        raise_if_not(isinstance(model_mode, ModelMode),
                      "Unknown value for model_mode: {}.".format(model_mode), logger)
-        raise_if_not(trend_mode in TrendMode,
+        raise_if_not(isinstance(trend_mode, TrendMode),
                      "Unknown value for trend_mode: {}.".format(trend_mode), logger)
-        raise_if_not(season_mode in SeasonalityMode,
+        raise_if_not(isinstance(season_mode, SeasonalityMode),
                      "Unknown value for season_mode: {}.".format(season_mode), logger)
 
     def fit(self, series):

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -463,7 +463,7 @@ class TimeSeriesTestCase(DartsBaseTestClass):
                                              fill_missing_dates=True)
         # test empty pandas series error
         with self.assertRaises(ValueError):
-            TimeSeries.from_series(pd.Series(), freq='D')
+            TimeSeries.from_series(pd.Series(dtype='object'), freq='D')
         # frequency should be ignored when fill_missing_dates is False
         seriesA = TimeSeries.from_times_and_values(pd.date_range('20130101', '20130105'),
                                                    range(5),

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -159,7 +159,7 @@ class TimeSeries:
                     for x
                     in range(len(time_index) - samples_size + 1)]
 
-                observed_frequencies = set(filter(None.__ne__, observed_frequencies))
+                observed_frequencies = set(obs_freq for obs_freq in observed_frequencies if obs_freq is not None)
 
                 raise_if_not(
                     len(observed_frequencies) == 1,


### PR DESCRIPTION
Fixes DeprecationWarnings from #DARTS-372.

### Summary

* Fixes non-Enum in containment checks
* Fixes instantiating empty pandas.Series without specified dtype
* Fixes evaluating NotImplemented in a boolean context (from python 3.9)
* DeprecationWarning "import imp" still remains. Comes from Cython package (they already fixed it, see https://github.com/cython/cython/commit/120a841e7afa1958e803517f007bb9fd37c921f7)