### PR TITLE
Remove extra convolutions in TCN

### DIFF
--- a/darts/models/tcn_model.py
+++ b/darts/models/tcn_model.py
@@ -84,7 +84,7 @@ class _ResidualBlock(nn.Module):
         if weight_norm:
             self.conv1, self.conv2 = nn.utils.weight_norm(self.conv1), nn.utils.weight_norm(self.conv2)
 
-        if nr_blocks_below in (0, num_layers - 1) and input_dim != output_dim:
+        if nr_blocks_below in {0, num_layers - 1} and input_dim != output_dim:
             self.conv3 = nn.Conv1d(input_dim, output_dim, 1)
 
     def forward(self, x):
@@ -103,7 +103,8 @@ class _ResidualBlock(nn.Module):
         x = self.dropout_fn(x)
 
         # add residual
-        if self.nr_blocks_below in {0, self.num_layers - 1}:
+        if (self.nr_blocks_below in {0, self.num_layers - 1} and 
+            self.conv1.in_channels != self.conv2.out_channels):
             residual = self.conv3(residual)
         x += residual
 

--- a/darts/models/tcn_model.py
+++ b/darts/models/tcn_model.py
@@ -84,7 +84,7 @@ class _ResidualBlock(nn.Module):
         if weight_norm:
             self.conv1, self.conv2 = nn.utils.weight_norm(self.conv1), nn.utils.weight_norm(self.conv2)
 
-        if nr_blocks_below == 0 or nr_blocks_below == num_layers - 1:
+        if nr_blocks_below in (0, num_layers - 1) and input_dim != output_dim:
             self.conv3 = nn.Conv1d(input_dim, output_dim, 1)
 
     def forward(self, x):

--- a/darts/models/tcn_model.py
+++ b/darts/models/tcn_model.py
@@ -84,7 +84,7 @@ class _ResidualBlock(nn.Module):
         if weight_norm:
             self.conv1, self.conv2 = nn.utils.weight_norm(self.conv1), nn.utils.weight_norm(self.conv2)
 
-        if nr_blocks_below in {0, num_layers - 1} and input_dim != output_dim:
+        if input_dim != output_dim:
             self.conv3 = nn.Conv1d(input_dim, output_dim, 1)
 
     def forward(self, x):
@@ -103,8 +103,7 @@ class _ResidualBlock(nn.Module):
         x = self.dropout_fn(x)
 
         # add residual
-        if (self.nr_blocks_below in {0, self.num_layers - 1} and 
-            self.conv1.in_channels != self.conv2.out_channels):
+        if self.conv1.in_channels != self.conv2.out_channels:
             residual = self.conv3(residual)
         x += residual
 


### PR DESCRIPTION
Fixes #470. Add the 1x1 convolution in a case of different number of channels between input and output of a residual block