### PR TITLE
Feat/tft relative index

### DIFF
--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -84,7 +84,8 @@ class _TFTModule(nn.Module):
             Fraction of neurons afected by Dropout.
         add_relative_index : bool
             Whether to add positional values to future covariates. Defaults to `False`.
-            This gives a value to the position of each step from input and output chunk relative to the prediction
+            This allows to use the TFTModel without having to pass future_covariates to `fit()` and `train()`.
+            It gives a value to the position of each step from input and output chunk relative to the prediction
             point. The values are normalized with `input_chunk_length`.
         likelihood
             The likelihood model to be used for probabilistic forecasts. By default the TFT uses
@@ -582,7 +583,8 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
             <darts.utils.timeseries_generation.datetime_attribute_timeseries>`
         add_relative_index : bool
             Whether to add positional values to future covariates. Defaults to `False`.
-            This gives a value to the position of each step from input and output chunk relative to the prediction
+            This allows to use the TFTModel without having to pass future_covariates to `fit()` and `train()`.
+            It gives a value to the position of each step from input and output chunk relative to the prediction
             point. The values are normalized with `input_chunk_length`.
         loss_fn : nn.Module
             PyTorch loss function used for training. By default the TFT model is probabilistic and uses a ``likelihood``
@@ -690,15 +692,15 @@ class TFTModel(TorchParametricProbabilisticForecastingModel, MixedCovariatesTorc
         if self.add_relative_index:
             time_steps = self.input_chunk_length + self.output_chunk_length
 
-            expand_covariate = np.arange(time_steps).reshape((time_steps, 1))
+            expand_future_covariate = np.arange(time_steps).reshape((time_steps, 1))
 
             historic_future_covariate = np.concatenate(
-                [ts[:self.input_chunk_length] for ts in [historic_future_covariate, expand_covariate] if
+                [ts[:self.input_chunk_length] for ts in [historic_future_covariate, expand_future_covariate] if
                  ts is not None],
                 axis=1
             )
             future_covariate = np.concatenate(
-                [ts[-self.output_chunk_length:] for ts in [future_covariate, expand_covariate] if
+                [ts[-self.output_chunk_length:] for ts in [future_covariate, expand_future_covariate] if
                  ts is not None],
                 axis=1
             )

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -356,10 +356,10 @@ class _TFTModule(nn.Module):
                                                                      device=past_target.device)
             if self.add_relative_index:
                 self.relative_index = self.get_relative_index(encoder_length=encoder_length,
-                                                                        decoder_length=decoder_length,
-                                                                        batch_size=batch_size,
-                                                                        device=past_target.device,
-                                                                        dtype=past_target.dtype)
+                                                              decoder_length=decoder_length,
+                                                              batch_size=batch_size,
+                                                              device=past_target.device,
+                                                              dtype=past_target.dtype)
 
             self.batch_size_last = batch_size
 

--- a/darts/tests/test_TFT.py
+++ b/darts/tests/test_TFT.py
@@ -34,18 +34,23 @@ if TORCH_AVAILABLE:
             with self.assertRaises(ValueError):
                 QuantileRegression(q_non_symmetric)
 
-        def test_no_future_covariates(self):
-            # data comes as multivariate
-            ts = tg.sine_timeseries(length=2, freq='h')
+        def test_future_covariate_handling(self):
+            ts_time_index = tg.sine_timeseries(length=2, freq='h')
+            ts_integer_index = TimeSeries.from_values(values=ts_time_index.values())
 
             # model requires future covariates without cyclic encoding
             model = TFTModel(input_chunk_length=1, output_chunk_length=1)
             with self.assertRaises(ValueError):
-                model.fit(ts, verbose=False)
+                model.fit(ts_time_index, verbose=False)
 
-            # should work with cyclic encoding
+            # should work with cyclic encoding for time index
             model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_cyclic_encoder='hour')
-            model.fit(ts, verbose=False)
+            model.fit(ts_time_index, verbose=False)
+
+            # should work with relative index both with time index and integer index
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_relative_index=True)
+            model.fit(ts_time_index, verbose=False)
+            model.fit(ts_integer_index, verbose=False)
 
         def test_prediction_shape(self):
             """checks whether prediction has same number of variable as input series and

--- a/darts/tests/test_TFT.py
+++ b/darts/tests/test_TFT.py
@@ -39,16 +39,16 @@ if TORCH_AVAILABLE:
             ts_integer_index = TimeSeries.from_values(values=ts_time_index.values())
 
             # model requires future covariates without cyclic encoding
-            model = TFTModel(input_chunk_length=1, output_chunk_length=1)
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1, random_state=0)
             with self.assertRaises(ValueError):
                 model.fit(ts_time_index, verbose=False)
 
             # should work with cyclic encoding for time index
-            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_cyclic_encoder='hour')
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_cyclic_encoder='hour', random_state=0)
             model.fit(ts_time_index, verbose=False)
 
             # should work with relative index both with time index and integer index
-            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_relative_index=True)
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_relative_index=True, random_state=0)
             model.fit(ts_time_index, verbose=False)
             model.fit(ts_integer_index, verbose=False)
 


### PR DESCRIPTION
### Summary

- relative time index can now be generated without having to specify any future covariates
- @hrzn I think this is the closest we get to a "historic"-only TFT as:
  - it creates the required decoder part if no future covariates are given
  - relative index is identical for all samples since input_ - and output_chunk_length stay the same.
  - if the relative index doesn't generate any additional value, the TFT should be able to ignore it through its Variable Selection Networks.
  - (+) relative index can indeed be helpful! It was most obvious when input and output chunk length were a multiple of a seasonal period.
