### PR TITLE
Feat/quantile loss as likelihood

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Some of the models depend on `prophet` and `torch`, which have non-Python depend
 A Conda environment is thus recommended because it will handle all of those in one go.
 
 ### From conda-forge
-Currently only the x86_64 architecture with Python 3.7 or 3.8 
+Currently only the x86_64 architecture with Python 3.7-3.9
 is fully supported with conda; consider using PyPI if you are running into troubles.
 
 To create a conda environment for Python 3.7

--- a/darts/models/forecasting/fft.py
+++ b/darts/models/forecasting/fft.py
@@ -171,7 +171,7 @@ def _crop_to_match_seasons(series: TimeSeries, required_matches: Optional[set]) 
         return series
 
     first_ts = series.time_index[0]
-    freq = first_ts.freq
+    freq = series.freq
     pred_ts = series.time_index[-1] + freq
 
     # start at first timestamp of given series and move forward until a matching timestamp is found

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -334,6 +334,7 @@ class _TFTModule(nn.Module):
         # do not attend to steps where data is padded
         encoder_mask = self.create_mask(encoder_lengths.max(), encoder_lengths)
         # combine masks along attended time - first encoder and then decoder
+
         mask = torch.cat(
             (
                 encoder_mask.unsqueeze(1).expand(-1, decoder_length, -1),
@@ -398,10 +399,14 @@ class _TFTModule(nn.Module):
 
         # batch_size = x.shape[0]
         encoder_lengths = torch.tensor(
-            [self.input_chunk_length] * x_cont_past.shape[dim_samples], dtype=past_target.dtype
+            [self.input_chunk_length] * x_cont_past.shape[dim_samples], 
+            dtype=past_target.dtype,
+            device=past_target.device
         )
         decoder_lengths = torch.tensor(
-            [self.output_chunk_length] * x_cont_future.shape[dim_samples], dtype=past_target.dtype
+            [self.output_chunk_length] * x_cont_future.shape[dim_samples], 
+            dtype=past_target.dtype,
+            device=past_target.device
         )
 
         timesteps = self.input_chunk_length + self.output_chunk_length

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -12,47 +12,27 @@ from torch import nn
 
 from darts import TimeSeries
 from darts.utils.torch import random_method
-from darts.logging import get_logger, raise_if_not
+from darts.logging import get_logger, raise_if_not, raise_if
 from darts.utils.likelihood_models import Likelihood
-from darts.utils.data import TrainingDataset, MixedCovariatesSequentialDataset
-
+from darts.utils.data import (
+    TrainingDataset,
+    MixedCovariatesSequentialDataset,
+    MixedCovariatesTrainingDataset
+)
 from darts.models.forecasting.torch_forecasting_model import (
     MixedCovariatesTorchModel,
     TorchParametricProbabilisticForecastingModel
 )
-
-from pytorch_forecasting.models.temporal_fusion_transformer.sub_modules import (
-    AddNorm as _AddNorm,
-    GateAddNorm as _GateAddNorm,
-    GatedLinearUnit as _GatedLinearUnit,
-    GatedResidualNetwork as _GatedResidualNetwork,
-    InterpretableMultiHeadAttention as _InterpretableMultiHeadAttention,
-    VariableSelectionNetwork as _VariableSelectionNetwork,
-)
-
-from pytorch_forecasting.models.nn.rnn import (
-    LSTM as _LSTM,
-)
-
-from pytorch_forecasting.models.nn.embeddings import (
-    MultiEmbedding as _MultiEmbedding
-)
-
 from darts.models.forecasting.tft_submodels import (
-    # _AddNorm,
-    # _GateAddNorm,
-    # _GatedLinearUnit,
-    # _GatedResidualNetwork,
-    # _InterpretableMultiHeadAttention,
-    # _VariableSelectionNetwork,
-    # _LSTM,
-    # _MultiEmbedding,
+    _GateAddNorm,
+    _GatedResidualNetwork,
+    _InterpretableMultiHeadAttention,
+    _VariableSelectionNetwork,
+    _LSTM,
     QuantileLoss
 )
 
 logger = get_logger(__name__)
-
-USE_POST_LSTM_GLU = False
 
 MixedCovariatesTrainTensorType = Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 
@@ -66,7 +46,7 @@ class _TFTModule(nn.Module):
                  variables_meta: Dict[str, Dict[str, List[str]]],
                  hidden_size: Union[int, List[int]] = 16,
                  lstm_layers: int = 2,
-                 attention_head_size: int = 4,
+                 num_attention_heads: int = 4,
                  hidden_continuous_size: int = 8,
                  dropout: float = 0.1,
                  loss_fn: nn.Module = QuantileLoss(),
@@ -90,10 +70,10 @@ class _TFTModule(nn.Module):
             hidden state size of the TFT. It is the main hyper-parameter and common across the internal TFT architecture.
         lstm_layers : int
             number of layers for the Long Short Term Memory (LSTM) Encoder and Decoder (2 is a good default).
-        attention_head_size : int
+        num_attention_heads : int
             number of attention heads (4 is a good default)
         hidden_continuous_size : int
-            default for hidden size for processing continuous variables (similar to categorical embedding size)
+            default for hidden size for processing continuous variables
         dropout : float
             Fraction of neurons afected by Dropout.
         loss_fn : nn.Module
@@ -112,7 +92,7 @@ class _TFTModule(nn.Module):
         self.hidden_size = hidden_size
         self.hidden_continuous_size = hidden_continuous_size
         self.lstm_layers = lstm_layers
-        self.attention_head_size = attention_head_size
+        self.num_attention_heads = num_attention_heads
         self.dropout = dropout
         self.loss_fn = loss_fn
         self.likelihood = likelihood
@@ -121,7 +101,6 @@ class _TFTModule(nn.Module):
         # _vsn: VariableSelectionNetwork
         # _grn: GatedResidualNetwork
         # _glu: GatedLinearUnit
-        # _an: AddNorm
         # _gan: GateAddNorm
         # _attn: Attention
 
@@ -216,20 +195,18 @@ class _TFTModule(nn.Module):
             batch_first=True,
         )
 
-        if not USE_POST_LSTM_GLU:
-            # skip connection for lstm
-            self.post_lstm_encoder_glu = _GatedLinearUnit(self.hidden_size, dropout=self.dropout)
-            self.post_lstm_decoder_glu = self.post_lstm_encoder_glu
-            self.post_lstm_encoder_an = _AddNorm(self.hidden_size)
-            self.post_lstm_decoder_an = self.post_lstm_encoder_an
-        else:
-            self.post_lstm_gan = _GateAddNorm(
-                input_size=self.hidden_size,
-                dropout=self.dropout
-            )
+        # post lstm GateAddNorm
+        self.post_lstm_encoder_gan = _GateAddNorm(
+            input_size=self.hidden_size,
+            dropout=dropout
+        )
+        self.post_lstm_decoder_gan = _GateAddNorm(
+            input_size=self.hidden_size,
+            dropout=dropout
+        )
 
         # static enrichment and processing past LSTM
-        self.static_enrichment = _GatedResidualNetwork(
+        self.static_enrichment_grn = _GatedResidualNetwork(
             input_size=self.hidden_size,
             hidden_size=self.hidden_size,
             output_size=self.hidden_size,
@@ -239,7 +216,7 @@ class _TFTModule(nn.Module):
 
         # attention for long-range processing
         self.multihead_attn = _InterpretableMultiHeadAttention(
-            d_model=self.hidden_size, n_head=self.attention_head_size, dropout=self.dropout
+            d_model=self.hidden_size, n_head=self.num_attention_heads, dropout=self.dropout
         )
         self.post_attn_gan = _GateAddNorm(self.hidden_size, dropout=self.dropout)
         self.positionwise_feedforward_grn = _GatedResidualNetwork(
@@ -260,26 +237,11 @@ class _TFTModule(nn.Module):
         return self.variables_meta['model_config']['reals_input']
 
     @property
-    def categoricals(self) -> List[str]:
-        """
-        List of all categorical variables in model
-        """
-        # TODO: (Darts) we might want to include categorical variables in the future?
-        # return list(
-        #     dict.fromkeys(
-        #         self.static_categoricals
-        #         + self.time_varying_categoricals_encoder
-        #         + self.time_varying_categoricals_decoder
-        #     )
-        # )
-        raise NotImplementedError('TFT does not yet support categorical variables')
-
-    @property
     def static_variables(self) -> List[str]:
         """
         List of all static variables in model
         """
-        # TODO: (Darts: dbader) we might want to include categorical variables in the future?
+        # TODO: (Darts: dbader) we might want to include static variables in the future?
         return self.variables_meta['model_config']['static_input']
 
     @property
@@ -358,16 +320,6 @@ class _TFTModule(nn.Module):
 
         # TODO: impelement static covariates
         static_covariates = None
-
-        # when there are no future_covariates we will need to create a zero tensor of
-        # shape (n_samples, output_chunk_length, 1) in _TFTModule.forward()
-        if future_covariates is None:
-            historic_future_covariates = torch.zeros((past_target.shape[dim_samples], self.input_chunk_length, 1),
-                                                     dtype=past_target.dtype,
-                                                     device=past_target.device)
-            future_covariates = torch.zeros((past_target.shape[dim_samples], self.output_chunk_length, 1),
-                                            dtype=past_target.dtype,
-                                            device=past_target.device)
 
         # data is of size (batch_size, input_length, input_size)
         x_cont_past = torch.cat(
@@ -451,54 +403,37 @@ class _TFTModule(nn.Module):
             self.lstm_layers, -1, -1
         )
 
-        # run local encoder
-        encoder_output, (hidden, cell) = self.lstm_encoder(
+        # run local lstm encoder
+        encoder_out, (hidden, cell) = self.lstm_encoder(
             x=embeddings_varying_encoder,
             hx=(input_hidden, input_cell),
             lengths=encoder_lengths,
             enforce_sorted=False
         )
 
-        # run local decoder
-        decoder_output, _ = self.lstm_decoder(
+        # run local lstm decoder
+        decoder_out, _ = self.lstm_decoder(
             x=embeddings_varying_decoder,
             hx=(hidden, cell),
             lengths=decoder_lengths,
             enforce_sorted=False,
         )
 
-        # TODO: (Darts: dbader) why not simply _GateAddNorm?
-        if not USE_POST_LSTM_GLU:
-            # skip connection over lstm
-            lstm_output_encoder = self.post_lstm_encoder_glu(encoder_output)
-            lstm_output_encoder = self.post_lstm_encoder_an(
-                x=lstm_output_encoder,
-                skip=embeddings_varying_encoder
-            )
+        # post lstm GateAddNorm
+        lstm_out_encoder = self.post_lstm_encoder_gan(x=encoder_out, skip=embeddings_varying_encoder)
+        lstm_out_decoder = self.post_lstm_encoder_gan(x=decoder_out, skip=embeddings_varying_decoder)
 
-            lstm_output_decoder = self.post_lstm_decoder_glu(decoder_output)
-            lstm_output_decoder = self.post_lstm_decoder_an(
-                x=lstm_output_decoder,
-                skip=embeddings_varying_decoder
-            )
-            lstm_output = torch.cat([lstm_output_encoder, lstm_output_decoder], dim=1)
-        else:
-            lstm_out = torch.cat([encoder_output, decoder_output], dim=1)
-            input_embeddings = torch.cat([embeddings_varying_encoder, embeddings_varying_decoder], dim=1)
-            lstm_output = self.post_lstm_gan(
-                x=lstm_out,
-                skip=input_embeddings
-            )
+        lstm_out = torch.cat([lstm_out_encoder, lstm_out_decoder], dim=1)
 
         # static enrichment
         static_context_enriched = self.static_context_enrichment(static_embedding)
-        attn_input = self.static_enrichment(
-            x=lstm_output,
+        attn_input = self.static_enrichment_grn(
+            x=lstm_out,
             context=self.expand_static_context(context=static_context_enriched, timesteps=timesteps)
         )
 
-        # Attention
-        attn_output, attn_output_weights = self.multihead_attn(
+        # multi-head attention
+        attn_out, attn_out_weights = self.multihead_attn(
             q=attn_input[:, encoder_length:],  # query only for predictions
             k=attn_input,
             v=attn_input,
@@ -510,41 +445,33 @@ class _TFTModule(nn.Module):
         )
 
         # skip connection over attention
-        attn_output = self.post_attn_gan(
-            x=attn_output,
-            skip=attn_input[:, encoder_length:]
-        )
+        attn_out = self.post_attn_gan(x=attn_out, skip=attn_input[:, encoder_length:])
 
-        output = self.positionwise_feedforward_grn(
-            x=attn_output,
-            context=None
-        )
+        # position-wise feed-forward
+        out = self.positionwise_feedforward_grn(x=attn_out, context=None)
 
         # skip connection over temporal fusion decoder from LSTM post _GateAddNorm
-        output = self.pre_output_gan(
-            x=output,
-            skip=lstm_output[:, encoder_length:]
-        )
+        out = self.pre_output_gan(x=out, skip=lstm_out[:, encoder_length:])
 
         # generate output for n_targets and loss_size elements for loss evaluation
-        output = [output_layer(output) for output_layer in self.output_layer]
+        out = [output_layer(out) for output_layer in self.output_layer]
 
         # stack output
         if self.likelihood is not None or self.loss_size == 1 and self.n_targets > 1:
             # returns shape (n_samples, n_timesteps, n_likelihood_params/n_targets)
-            output = torch.cat(output, dim=dim_variable)
+            out = torch.cat(out, dim=dim_variable)
         elif self.loss_size == 1 and self.n_targets == 1:
             # returns shape (n_samples, n_timesteps, 1) for univariate
-            output = output[0]
+            out = out[0]
         else:
             # loss_size > 1 for losses such as QuantileLoss
             # returns shape (n_samples, n_timesteps, n_targets, n_losses)
-            output = torch.cat([out_i.unsqueeze(dim_variable) for out_i in output], dim=dim_variable)
+            out = torch.cat([out_i.unsqueeze(dim_variable) for out_i in out], dim=dim_variable)
 
         # TODO: (Darts) remember this in case we want to output interpretation
         # return self.to_network_output(
-        #     prediction=self.transform_output(output, target_scale=x["target_scale"]),
-        #     attention=attn_output_weights,
+        #     prediction=self.transform_output(out, target_scale=x["target_scale"]),
+        #     attention=attn_out_weights,
         #     static_variables=static_covariate_var,
         #     encoder_variables=encoder_sparse_weights,
         #     decoder_variables=decoder_sparse_weights,
@@ -552,7 +479,7 @@ class _TFTModule(nn.Module):
         #     encoder_lengths=encoder_lengths,
         # )
 
-        return output
+        return out
 
 
 class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorchModel):
@@ -562,7 +489,7 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
                  output_chunk_length: int = 1,
                  hidden_size: Union[int, List[int]] = 16,
                  lstm_layers: int = 1,
-                 attention_head_size: int = 4,
+                 num_attention_heads: int = 4,
                  dropout: float = 0.1,
                  loss_fn: Optional[nn.Module] = QuantileLoss(),
                  hidden_continuous_size: int = 8,
@@ -597,7 +524,7 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
             hidden state size of the TFT. It is the main hyper-parameter and common across the internal TFT architecture.
         lstm_layers : int
             number of layers for the Long Short Term Memory (LSTM) Encoder and Decoder (2 is a good default).
-        attention_head_size : int
+        num_attention_heads : int
             number of attention heads (4 is a good default)
         dropout : float
             Fraction of neurons afected by Dropout.
@@ -608,7 +535,7 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
             Default: :meth:`darts.models.forecasting.tft_submodels.QuantileLoss()
             <darts.models.forecasting.tft_submodels.QuantileLoss>`
         hidden_continuous_size : int
-            default for hidden size for processing continuous variables (similar to categorical embedding size)
+            default for hidden size for processing continuous variables
         random_state
             Control the randomness of the weights initialization. Check this
             `link <https://scikit-learn.org/stable/glossary.html#term-random-state>`_ for more details.
@@ -657,6 +584,11 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
         likelihood
             Optionally, the likelihood model to be used for probabilistic forecasts.
             If no likelihood model is provided, forecasts will be deterministic.
+        save_checkpoints
+            Whether or not to automatically save the untrained model and checkpoints from training.
+            If set to `False`, the model can still be manually saved using :meth:`save_model()
+            <TorchForeCastingModel.save_model()>` and loaded using :meth:`load_model()
+            <TorchForeCastingModel.load_model()>`.
         """
         kwargs['loss_fn'] = loss_fn
         kwargs['input_chunk_length'] = input_chunk_length
@@ -671,7 +603,7 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
         self.loss_fn = loss_fn
         # QuantileLoss requires one output per quantile, MSELoss requires 1
         self.loss_size = 1 if not isinstance(loss_fn, QuantileLoss) else len(loss_fn.quantiles)
-        self.attention_head_size = attention_head_size
+        self.num_attention_heads = num_attention_heads
         self.hidden_continuous_size = hidden_continuous_size
         self.likelihood = likelihood
         self.max_sample_per_ts = max_samples_per_ts
@@ -693,12 +625,20 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
 
             time_varying_encoders : [past_targets, past_covariates, historic_future_covariates, future_covariates]
             time_varying_decoders : [historic_future_covariates, future_covariates]
-        
-        for categoricals (if we want to use it in the future) we would need embeddings
 
         `variable_meta` is used in TFT to access specific variables
         """
         past_target, past_covariate, historic_future_covariate, future_covariate, future_target = train_sample
+
+        # TODO: we might want to include cyclic encoding variable here (which will need to be added to
+        #  train and predict datasets)? For now we raise an Error when future covariates are not defined.
+        raise_if(future_covariate is None,
+                 'TFTModel requires future covariates. The model applies multi-head attention queries on future inputs. '
+                 'Without future covariates, the model performs much worse. Consider supplying a cyclic encoding of '
+                 'the time index as future_covariates to the `fit()` and `predict()` methods. See '
+                 'https://unit8co.github.io/darts/generated_api/darts.utils.timeseries_generation.html#'
+                 'darts.utils.timeseries_generation.datetime_attribute_timeseries',
+                 logger)
 
         static_covariates = None  # placeholder for future
 
@@ -729,15 +669,6 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
             'model_config': {}
         }
 
-        # TODO: we might want to include cyclic encoding variable here (which will need to be added to
-        #  train and predict datasets)?
-        # when there are no future_covariates we will need to create a zero tensor of
-        # shape (n_samples, output_chunk_length, 1) in _TFTModule.forward()
-        if future_covariate is None:
-            dummy_name = 'future_covariate_0'
-            variables_meta['input']['historic_future_covariate'] = [dummy_name]
-            variables_meta['input']['future_covariate'] = [dummy_name]
-
         reals_input = []
         time_varying_encoder_input = []
         time_varying_decoder_input = []
@@ -766,7 +697,7 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
             hidden_size=self.hidden_size,
             lstm_layers=self.lstm_layers,
             dropout=self.dropout,
-            attention_head_size=self.attention_head_size,
+            num_attention_heads=self.num_attention_heads,
             hidden_continuous_size=self.hidden_continuous_size,
             likelihood=self.likelihood
         )
@@ -784,8 +715,8 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
                                                 max_samples_per_ts=self.max_sample_per_ts)
 
     def _verify_train_dataset_type(self, train_dataset: TrainingDataset):
-        raise_if_not(isinstance(train_dataset, MixedCovariatesSequentialDataset),
-                     'TFTModel requires a training dataset of type MixedCovariatesSequentialDataset.')
+        raise_if_not(isinstance(train_dataset, MixedCovariatesTrainingDataset),
+                     'TFTModel requires a training dataset of type MixedCovariatesTrainingDataset.')
 
     def _produce_train_output(self, input_batch: Tuple):
         return self.model(input_batch)
@@ -803,14 +734,14 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
 
     @random_method
     def _produce_predict_output(self, x):
-        output = self.model(x)
+        out = self.model(x)
         if self.likelihood is not None:
-            return self.likelihood.sample(output)
+            return self.likelihood.sample(out)
         elif isinstance(self.loss_fn, QuantileLoss):
             p50_index = self.loss_fn.quantiles.index(0.5)
-            return output[..., p50_index]
+            return out[..., p50_index]
         else:
-            return output
+            return out
 
     def _get_batch_prediction(self, n: int, input_batch: Tuple, roll_size: int) -> torch.Tensor:
         """
@@ -835,7 +766,7 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
             dim=dim_component
         )
 
-        input_future = torch.clone(future_covariates[:, :roll_size, :]) if future_covariates is not None else None
+        input_future = future_covariates[:, :roll_size, :] if future_covariates is not None else None
 
         out = self._produce_predict_output(
             x=(past_target, past_covariates, historic_future_covariates, input_future)

--- a/darts/models/forecasting/tft_submodels.py
+++ b/darts/models/forecasting/tft_submodels.py
@@ -1,6 +1,25 @@
 """
-Implementation of ``nn.Modules`` for temporal fusion transformer.
+Implementation of ``nn.Modules`` for Temporal Fusion Transformer from PyTorch-Forecasting:
+https://github.com/jdb78/pytorch-forecasting
+
+PyTorch Forecasting v0.9.1 License from https://github.com/jdb78/pytorch-forecasting/blob/master/LICENSE, accessed
+on Wed, November 3, 2021:
+'THE MIT License
+
+Copyright 2020 Jan Beitner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+'
 """
+
 from abc import ABC, abstractmethod
 from typing import Dict, Tuple, List, Union, Optional
 
@@ -15,10 +34,6 @@ logger = get_logger(__name__)
 
 HiddenState = Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]
 
-USE_ADAPTION_GLU = False  # seems to work better without
-USE_ADAPTION_RESAMPLE = False  # seems to work better without
-USE_ADAPTION_VSN = False  # seems to work better without
-
 
 class QuantileLoss(nn.Module):
     """Quantile Loss Metric for custom quantiles centered around q=0.5
@@ -27,8 +42,10 @@ class QuantileLoss(nn.Module):
 
     def __init__(self, quantiles: Optional[List[float]] = None):
         """
-        Arguments:
-            quantiles: list of quantiles
+        Parameters
+        ----------
+        quantiles
+            list of quantiles
         """
 
         super().__init__()
@@ -86,78 +103,92 @@ class _RNN(ABC, nn.RNNBase):
     """
 
     @abstractmethod
-    def handle_no_encoding(self,
-                           hidden_state: HiddenState,
-                           no_encoding: torch.BoolTensor,
-                           initial_hidden_state: HiddenState) -> HiddenState:
+    def handle_no_encoding(
+        self, hidden_state: HiddenState, no_encoding: torch.BoolTensor, initial_hidden_state: HiddenState
+    ) -> HiddenState:
         """
         Mask the hidden_state where there is no encoding.
 
-        Args:
-            hidden_state (HiddenState): hidden state where some entries need replacement
-            no_encoding (torch.BoolTensor): positions that need replacement
-            initial_hidden_state (HiddenState): hidden state to use for replacement
+        Parameters
+        ----------
+        hidden_state
+            hidden state where some entries need replacement
+        no_encoding
+            positions that need replacement
+        initial_hidden_state
+            hidden state to use for replacement
 
-        Returns:
-            HiddenState: hidden state with propagated initial hidden state where appropriate
+        Returns
+        -------
+        HiddenState
+            hidden state with propagated initial hidden state where appropriate
         """
-
         pass
 
     @abstractmethod
-    def init_hidden_state(self,
-                          x: torch.Tensor) -> HiddenState:
+    def init_hidden_state(self, x: torch.Tensor) -> HiddenState:
         """
         Initialise a hidden_state.
 
-        Args:
-            x (torch.Tensor): network input
+        Parameters
+        ----------
+        x
+            network input
 
-        Returns:
-            HiddenState: default (zero-like) hidden state
+        Returns
+        -------
+        HiddenState
+            default (zero-like) hidden state
         """
-
         pass
 
     @abstractmethod
-    def repeat_interleave(self,
-                          hidden_state: HiddenState,
-                          n_samples: int) -> HiddenState:
+    def repeat_interleave(self, hidden_state: HiddenState, n_samples: int) -> HiddenState:
         """
         Duplicate the hidden_state n_samples times.
 
-        Args:
-            hidden_state (HiddenState): hidden state to repeat
-            n_samples (int): number of repetitions
+        Parameters
+        ----------
+        hidden_state
+            hidden state to repeat
+        n_samples
+            number of repetitions
 
-        Returns:
-            HiddenState: repeated hidden state
+        Returns
+        -------
+        HiddenState
+            repeated hidden state
         """
-
         pass
 
-    def forward(self,
-                x: Union[rnn.PackedSequence, torch.Tensor],
-                hx: HiddenState = None,
-                lengths: torch.LongTensor = None,
-                enforce_sorted: bool = True) -> Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]:
+    def forward(
+        self,
+        x: Union[rnn.PackedSequence, torch.Tensor],
+        hx: HiddenState = None,
+        lengths: torch.LongTensor = None,
+        enforce_sorted: bool = True,
+    ) -> Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]:
         """
         Forward function of rnn that allows zero-length sequences.
 
         Functions as normal for RNN. Only changes output if lengths are defined.
 
-        Args:
-            x (Union[rnn.PackedSequence, torch.Tensor]): input to RNN. either packed sequence or tensor of
-                padded sequences
-            hx (HiddenState, optional): hidden state. Defaults to None.
-            lengths (torch.LongTensor, optional): lengths of sequences. If not None, used to determine correct returned
-                hidden state. Can contain zeros. Defaults to None.
-            enforce_sorted (bool, optional): if lengths are passed, determines if RNN expects them to be sorted.
-                Defaults to True.
+        Parameters
+        ----------
+        x
+            input to RNN. either packed sequence or tensor of padded sequences
+        hx
+            hidden state. Defaults to None.
+        lengths
+            lengths of sequences. If not None, used to determine correct returned hidden state. Can contain zeros.
+            Defaults to None.
+        enforce_sorted
+            if lengths are passed, determines if RNN expects them to be sorted. Defaults to True.
 
-        Returns:
-            Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]: output and hidden state.
-                Output is packed sequence if input has been a packed sequence.
+        Returns
+        -------
+        Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]
+            output and hidden state. Output is packed sequence if input has been a packed sequence.
         """
 
         if isinstance(x, rnn.PackedSequence) or lengths is None:
@@ -171,9 +202,9 @@ class _RNN(ABC, nn.RNNBase):
             if max_length == 0:
                 hidden_state = self.init_hidden_state(x)
                 if self.batch_first:
-                    out = torch.zeros(lengths.shape[0], x.shape[1], self.hidden_size, dtype=x.dtype, device=x.device)
+                    out = torch.zeros(lengths.size(0), x.size(1), self.hidden_size, dtype=x.dtype, device=x.device)
                 else:
-                    out = torch.zeros(x.shape[0], lengths.shape[0], self.hidden_size, dtype=x.dtype, device=x.device)
+                    out = torch.zeros(x.size(0), lengths.size(0), self.hidden_size, dtype=x.dtype, device=x.device)
                 return out, hidden_state
             else:
                 pack_lengths = lengths.where(lengths > 0, torch.ones_like(lengths))
@@ -203,24 +234,20 @@ class _RNN(ABC, nn.RNNBase):
 class _LSTM(_RNN, nn.LSTM):
     """LSTM that can handle zero-length sequences"""
 
-    def handle_no_encoding(self,
-                           hidden_state: HiddenState,
-                           no_encoding: torch.BoolTensor,
-                           initial_hidden_state: HiddenState) -> HiddenState:
-
+    def handle_no_encoding(
+        self, hidden_state: HiddenState, no_encoding: torch.BoolTensor, initial_hidden_state: HiddenState
+    ) -> HiddenState:
         hidden, cell = hidden_state
         hidden = hidden.masked_scatter(no_encoding, initial_hidden_state[0])
         cell = cell.masked_scatter(no_encoding, initial_hidden_state[0])
         return hidden, cell
 
-    def init_hidden_state(self,
-                          x: torch.Tensor) -> HiddenState:
-
+    def init_hidden_state(self, x: torch.Tensor) -> HiddenState:
         num_directions = 2 if self.bidirectional else 1
         if self.batch_first:
-            batch_size = x.shape[0]
+            batch_size = x.size(0)
         else:
-            batch_size = x.shape[1]
+            batch_size = x.size(1)
         hidden = torch.zeros(
             (self.num_layers * num_directions, batch_size, self.hidden_size),
             device=x.device,
@@ -233,10 +260,7 @@ class _LSTM(_RNN, nn.LSTM):
         )
         return hidden, cell
 
-    def repeat_interleave(self,
-                          hidden_state: HiddenState,
-                          n_samples: int) -> HiddenState:
-
+    def repeat_interleave(self, hidden_state: HiddenState, n_samples: int) -> HiddenState:
         hidden, cell = hidden_state
         hidden = hidden.repeat_interleave(n_samples, 1)
         cell = cell.repeat_interleave(n_samples, 1)
@@ -244,63 +268,57 @@ class _LSTM(_RNN, nn.LSTM):
 
 
 class _TimeDistributedEmbeddingBag(nn.EmbeddingBag):
-    """Used for categorical embedding"""
-
-    def __init__(self,
-                 *args,
-                 batch_first: bool = False,
-                 **kwargs):
-
+    def __init__(self, *args, batch_first: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
         self.batch_first = batch_first
 
     def forward(self, x):
 
         if len(x.size()) <= 2:
-            return self.forward(x)
+            return super().forward(x)
 
         # Squash samples and timesteps into a single axis
-        x_reshape = x.contiguous().view(-1, x.shape[-1])  # (samples * timesteps, input_size)
+        x_reshape = x.contiguous().view(-1, x.size(-1))  # (samples * timesteps, input_size)
 
         y = super().forward(x_reshape)
 
         # We have to reshape Y
         if self.batch_first:
-            y = y.contiguous().view(x.shape[0], -1, y.shape[-1])  # (samples, timesteps, output_size)
+            y = y.contiguous().view(x.size(0), -1, y.size(-1))  # (samples, timesteps, output_size)
         else:
-            y = y.view(-1, x.shape[1], y.shape[-1])  # (timesteps, samples, output_size)
+            y = y.view(-1, x.size(1), y.size(-1))  # (timesteps, samples, output_size)
         return y
 
 
 class _MultiEmbedding(nn.Module):
-    """Can be used to do multi-embed categorical variables"""
-
-    def __init__(self,
-                 embedding_sizes: Dict[str, Tuple[int, int]],
-                 categorical_groups: Dict[str, List[str]],
-                 embedding_paddings: List[str],
-                 x_categoricals: List[str],
-                 max_embedding_size: Optional[int] = None):
-
+    def __init__(
+        self,
+        embedding_sizes: Dict[str, Tuple[int, int]],
+        categorical_groups: Dict[str, List[str]],
+        embedding_paddings: List[str],
+        x_categoricals: List[str],
+        max_embedding_size: int = None,
+    ):
         super().__init__()
-        self.embedding_sizes = {key: list(size_tuple) for key, size_tuple in embedding_sizes.items()}
+        self.embedding_sizes = embedding_sizes
         self.categorical_groups = categorical_groups
         self.embedding_paddings = embedding_paddings
         self.max_embedding_size = max_embedding_size
         self.x_categoricals = x_categoricals
 
-        self.embeddings = self.init_embeddings()
+        self.init_embeddings()
 
     def init_embeddings(self):
-        embeddings = nn.ModuleDict()
-        for name in self.embedding_sizes:
+        self.embeddings = nn.ModuleDict()
+        for name in self.embedding_sizes.keys():
             embedding_size = self.embedding_sizes[name][1]
             if self.max_embedding_size is not None:
                 embedding_size = min(embedding_size, self.max_embedding_size)
+            # convert to list to become mutable
+            self.embedding_sizes[name] = list(self.embedding_sizes[name])
             self.embedding_sizes[name][1] = embedding_size
-
             if name in self.categorical_groups:  # embedding bag if related embeddings
-                embeddings[name] = _TimeDistributedEmbeddingBag(
+                self.embeddings[name] = _TimeDistributedEmbeddingBag(
                     self.embedding_sizes[name][0], embedding_size, mode="sum", batch_first=True
                 )
             else:
@@ -308,12 +326,11 @@ class _MultiEmbedding(nn.Module):
                     padding_idx = 0
                 else:
                     padding_idx = None
-                embeddings[name] = nn.Embedding(
+                self.embeddings[name] = nn.Embedding(
                     self.embedding_sizes[name][0],
                     embedding_size,
                     padding_idx=padding_idx,
                 )
-        return embeddings
 
     def names(self):
         return list(self.keys())
@@ -335,7 +352,10 @@ class _MultiEmbedding(nn.Module):
         for name, emb in self.embeddings.items():
             if name in self.categorical_groups:
                 input_vectors[name] = emb(
-                    x[..., [self.x_categoricals.index(cat_name) for cat_name in self.categorical_groups[name]],]
+                    x[
+                        ...,
+                        [self.x_categoricals.index(cat_name) for cat_name in self.categorical_groups[name]],
+                    ]
                 )
             else:
                 input_vectors[name] = emb(x[..., self.x_categoricals.index(name)])
@@ -343,17 +363,19 @@ class _MultiEmbedding(nn.Module):
 
 
 class _TimeDistributedInterpolation(nn.Module):
-    """interpolates input size to output size."""
-
-    def __init__(self,
-                 output_size: int,
-                 batch_first: bool = False):
+    def __init__(self, output_size: int, batch_first: bool = False, trainable: bool = False):
         super().__init__()
         self.output_size = output_size
         self.batch_first = batch_first
+        self.trainable = trainable
+        if self.trainable:
+            self.mask = nn.Parameter(torch.zeros(self.output_size, dtype=torch.float32))
+            self.gate = nn.Sigmoid()
 
     def interpolate(self, x):
         upsampled = F.interpolate(x.unsqueeze(1), self.output_size, mode="linear", align_corners=True).squeeze(1)
+        if self.trainable:
+            upsampled = upsampled * self.gate(self.mask.unsqueeze(0)) * 2.0
         return upsampled
 
     def forward(self, x):
@@ -362,50 +384,31 @@ class _TimeDistributedInterpolation(nn.Module):
             return self.interpolate(x)
 
         # Squash samples and timesteps into a single axis
-        x_reshape = x.contiguous().view(-1, x.shape[-1])  # (samples * timesteps, input_size)
+        x_reshape = x.contiguous().view(-1, x.size(-1))  # (samples * timesteps, input_size)
 
         y = self.interpolate(x_reshape)
 
         # We have to reshape Y
         if self.batch_first:
-            y = y.contiguous().view(x.shape[0], -1, y.shape[-1])  # (samples, timesteps, output_size)
+            y = y.contiguous().view(x.size(0), -1, y.size(-1))  # (samples, timesteps, output_size)
         else:
-            y = y.view(-1, x.shape[1], y.shape[-1])  # (timesteps, samples, output_size)
+            y = y.view(-1, x.size(1), y.size(-1))  # (timesteps, samples, output_size)
 
         return y
 
 
 class _GatedLinearUnit(nn.Module):
-    def __init__(self,
-                 input_size: int,
-                 hidden_size: int = None,
-                 dropout: float = None):
+    """Gated Linear Unit"""
 
-        """Applies a Gated Linear Unit (GLU) to an input, see equation (5).
-
-        Parameters
-        ----------
-        input_size
-            input size of x
-        hidden_size
-            Dimension of GLU
-        dropout
-            Dropout rate to apply if any
-        """
-
+    def __init__(self, input_size: int, hidden_size: int = None, dropout: float = None):
         super().__init__()
-        self.input_size = input_size
+
+        if dropout is not None:
+            self.dropout = nn.Dropout(dropout)
+        else:
+            self.dropout = dropout
         self.hidden_size = hidden_size or input_size
-
-        self.dropout = nn.Dropout(dropout) if dropout is not None else dropout
-
-        if not USE_ADAPTION_GLU:
-            # from pytorch-forecasting: built-in glu() splits input half along given dimension
-            self.fc = nn.Linear(self.input_size, self.hidden_size * 2)
-        else:  # according to paper this would be the correct way
-            self.fc1 = nn.Linear(self.input_size, self.hidden_size)
-            self.fc2 = nn.Linear(self.input_size, self.hidden_size)
-            self.sigmoid = nn.Sigmoid()
+        self.fc = nn.Linear(input_size, self.hidden_size * 2)
 
         self.init_weights()
 
@@ -413,88 +416,80 @@ class _GatedLinearUnit(nn.Module):
         for n, p in self.named_parameters():
             if "bias" in n:
                 torch.nn.init.zeros_(p)
-            elif "weight" in n:
+            elif "fc" in n:
                 torch.nn.init.xavier_uniform_(p)
 
     def forward(self, x):
         if self.dropout is not None:
             x = self.dropout(x)
-
-        if not USE_ADAPTION_GLU:
-            x = self.fc(x)
-            x = F.glu(x, dim=-1)
-        else:  # I actually think this is better, see https://leimao.github.io/blog/Gated-Linear-Units/
-            x_sig = self.sigmoid(self.fc1(x))
-            x = self.fc2(x)
-            x = torch.mul(x_sig, x)
+        x = self.fc(x)
+        x = F.glu(x, dim=-1)
         return x
 
 
 class _ResampleNorm(nn.Module):
-    """Resamples an input to an output size"""
-
-    def __init__(self,
-                 input_size: int,
-                 output_size: int = None):
-
+    def __init__(self, input_size: int, output_size: int = None, trainable_add: bool = True):
         super().__init__()
 
         self.input_size = input_size
+        self.trainable_add = trainable_add
         self.output_size = output_size or input_size
 
         if self.input_size != self.output_size:
-            self.resample = _TimeDistributedInterpolation(self.output_size, batch_first=True)
+            self.resample = _TimeDistributedInterpolation(self.output_size, batch_first=True, trainable=False)
 
-        self.mask = nn.Parameter(torch.zeros(self.output_size, dtype=torch.float))
-        self.gate = nn.Sigmoid()
+        if self.trainable_add:
+            self.mask = nn.Parameter(torch.zeros(self.output_size, dtype=torch.float))
+            self.gate = nn.Sigmoid()
         self.norm = nn.LayerNorm(self.output_size)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.input_size != self.output_size:
             x = self.resample(x)
 
-        x = x * self.gate(self.mask) * 2.0
+        if self.trainable_add:
+            x = x * self.gate(self.mask) * 2.0
 
         output = self.norm(x)
         return output
 
 
 class _AddNorm(nn.Module):
-    """Applies skip connection followed by layer normalisation."""
-
-    def __init__(self,
-                 input_size: int,
-                 skip_size: int = None):
-
+    def __init__(self, input_size: int, skip_size: int = None, trainable_add: bool = True):
         super().__init__()
 
         self.input_size = input_size
+        self.trainable_add = trainable_add
         self.skip_size = skip_size or input_size
 
         if self.input_size != self.skip_size:
-            self.resample = _TimeDistributedInterpolation(self.input_size, batch_first=True)
+            self.resample = _TimeDistributedInterpolation(self.input_size, batch_first=True, trainable=False)
 
+        if self.trainable_add:
+            self.mask = nn.Parameter(torch.zeros(self.input_size, dtype=torch.float))
+            self.gate = nn.Sigmoid()
         self.norm = nn.LayerNorm(self.input_size)
 
     def forward(self, x: torch.Tensor, skip: torch.Tensor):
-        """Norm(Add)"""
-
         if self.input_size != self.skip_size:
             skip = self.resample(skip)
+
+        if self.trainable_add:
+            skip = skip * self.gate(self.mask) * 2.0
 
         output = self.norm(x + skip)
         return output
 
 
 class _GateAddNorm(nn.Module):
-    """Equation (2)"""
-
-    def __init__(self,
-                 input_size: int,
-                 hidden_size: int = None,
-                 skip_size: int = None,
-                 dropout: float = None):
-
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int = None,
+        skip_size: int = None,
+        trainable_add: bool = False,
+        dropout: float = None,
+    ):
         super().__init__()
 
         self.input_size = input_size
@@ -503,155 +498,138 @@ class _GateAddNorm(nn.Module):
         self.dropout = dropout
 
         self.glu = _GatedLinearUnit(self.input_size, hidden_size=self.hidden_size, dropout=self.dropout)
-        self.add_norm = _AddNorm(self.hidden_size, skip_size=self.skip_size)
+        self.add_norm = _AddNorm(self.hidden_size, skip_size=self.skip_size, trainable_add=trainable_add)
 
     def forward(self, x, skip):
-        # skip is the same as residual
         output = self.glu(x)
         output = self.add_norm(output, skip)
         return output
 
 
 class _GatedResidualNetwork(nn.Module):
-    """Top right graph in Figure 2 and formulas (2) -- (5)"""
-
-    def __init__(self,
-                 input_size: int,
-                 hidden_size: int,
-                 output_size: int,
-                 dropout: float = 0.1,
-                 context_size: Optional[int] = None):
-        """Applies the gated residual network (GRN) as defined in paper.
-
-        Parameters
-        ----------
-        hidden_size
-            Internal state size
-        output_size
-            Size of output layer
-        dropout
-            Dropout rate if dropout is applied
-        context_size
-            size of optional context vector
-        """
-
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        output_size: int,
+        dropout: float = 0.1,
+        context_size: int = None,
+        residual: bool = False,
+    ):
         super().__init__()
         self.input_size = input_size
         self.output_size = output_size
         self.context_size = context_size
         self.hidden_size = hidden_size
         self.dropout = dropout
+        self.residual = residual
 
-        # convert raw input into output size for residuals
-        if self.input_size != self.output_size:
-            if not USE_ADAPTION_RESAMPLE:
-                self.resample_norm = _ResampleNorm(self.input_size, self.output_size)
-            else:
-                self.resample_norm = _TimeDistributedInterpolation(self.output_size, batch_first=True)
+        if self.input_size != self.output_size and not self.residual:
+            residual_size = self.input_size
+        else:
+            residual_size = self.output_size
+
+        if self.output_size != residual_size:
+            self.resample_norm = _ResampleNorm(residual_size, self.output_size)
 
         self.fc1 = nn.Linear(self.input_size, self.hidden_size)
-        if self.context_size is not None:
-            # according to equation (4), no context bias
-            self.context = nn.Linear(self.context_size, self.hidden_size, bias=False)
         self.elu = nn.ELU()
 
-        self.fc2 = nn.Linear(self.hidden_size, self.hidden_size)
+        if self.context_size is not None:
+            self.context = nn.Linear(self.context_size, self.hidden_size, bias=False)
 
+        self.fc2 = nn.Linear(self.hidden_size, self.hidden_size)
         self.init_weights()
 
-        self.gate_add_norm = _GateAddNorm(
+        self.gate_norm = _GateAddNorm(
             input_size=self.hidden_size,
             skip_size=self.output_size,
             hidden_size=self.output_size,
             dropout=self.dropout,
+            trainable_add=False,
         )
 
     def init_weights(self):
-        # p contains the parameter values
         for name, p in self.named_parameters():
             if "bias" in name:
                 torch.nn.init.zeros_(p)
-            elif "fc" in name:  # fc weights
+            elif "fc1" in name or "fc2" in name:
                 torch.nn.init.kaiming_normal_(p, a=0, mode="fan_in", nonlinearity="leaky_relu")
-            elif "context" in name:  # context weights
+            elif "context" in name:
                 torch.nn.init.xavier_uniform_(p)
 
-    def forward(self, x, context=None):
-        # residual connection, also called `skip` basically bypasses until add_norm
-        if self.input_size != self.output_size:
-            residual = self.resample_norm(x)
-        else:
+    def forward(self, x, context=None, residual=None):
+        if residual is None:
             residual = x
+
+        if self.input_size != self.output_size and not self.residual:
+            residual = self.resample_norm(residual)
+
         x = self.fc1(x)
         if context is not None:
             context = self.context(context)
             x = x + context
         x = self.elu(x)
         x = self.fc2(x)
-        x = self.gate_add_norm(x, residual)
+        x = self.gate_norm(x, residual)
         return x
 
 
 class _VariableSelectionNetwork(nn.Module):
-    def __init__(self,
-                 input_sizes: Dict[str, int],
-                 hidden_size: int,
-                 input_embedding_flags: Optional[Dict[str, bool]] = None,
-                 dropout: float = 0.1,
-                 context_size: Optional[int] = None,
-                 single_variable_grns: Optional[Dict[str, _GatedResidualNetwork]] = None,
-                 prescalers: Optional[torch.nn.ModuleDict] = None):
+    def __init__(
+        self,
+        input_sizes: Dict[str, int],
+        hidden_size: int,
+        input_embedding_flags: Dict[str, bool] = {},
+        dropout: float = 0.1,
+        context_size: int = None,
+        single_variable_grns: Dict[str, _GatedResidualNetwork] = {},
+        prescalers: Dict[str, nn.Linear] = {},
+    ):
         """
-        From paper https://arxiv.org/pdf/1912.09363.pdf:
-        TFT is designed to provide instance-wise variable selection through the use of variable selection networks
-        applied to both static covariates and time-dependent covariates. Beyond provid- ing insights into which
-        variables are most significant for the prediction problem, variable selection also allows TFT to remove any
-        unnecessary noisy inputs which could negatively impact performance.
+        Calcualte weights for ``num_inputs`` variables  which are each of size ``input_size``
         """
-
         super().__init__()
 
-        self.input_sizes = input_sizes
         self.hidden_size = hidden_size
-        self.input_embedding_flags = {} if input_embedding_flags is None else input_embedding_flags
+        self.input_sizes = input_sizes
+        self.input_embedding_flags = input_embedding_flags
         self.dropout = dropout
         self.context_size = context_size
-        single_variable_grns = {} if single_variable_grns is None else single_variable_grns
-        prescalers = {} if prescalers is None else prescalers
 
-        self.num_inputs = len(self.input_sizes)
-        self.input_sizes_total = sum(self.input_sizes.values())
+        if self.num_inputs > 1:
+            if self.context_size is not None:
+                self.flattened_grn = _GatedResidualNetwork(
+                    self.input_size_total,
+                    min(self.hidden_size, self.num_inputs),
+                    self.num_inputs,
+                    self.dropout,
+                    self.context_size,
+                    residual=False,
+                )
+            else:
+                self.flattened_grn = _GatedResidualNetwork(
+                    self.input_size_total,
+                    min(self.hidden_size, self.num_inputs),
+                    self.num_inputs,
+                    self.dropout,
+                    residual=False,
+                )
 
-        if self.num_inputs >= 1:
-            # right side of figure 2 bottom right graph
-            self.vars_flattened_grn = _GatedResidualNetwork(
-                input_size=self.input_sizes_total,
-                hidden_size=min(self.hidden_size, self.num_inputs) if not USE_ADAPTION_VSN else self.hidden_size,
-                output_size=self.num_inputs,
-                dropout=self.dropout,
-                context_size=self.context_size
-            )
-
-        # TODO: (dbader) this can be cleaner, also think about moving prescalers out of _VariableSelectionNetwork
-        # left side of figure 2 bottom right graph
-        self.vars_single_grns = nn.ModuleDict()
+        self.single_variable_grns = nn.ModuleDict()
         self.prescalers = nn.ModuleDict()
         for name, input_size in self.input_sizes.items():
             if name in single_variable_grns:
-                self.vars_single_grns[name] = single_variable_grns[name]
+                self.single_variable_grns[name] = single_variable_grns[name]
             elif self.input_embedding_flags.get(name, False):
-                if not USE_ADAPTION_RESAMPLE:
-                    self.vars_single_grns[name] = _ResampleNorm(input_size, self.hidden_size)
-                else:
-                    self.vars_single_grns[name] = _TimeDistributedInterpolation(self.hidden_size, batch_first=True)
+                self.single_variable_grns[name] = _ResampleNorm(input_size, self.hidden_size)
             else:
-                self.vars_single_grns[name] = _GatedResidualNetwork(
-                    input_size=input_size,
-                    hidden_size=min(input_size, self.hidden_size) if not USE_ADAPTION_VSN else self.hidden_size,
+                self.single_variable_grns[name] = _GatedResidualNetwork(
+                    input_size,
+                    min(input_size, self.hidden_size),
                     output_size=self.hidden_size,
-                    dropout=self.dropout
+                    dropout=self.dropout,
                 )
-
             if name in prescalers:  # reals need to be first scaled up
                 self.prescalers[name] = prescalers[name]
             elif not self.input_embedding_flags.get(name, False):
@@ -659,104 +637,87 @@ class _VariableSelectionNetwork(nn.Module):
 
         self.softmax = nn.Softmax(dim=-1)
 
+    @property
+    def input_size_total(self):
+        return sum(size if name in self.input_embedding_flags else size for name, size in self.input_sizes.items())
+
+    @property
+    def num_inputs(self):
+        return len(self.input_sizes)
+
     def forward(self, x: Dict[str, torch.Tensor], context: torch.Tensor = None):
-        # transform variables and GRN for transformed variables (left side of figure 2 bottom right graph)
-        vars_out = []
-        transformed = []
-        for var_name in self.input_sizes.keys():
-            # select embedding belonging to a single input variable
-            var_transformed = x[var_name]
-            if var_name in self.prescalers:
-                var_transformed = self.prescalers[var_name](var_transformed)
-            vars_out.append(self.vars_single_grns[var_name](var_transformed))
-            transformed.append(var_transformed)
+        if self.num_inputs > 1:
+            # transform single variables
+            var_outputs = []
+            weight_inputs = []
+            for name in self.input_sizes.keys():
+                # select embedding belonging to a single input
+                variable_embedding = x[name]
+                if name in self.prescalers:
+                    variable_embedding = self.prescalers[name](variable_embedding)
+                weight_inputs.append(variable_embedding)
+                var_outputs.append(self.single_variable_grns[name](variable_embedding))
+            var_outputs = torch.stack(var_outputs, dim=-1)
 
-        vars_out = torch.stack(vars_out, dim=-1)
+            # calculate variable weights
+            flat_embedding = torch.cat(weight_inputs, dim=-1)
+            sparse_weights = self.flattened_grn(flat_embedding, context)
+            sparse_weights = self.softmax(sparse_weights).unsqueeze(-2)
 
-        # calculate variable weights with flattened variables (right side of figure 2 bottom right graph)
-        flattened = torch.cat(transformed, dim=-1)
-
-        selection_weights = self.vars_flattened_grn(flattened, context)
-        selection_weights = self.softmax(selection_weights).unsqueeze(-2)
-
-        # join single variable with variable selection weigths (top of figure 2 bottom right graph)
-        outputs = vars_out * selection_weights
-        outputs = outputs.sum(dim=-1)
-        return outputs, selection_weights
+            outputs = var_outputs * sparse_weights
+            outputs = outputs.sum(dim=-1)
+        else:  # for one input, do not perform variable selection but just encoding
+            name = next(iter(self.single_variable_grns.keys()))
+            variable_embedding = x[name]
+            if name in self.prescalers:
+                variable_embedding = self.prescalers[name](variable_embedding)
+            outputs = self.single_variable_grns[name](variable_embedding)  # fast forward if only one variable
+            if outputs.ndim == 3:  # -> batch size, time, hidden size, n_variables
+                sparse_weights = torch.ones(outputs.size(0), outputs.size(1), 1, 1, device=outputs.device)  #
+            else:  # ndim == 2 -> batch size, hidden size, n_variables
+                sparse_weights = torch.ones(outputs.size(0), 1, 1, device=outputs.device)
+        return outputs, sparse_weights
 
 
 class _ScaledDotProductAttention(nn.Module):
-    """_ScaledDotProductAttention is a self-attention mechanism to learn long-term
-    relationships across different time steps. It scales values V based on relationship
-    between Keys K and queries Q.
-
-    From equations (9) -- (10)"""
-
-    def __init__(self):
-
+    def __init__(self, dropout: float = None, scale: bool = True):
         super(_ScaledDotProductAttention, self).__init__()
-
+        if dropout is not None:
+            self.dropout = nn.Dropout(p=dropout)
+        else:
+            self.dropout = dropout
         self.softmax = nn.Softmax(dim=2)
+        self.scale = scale
 
     def forward(self, q, k, v, mask=None):
-        """
-        Parameters
-        ----------
-        q
-            Queries matrix of dimension (N x d_attention)
-        k
-            Keys matrix of dimension (N x d_attention)
-        v
-            Values matrix of dimension (N x d_Values)
-        mask
-            masking if required -- sets softmax to very large value
-        """
+        attn = torch.bmm(q, k.permute(0, 2, 1))  # query-key overlap
 
-        attn = torch.bmm(q, k.transpose(1, 2))
-
-        dimension = torch.sqrt(torch.tensor(k.shape[-1]).to(torch.float32))
-        attn = attn / dimension
+        if self.scale:
+            dimension = torch.sqrt(torch.tensor(k.shape[-1]).to(torch.float32))
+            attn = attn / dimension
 
         if mask is not None:
-            attn = attn.masked_fill(mask, float('-inf'))
+            attn = attn.masked_fill(mask, -1e9)
         attn = self.softmax(attn)
 
+        if self.dropout is not None:
+            attn = self.dropout(attn)
         output = torch.bmm(attn, v)
         return output, attn
 
 
 class _InterpretableMultiHeadAttention(nn.Module):
-    """Equations (13) -- (16)"""
-
-    def __init__(self,
-                 n_head: int,
-                 d_model: int,
-                 dropout: Optional[float] = None):
-        """
-        Description of parameters
-            n_head: number of heads
-            d_model: TFT state dimensionality
-            d_k: Key/query dimensionality per head
-            d_v: value dimensionality
-            q_layers: list of queries across heads
-            k_layers: list of keys across heads
-            v_layers: list of values across heads
-            attention: scaled dot product attention layer
-            w_h: output head weight matrix to project internal state to the original TFT state size
-        """
-
+    def __init__(self, n_head: int, d_model: int, dropout: float = 0.0):
         super(_InterpretableMultiHeadAttention, self).__init__()
 
         self.n_head = n_head
         self.d_model = d_model
         self.d_k = self.d_q = self.d_v = d_model // n_head
-        self.dropout = nn.Dropout(p=dropout) if dropout is not None else dropout
+        self.dropout = nn.Dropout(p=dropout)
 
-        # use same value layer to facilitate interpretation
         self.v_layer = nn.Linear(self.d_model, self.d_v)
         self.q_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_q) for _ in range(self.n_head)])
         self.k_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_k) for _ in range(self.n_head)])
-
         self.attention = _ScaledDotProductAttention()
         self.w_h = nn.Linear(self.d_v, self.d_model, bias=False)
 
@@ -764,9 +725,9 @@ class _InterpretableMultiHeadAttention(nn.Module):
 
     def init_weights(self):
         for name, p in self.named_parameters():
-            if 'weight' in name:
+            if "bias" not in name:
                 torch.nn.init.xavier_uniform_(p)
-            elif 'bias' in name:
+            else:
                 torch.nn.init.zeros_(p)
 
     def forward(self, q, k, v, mask=None) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -777,18 +738,15 @@ class _InterpretableMultiHeadAttention(nn.Module):
             qs = self.q_layers[i](q)
             ks = self.k_layers[i](k)
             head, attn = self.attention(qs, ks, vs, mask)
-            if self.dropout is not None:
-                head = self.dropout(head)
-            heads.append(head)
+            head_dropout = self.dropout(head)
+            heads.append(head_dropout)
             attns.append(attn)
 
         head = torch.stack(heads, dim=2) if self.n_head > 1 else heads[0]
         attn = torch.stack(attns, dim=2)
 
         outputs = torch.mean(head, dim=2) if self.n_head > 1 else head
-
         outputs = self.w_h(outputs)
-        if self.dropout is not None:
-            outputs = self.dropout(outputs)
+        outputs = self.dropout(outputs)
 
         return outputs, attn

--- a/darts/models/forecasting/tft_submodels.py
+++ b/darts/models/forecasting/tft_submodels.py
@@ -35,66 +35,6 @@ logger = get_logger(__name__)
 HiddenState = Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
-class QuantileLoss(nn.Module):
-    """Quantile Loss Metric for custom quantiles centered around q=0.5
-
-    From: https://medium.com/the-artificial-impostor/quantile-regression-part-2-6fdbc26b2629"""
-
-    def __init__(self, quantiles: Optional[List[float]] = None):
-        """
-        Parameters
-        ----------
-        quantiles
-            list of quantiles
-        """
-
-        super().__init__()
-        self.quantiles = [0.02, 0.1, 0.25, 0.5, 0.75, 0.9, 0.98] if quantiles is None else quantiles
-        self._check_quantiles(self.quantiles)
-        self.first = True
-
-    def forward(self, y_pred, y_true):
-        """
-        Parameters
-        ----------
-        y_pred
-            must be of shape (n_samples, n_timesteps, n_target_variables, n_quantiles)
-        y_true
-            must be of shape (n_samples, n_timesteps, n_target_variables)
-        """
-
-        dim_q = 3
-
-        if self.first:  # test if torch model forward produces correct output
-            raise_if_not(len(y_pred.shape) == 4 or len(y_true.shape) == 3 or y_pred.shape[:2] != y_true.shape[:2],
-                         'mismatch between predicted and target shape',
-                         logger)
-            raise_if_not(y_pred.shape[dim_q] == len(self.quantiles),
-                         'mismatch between number of predicted quantiles and target quantiles',
-                         logger)
-            self.first = False
-
-        losses = []
-        for i, q in enumerate(self.quantiles):
-            errors = y_true - y_pred[..., i]
-            losses.append(torch.max((q - 1) * errors, q * errors).unsqueeze(dim_q))
-        losses = torch.cat(losses, dim=dim_q)
-        return losses.sum(dim=dim_q).mean()
-
-    @staticmethod
-    def _check_quantiles(quantiles):
-        median_q = 0.5
-        raise_if_not(median_q in quantiles,
-                     'median quantile `q=0.5` must be in `quantiles`',
-                     logger)
-        is_centered = [(median_q - left_q) == -(median_q - right_q)
-                       for left_q, right_q in zip(quantiles, quantiles[::-1])]
-        raise_if_not(all(is_centered),
-                     'quantiles lower than `q=0.5` need to share same difference to `0.5` as quantiles '
-                     'higher than `q=0.5`',
-                     logger)
-
-
 class _RNN(ABC, nn.RNNBase):
     """
     Base class flexible RNNs.

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -250,8 +250,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             logger.info('Time series values are 32-bits; casting model to float32.')
             self.model = model.float()
         elif np.issubdtype(self.train_sample[0].dtype, np.float64):
-            logger.info('Time series values are 64-bits; casting model to float64. If training is too slow you '
-                        'can try casting your data to 32-bits.')
+            logger.info('Time series values are 64-bits; casting model to float64.')
             self.model = model.double()
 
         self.model = self.model.to(self.device)

--- a/darts/tests/test_probabilistic_models.py
+++ b/darts/tests/test_probabilistic_models.py
@@ -28,7 +28,8 @@ try:
                                                ContinuousBernoulliLikelihood,
                                                HalfNormalLikelihood,
                                                LogNormalLikelihood,
-                                               WeibullLikelihood)
+                                               WeibullLikelihood,
+                                               QuantileRegression)
     TORCH_AVAILABLE = True
 except ImportError:
     logger.warning('Torch not available. TCN tests will be skipped.')
@@ -144,7 +145,8 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
                       (ContinuousBernoulliLikelihood(), bounded_series, 0.1, 0.1),
                       (HalfNormalLikelihood(), real_pos_series, 0.3, 8),
                       (LogNormalLikelihood(), real_pos_series, 0.3, 1),
-                      (WeibullLikelihood(), real_pos_series, 0.2, 2))
+                      (WeibullLikelihood(), real_pos_series, 0.2, 2),
+                      (QuantileRegression(), real_series, 0.2, 1))
 
         def test_likelihoods_and_resulting_mean_forecasts(self):
             def _get_avgs(series):

--- a/darts/tests/test_timeseries_multivariate.py
+++ b/darts/tests/test_timeseries_multivariate.py
@@ -149,7 +149,7 @@ class TimeSeriesMultivariateTestCase(DartsBaseTestClass):
         values_cos = seriesF.values()[:, 2]
 
         self.assertTrue(np.allclose(np.add(np.square(values_sin), np.square(values_cos)), 1))
-        start_of_month = [pd.Timestamp(year=start.year, month=m, day=1, freq='d') - start for m in range(start.month, end.month)]
+        start_of_month = [pd.Timestamp(year=start.year, month=m, day=1) - start for m in range(start.month, end.month)]
         start_of_month_idx = [stamp.days for stamp in start_of_month]
 
         self.assertTrue(np.allclose(values_sin[start_of_month_idx], 0))

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -24,6 +24,8 @@ logger = get_logger(__name__)
 # the "time" one can be different, if it has a name in the underlying Series/DataFrame.
 DIMS = ('time', 'component', 'sample')
 
+VALID_INDEX_TYPES = (pd.DatetimeIndex, pd.RangeIndex, pd.Int64Index)
+
 
 class TimeSeries:
     def __init__(self, xa: xr.DataArray):
@@ -71,7 +73,7 @@ class TimeSeries:
 
         self._time_index = self._xa.get_index(self._time_dim)
 
-        if not isinstance(self._time_index, pd.DatetimeIndex) and not isinstance(self._time_index, pd.Int64Index):
+        if not isinstance(self._time_index, VALID_INDEX_TYPES):
             raise_log(ValueError('The time dimension of the DataArray must be indexed either with a DatetimeIndex,'
                                  'or with an Int64Index (this can include a RangeIndex).'), logger)
 
@@ -329,7 +331,7 @@ class TimeSeries:
             else:
                 raise_log(AttributeError('time_col=\'{}\' is not present.'.format(time_col)))
         else:
-            raise_if_not(isinstance(df.index, pd.Int64Index) or isinstance(df.index, pd.DatetimeIndex),
+            raise_if_not(isinstance(df.index, VALID_INDEX_TYPES),
                          'If time_col is not specified, the DataFrame must be indexed either with'
                          'a DatetimeIndex, or with a Int64Index (incl. RangeIndex).', logger)
             time_index = df.index
@@ -385,7 +387,7 @@ class TimeSeries:
                                          fillna_value=fillna_value)
 
     @staticmethod
-    def from_times_and_values(times: Union[pd.DatetimeIndex, pd.Int64Index],
+    def from_times_and_values(times: Union[pd.DatetimeIndex, pd.Int64Index, pd.RangeIndex],
                               values: np.ndarray,
                               fill_missing_dates: Optional[bool] = False,
                               freq: Optional[str] = None,
@@ -422,7 +424,7 @@ class TimeSeries:
         TimeSeries
             A TimeSeries constructed from the inputs.
         """
-        raise_if_not(isinstance(times, pd.Int64Index) or isinstance(times, pd.DatetimeIndex),
+        raise_if_not(isinstance(times, VALID_INDEX_TYPES),
                      'the `times` argument must be a Int64Index (or RangeIndex), or a DateTimeIndex. Use '
                      'TimeSeries.from_values() if you want to use an automatic RangeIndex.')
 
@@ -707,9 +709,9 @@ class TimeSeries:
         self._assert_univariate()
         self._assert_deterministic()
         if copy:
-            return pd.Series(self._xa[:, 0, 0].copy(), index=self._time_index.copy())
+            return pd.Series(self._xa[:, 0, 0].values.copy(), index=self._time_index.copy())
         else:
-            return pd.Series(self._xa[:, 0, 0], index=self._time_index)
+            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index)
 
     def pd_dataframe(self, copy=True) -> pd.DataFrame:
         """
@@ -2395,7 +2397,7 @@ class TimeSeries:
             _set_freq_in_xa(xa_)
 
             return TimeSeries(xa_)
-        elif isinstance(key, pd.Int64Index):
+        elif isinstance(key, (pd.Int64Index, pd.RangeIndex)):
             _check_range()
 
             return TimeSeries(self._xa.sel({self._time_dim: key}))

--- a/darts/utils/likelihood_models.py
+++ b/darts/utils/likelihood_models.py
@@ -34,7 +34,7 @@ to see what is the support. Similarly, the prior parameters also have to lie in 
 from darts.utils.utils import raise_if_not
 
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 import collections
 
 import numpy as np
@@ -61,6 +61,7 @@ from torch.distributions import (Normal as _Normal,
                                  )
 
 MIN_CAUCHY_GAMMA_SAMPLING = 1e-100
+
 
 # Some utils for checking parameters' domains
 def _check(param, predicate, param_name, condition_str):
@@ -948,6 +949,117 @@ class WeibullLikelihood(Likelihood):
         k = self.softplus(model_output[:, :, output_size // 2:])
         return lmbda, k
 
+
+class QuantileRegression(Likelihood):
+    def __init__(self, quantiles: Optional[List[float]] = None):
+        """
+        The "likelihood" corresponding to quantile regression.
+        It uses the Quantile Loss Metric for custom quantiles centered around q=0.5.
+
+        This class can be used as any other Likelihood objects even though it is not
+        representing the likelihood of a well defined distribution.
+
+        Parameters:
+        -----------
+        quantiles
+            list of quantiles
+        """
+
+        super().__init__()
+        if quantiles is None:
+            self.quantiles = [0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5,
+                              0.6, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99]
+        else:
+            self.quantiles = sorted(quantiles)
+        self._check_quantiles(self.quantiles)
+        self._median_idx = self.quantiles.index(0.5)
+        self.first = True
+
+    def sample(self, model_output: torch.Tensor) -> torch.Tensor:
+        """
+        Select a quantile (for each batch example) and return this quantile (over time and components).
+
+        model_output is of shape (batch_size, n_timesteps, n_components, n_quantiles)
+        """
+        batch_size, length = model_output.shape[:2]
+        model_output = model_output.view(batch_size, length, -1, len(self.quantiles))
+
+        device = model_output.device
+
+        quantiles = torch.tile(torch.tensor(self.quantiles), (batch_size, 1)).to(device)
+        probas = torch.tile(torch.rand(size=(batch_size,)), (len(self.quantiles), 1)).to(device)
+
+        quantile_idxs = torch.sum(probas.T > quantiles, axis=1)
+
+        # To make the sampling symmetric around the median, we assign the two "probability buckets" before and after
+        # the median to the median value. If we don't do that, the highest quantile would be wrongly sampled
+        # too often as it would capture the "probability buckets" preceding and following it.
+        #
+        # Example; the arrows shows how the buckets map to values: [--> 0.1 --> 0.25 --> 0.5 <-- 0.75 <-- 0.9 <--]
+        quantile_idxs = torch.where(quantile_idxs <= self._median_idx, quantile_idxs, quantile_idxs - 1)
+
+        batch_idx = torch.tensor(range(batch_size)).to(device)
+        return model_output[batch_idx, :, :, quantile_idxs]
+
+    @property
+    def num_parameters(self) -> int:
+        return len(self.quantiles)
+
+    def compute_loss(self, model_output: torch.Tensor, target: torch.Tensor):
+        """
+        We are re-defining a custom loss (which is not a likelihood loss) compared to Likelihood
+
+        Parameters
+        ----------
+        model_output
+            must be of shape (batch_size, n_timesteps, n_target_variables, n_quantiles)
+        target
+            must be of shape (n_samples, n_timesteps, n_target_variables)
+        """
+
+        dim_q = 3
+
+        batch_size, length = model_output.shape[:2]
+        model_output = model_output.view(batch_size, length, -1, len(self.quantiles))
+
+        if self.first:  # test if torch model forward produces correct output
+            raise_if_not(len(model_output.shape) == 4 or len(target.shape) == 3 or
+                         model_output.shape[:2] != target.shape[:2],
+                         'mismatch between predicted and target shape')
+            raise_if_not(model_output.shape[dim_q] == len(self.quantiles),
+                         'mismatch between number of predicted quantiles and target quantiles')
+            self.first = False
+
+        losses = []
+        for i, q in enumerate(self.quantiles):
+            errors = target - model_output[..., i]
+            losses.append(torch.max((q - 1) * errors, q * errors).unsqueeze(dim_q))
+        losses = torch.cat(losses, dim=dim_q)
+        return losses.sum(dim=dim_q).mean()
+
+    @staticmethod
+    def _check_quantiles(quantiles):
+        raise_if_not(all([0 < q < 1 for q in quantiles]),
+                     'All provided quantiles must be between 0 and 1.')
+
+        # we require the median to be present and the quantiles to be symmetric around it,
+        # for correctness of sampling.
+        median_q = 0.5
+        raise_if_not(median_q in quantiles,
+                     'median quantile `q=0.5` must be in `quantiles`')
+        is_centered = [-1e-6 < (median_q - left_q) + (median_q - right_q) < 1e-6
+                       for left_q, right_q in zip(quantiles, quantiles[::-1])]
+        raise_if_not(all(is_centered),
+                     'quantiles lower than `q=0.5` need to share same difference to `0.5` as quantiles '
+                     'higher than `q=0.5`')
+
+    def _distr_from_params(self, params: Tuple) -> torch.distributions.Distribution:
+        # This should not be called in this class (we are abusing Likelihood)
+        return None
+
+    def _params_from_output(self, model_output: torch.Tensor):
+        # This should not be called in this class (we are abusing Likelihood)
+        return None
 
 if False:
     """ TODO

--- a/darts/utils/likelihood_models.py
+++ b/darts/utils/likelihood_models.py
@@ -1023,8 +1023,8 @@ class QuantileRegression(Likelihood):
         model_output = model_output.view(batch_size, length, -1, len(self.quantiles))
 
         if self.first:  # test if torch model forward produces correct output
-            raise_if_not(len(model_output.shape) == 4 or len(target.shape) == 3 or
-                         model_output.shape[:2] != target.shape[:2],
+            raise_if_not(len(model_output.shape) == 4 and len(target.shape) == 3 and
+                         model_output.shape[:2] == target.shape[:2],
                          'mismatch between predicted and target shape')
             raise_if_not(model_output.shape[dim_q] == len(self.quantiles),
                          'mismatch between number of predicted quantiles and target quantiles')

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -3,7 +3,7 @@ xarray>=0.18.0
 scipy>=1.6.0
 statsmodels>=0.13.0
 matplotlib>=3.4.0
-pandas>=1.2.0,<=1.3.0
+pandas>=1.3.0
 ipython>=7.22.0
 tqdm>=4.60.0
 holidays>=0.11.0

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,9 +1,9 @@
 numpy>=1.19.0
 xarray>=0.18.0
 scipy>=1.6.0
-statsmodels>=0.12.0
+statsmodels>=0.13.0
 matplotlib>=3.4.0
-pandas>=1.2.0,<1.3.0
+pandas>=1.2.0,<=1.3.0
 ipython>=7.22.0
 tqdm>=4.60.0
 holidays>=0.11.0

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,12 +1,13 @@
 # docs
-jinja2==2.11.3
-sphinx==3.2.1
+jinja2==3.0.2
+sphinx==4.2.0
 sphinx-automodapi==0.13
-sphinx_autodoc_typehints==1.11.1
-nbsphinx==0.8.0
-pydata-sphinx-theme==0.4.1
+sphinx_autodoc_typehints==1.12.0
+nbsphinx==0.8.7
+pydata-sphinx-theme==0.7.1
 recommonmark==0.7.1
-m2r2==0.3.0
+m2r2==0.3.1
+docutils<=0.17.1
 
 # publish
 twine==3.3.0

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,3 +1,2 @@
 torch>=1.8.0,<1.9.0
 tensorboard>=2.4.0
-pytorch-forecasting>=0.9.1

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,2 +1,3 @@
 torch>=1.8.0,<1.9.0
 tensorboard>=2.4.0
+pytorch-forecasting>=0.9.1


### PR DESCRIPTION
Transformed the `QuantileLoss` into a new `QuantileRegression` class, which makes it possible to use with other probabilistic models as well. TFT is also using this now by default.

The sampling is made by sampling the quantile values directly, with a "trick" relying on the presence of the median in the quantiles in order to avoid over-sampling any of the smallest or highest quantiles.

![image](https://user-images.githubusercontent.com/4806678/139479856-6f7dd8bf-09af-4bea-ae8d-20c68c196678.png)
