### PR TITLE
A probabilistic version of NBEATS

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Model | Univariate | Multivariate | Probabilistic | Multiple-series training | P
 `RegressionModel` (incl `RandomForest`, `LinearRegressionModel` and `LightGBMModel`) | ✅ | ✅ | | ✅ | ✅ | ✅ |
 `RNNModel` (incl. LSTM and GRU); equivalent to DeepAR in its probabilistic version | ✅ | ✅ | ✅ | ✅ | | ✅ | [DeepAR paper](https://arxiv.org/abs/1704.04110)
 `BlockRNNModel` (incl. LSTM and GRU) | ✅ | ✅ | ✅ | ✅ | ✅ | |
-`NBEATSModel` | ✅ | ✅ | | ✅ | ✅ | | [N-BEATS paper](https://arxiv.org/abs/1905.10437)
+`NBEATSModel` | ✅ | ✅ | ✅ | ✅ | ✅ | | [N-BEATS paper](https://arxiv.org/abs/1905.10437)
 `TCNModel` | ✅ | ✅ | ✅ | ✅ | ✅ | | [TCN paper](https://arxiv.org/abs/1803.01271), [DeepTCN paper](https://arxiv.org/abs/1906.04397), [blog post](https://medium.com/unit8-machine-learning-publication/temporal-convolutional-networks-and-forecasting-5ce1b6e97ce4)
 `TransformerModel` | ✅ | ✅ | ✅ | ✅ | ✅ | | 
 `TFTModel` (Temporal Fusion Transformer) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [TFT paper](https://arxiv.org/pdf/1912.09363.pdf), [PyTorch Forecasting](https://pytorch-forecasting.readthedocs.io/en/latest/models.html)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Model | Univariate | Multivariate | Probabilistic | Multiple-series training | P
 `RegressionModel` (incl `RandomForest`, `LinearRegressionModel` and `LightGBMModel`) | ✅ | ✅ | | ✅ | ✅ | ✅ |
 `RNNModel` (incl. LSTM and GRU); equivalent to DeepAR in its probabilistic version | ✅ | ✅ | ✅ | ✅ | | ✅ | [DeepAR paper](https://arxiv.org/abs/1704.04110)
 `BlockRNNModel` (incl. LSTM and GRU) | ✅ | ✅ | ✅ | ✅ | ✅ | |
-`NBEATSModel` | ✅ | ✅ | ✅ | ✅ | ✅ | | [N-BEATS paper](https://arxiv.org/abs/1905.10437)
+`NBEATSModel` | ✅ | ✅ | | ✅ | ✅ | | [N-BEATS paper](https://arxiv.org/abs/1905.10437)
 `TCNModel` | ✅ | ✅ | ✅ | ✅ | ✅ | | [TCN paper](https://arxiv.org/abs/1803.01271), [DeepTCN paper](https://arxiv.org/abs/1906.04397), [blog post](https://medium.com/unit8-machine-learning-publication/temporal-convolutional-networks-and-forecasting-5ce1b6e97ce4)
 `TransformerModel` | ✅ | ✅ | ✅ | ✅ | ✅ | | 
 `TFTModel` (Temporal Fusion Transformer) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [TFT paper](https://arxiv.org/pdf/1912.09363.pdf), [PyTorch Forecasting](https://pytorch-forecasting.readthedocs.io/en/latest/models.html)

--- a/darts/models/forecasting/block_rnn_model.py
+++ b/darts/models/forecasting/block_rnn_model.py
@@ -58,7 +58,7 @@ class _BlockRNNModule(nn.Module):
         target_size
             The dimensionality of the output time series.
         nr_params
-            The number of parameters of the likelihood (or 1)
+            The number of parameters of the likelihood (or 1 if no likelihood is used).
         num_layers_out_fc
             A list containing the dimensions of the hidden layers of the fully connected NN.
             This network connects the last hidden layer of the PyTorch RNN module to the output.
@@ -72,8 +72,8 @@ class _BlockRNNModule(nn.Module):
 
         Outputs
         -------
-        y of shape `(batch_size, output_chunk_length, target_size)`
-            Tensor containing the (point) prediction at the last time step of the sequence.
+        y of shape `(batch_size, output_chunk_length, target_size, nr_params)`
+            Tensor containing the prediction at the last time step of the sequence.
         """
 
         super(_BlockRNNModule, self).__init__()

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -197,7 +197,6 @@ class _Stack(nn.Module):
             The number of parameters of the likelihood (or 1 if no likelihood is used)
         expansion_coefficient_dim
             The dimensionality of the waveform generator parameters, also known as expansion coefficients.
-            Only used if `generic_architecture` is set to `True`.
         input_chunk_length
             The length of the input sequence fed to the model.
         target_length

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -89,7 +89,7 @@ class _Block(nn.Module):
             The number of parameters of the likelihood (or 1 if no likelihood is used)
         expansion_coefficient_dim
             The dimensionality of the waveform generator parameters, also known as expansion coefficients.
-            Only used if `generic_architecture` is set to `True`.
+            Used in the generic architecture and the trend module of the interpretable architecture, where it determines the degree of the polynomial basis.
         input_chunk_length
             The length of the input sequence fed to the model.
         target_length

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -86,7 +86,7 @@ class _Block(nn.Module):
         """ PyTorch module implementing the basic building block of the N-BEATS architecture.
 
         The blocks produce outputs of size (target_length, nr_likelihood_params); i.e.
-        "one vector per parameter". The parameters a predicted only for forecast outputs.
+        "one vector per parameter". The parameters are predicted only for forecast outputs.
         Backcast outputs are in the original "domain".
 
         Parameters

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -320,7 +320,7 @@ class _NBEATSModule(nn.Module):
 
         Outputs
         -------
-        y of shape `(batch_size, output_chunk_length)`
+        y of shape `(batch_size, output_chunk_length, target_size/output_dim, nr_params)`
             Tensor containing the output of the NBEATS module.
 
         """

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -578,4 +578,4 @@ class NBEATSModel(TorchParametricProbabilisticForecastingModel, PastCovariatesTo
             output = self.model(x)
             return self.likelihood.sample(output)
         else:
-            return self.model(x)
+            return self.model(x).squeeze(dim=-1)

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -53,6 +53,8 @@ class _SeasonalityGenerator(nn.Module):
         half_minus_one = int(target_length / 2 - 1)
         cos_vectors = [torch.cos(torch.arange(target_length) * 2 * np.pi * i) for i in range(1, half_minus_one + 1)]
         sin_vectors = [torch.sin(torch.arange(target_length) * 2 * np.pi * i) for i in range(1, half_minus_one + 1)]
+        
+        # basis is of size (2 * int(target_length / 2 - 1) + 1, target_length)
         basis = torch.stack([torch.ones(target_length)] + cos_vectors + sin_vectors, dim=1).T
 
         self.basis = nn.Parameter(basis, requires_grad=False)

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -60,7 +60,7 @@ class _RNNModule(nn.Module):
 
         Outputs
         -------
-        y of shape `(batch_size, input_chunk_length, target_size, nr_params)`
+        y of shape `(batch_size, output_chunk_length, target_size, nr_params)`
             Tensor containing the outputs of the RNN at every time step of the input sequence.
             During training the whole tensor is used as output, whereas during prediction we only use y[:, -1, :].
             However, this module always returns the whole Tensor.

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -25,7 +25,8 @@ class _RNNModule(nn.Module):
                  input_size: int,
                  hidden_dim: int,
                  num_layers: int,
-                 target_size: int = 1,
+                 target_size: int,
+                 nr_params: int,
                  dropout: float = 0.):
 
         """ PyTorch module implementing an RNN to be used in `RNNModel`.
@@ -47,11 +48,10 @@ class _RNNModule(nn.Module):
             The number of recurrent layers.
         target_size
             The dimensionality of the output time series.
+        nr_params
+            The number of parameters of the likelihood (or 1 if no likelihood is used).
         dropout
             The fraction of neurons that are dropped in all-but-last RNN layers.
-        likelihood
-            Optionally, the likelihood model to be used for probabilistic forecasts.
-            Expects an instance of 'darts.utils.likelihood_model.Likelihood'.
 
         Inputs
         ------
@@ -60,7 +60,7 @@ class _RNNModule(nn.Module):
 
         Outputs
         -------
-        y of shape `(batch_size, input_length, output_size)`
+        y of shape `(batch_size, input_chunk_length, target_size, nr_params)`
             Tensor containing the outputs of the RNN at every time step of the input sequence.
             During training the whole tensor is used as output, whereas during prediction we only use y[:, -1, :].
             However, this module always returns the whole Tensor.
@@ -70,13 +70,14 @@ class _RNNModule(nn.Module):
 
         # Defining parameters
         self.target_size = target_size
+        self.nr_params = nr_params
         self.name = name
 
         # Defining the RNN module
         self.rnn = getattr(nn, name)(input_size, hidden_dim, num_layers, batch_first=True, dropout=dropout)
 
         # The RNN module needs a linear layer V that transforms hidden states into outputs, individually
-        self.V = nn.Linear(hidden_dim, target_size)
+        self.V = nn.Linear(hidden_dim, target_size * nr_params)
 
     def forward(self, x, h=None):
         # data is of size (batch_size, input_length, input_size)
@@ -89,7 +90,7 @@ class _RNNModule(nn.Module):
         predictions = self.V(out)
 
         # predictions is of size (batch_size, input_length, target_size)
-        predictions = predictions.view(batch_size, -1, self.target_size)
+        predictions = predictions.view(batch_size, -1, self.target_size, self.nr_params)
 
         # returns outputs for all inputs, only the last one is needed for prediction time
         return predictions, last_hidden_state
@@ -227,21 +228,21 @@ class RNNModel(TorchParametricProbabilisticForecastingModel, DualCovariatesTorch
         # historic_future_covariates and future_covariates have the same width
         input_dim = train_sample[0].shape[1] + (train_sample[1].shape[1] if train_sample[1] is not None else 0)
         output_dim = train_sample[-1].shape[1]
+        nr_params = 1 if self.likelihood is None else self.likelihood.num_parameters
 
-        target_size = (
-            self.likelihood.num_parameters * output_dim if self.likelihood is not None else output_dim
-        )
         if self.rnn_type_or_module in ['RNN', 'LSTM', 'GRU']:
             model = _RNNModule(name=self.rnn_type_or_module,
                                input_size=input_dim,
-                               target_size=target_size,
+                               target_size=output_dim,
+                               nr_params=nr_params,
                                hidden_dim=self.hidden_dim,
                                dropout=self.dropout,
                                num_layers=self.n_rnn_layers)
         else:
             model = self.rnn_type_or_module(name='custom_module',
                                             input_size=input_dim,
-                                            target_size=target_size,
+                                            target_size=output_dim,
+                                            nr_params=nr_params,
                                             hidden_dim=self.hidden_dim,
                                             dropout=self.dropout,
                                             num_layers=self.n_rnn_layers)
@@ -272,11 +273,11 @@ class RNNModel(TorchParametricProbabilisticForecastingModel, DualCovariatesTorch
 
     @random_method
     def _produce_predict_output(self, x, last_hidden_state=None):
+        output, hidden = self.model(x, last_hidden_state)
         if self.likelihood:
-            output, hidden = self.model(x, last_hidden_state)
             return self.likelihood.sample(output), hidden
         else:
-            return self.model(x, last_hidden_state)
+            return output.squeeze(dim=-1), hidden
 
     def _get_batch_prediction(self, n: int, input_batch: Tuple, roll_size: int) -> torch.Tensor:
         """

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -120,6 +120,7 @@ class _TCNModule(nn.Module):
                  dilation_base: int,
                  weight_norm: bool,
                  target_size: int,
+                 nr_params: int,   
                  target_length: int,
                  dropout: float):
 
@@ -132,6 +133,8 @@ class _TCNModule(nn.Module):
             The dimensionality of the input time series.
         target_size
             The dimensionality of the output time series.
+        nr_params
+            The number of parameters of the likelihood (or 1)
         input_chunk_length
             The length of the input time series.
         target_length
@@ -156,7 +159,7 @@ class _TCNModule(nn.Module):
 
         Outputs
         -------
-        y of shape `(batch_size, input_chunk_length, 1)`
+        y of shape `(batch_size, input_chunk_length, target_size, nr_params)`
             Tensor containing the predictions of the next 'output_chunk_length' points in the last
             'output_chunk_length' entries of the tensor. The entries before contain the data points
             leading up to the first prediction, all in chronological order.
@@ -171,6 +174,7 @@ class _TCNModule(nn.Module):
         self.kernel_size = kernel_size
         self.target_length = target_length
         self.target_size = target_size
+        self.nr_params = nr_params
         self.dilation_base = dilation_base
         self.dropout = nn.Dropout(p=dropout)
 
@@ -188,7 +192,8 @@ class _TCNModule(nn.Module):
         self.res_blocks_list = []
         for i in range(num_layers):
             res_block = _ResidualBlock(num_filters, kernel_size, dilation_base,
-                                       self.dropout, weight_norm, i, num_layers, self.input_size, target_size)
+                                       self.dropout, weight_norm, i, num_layers, 
+                                       self.input_size, target_size * nr_params)
             self.res_blocks_list.append(res_block)
         self.res_blocks = nn.ModuleList(self.res_blocks_list)
 
@@ -201,7 +206,8 @@ class _TCNModule(nn.Module):
             x = res_block(x)
 
         x = x.transpose(1, 2)
-        x = x.view(batch_size, self.input_chunk_length, self.target_size)
+        x = x.view(batch_size, self.input_chunk_length, self.target_size, self.nr_params)
+        # x = x.view(batch_size, self.input_chunk_length, self.target_size)
 
         return x
 
@@ -323,13 +329,15 @@ class TCNModel(TorchParametricProbabilisticForecastingModel, PastCovariatesTorch
         # samples are made of (past_target, past_covariates, future_target)
         input_dim = train_sample[0].shape[1] + (train_sample[1].shape[1] if train_sample[1] is not None else 0)
         output_dim = train_sample[-1].shape[1]
+        nr_params = 1 if self.likelihood is None else self.likelihood.num_parameters
 
-        target_size = (
+        output_dim = (
             self.likelihood.num_parameters * output_dim if self.likelihood is not None else output_dim
         )
         return _TCNModule(input_size=input_dim,
                           input_chunk_length=self.input_chunk_length,
-                          target_size=target_size,
+                          target_size=output_dim,
+                          nr_params=nr_params,
                           kernel_size=self.kernel_size,
                           num_filters=self.num_filters,
                           num_layers=self.num_layers,

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -331,9 +331,6 @@ class TCNModel(TorchParametricProbabilisticForecastingModel, PastCovariatesTorch
         output_dim = train_sample[-1].shape[1]
         nr_params = 1 if self.likelihood is None else self.likelihood.num_parameters
 
-        output_dim = (
-            self.likelihood.num_parameters * output_dim if self.likelihood is not None else output_dim
-        )
         return _TCNModule(input_size=input_dim,
                           input_chunk_length=self.input_chunk_length,
                           target_size=output_dim,

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -163,6 +163,7 @@ class _TCNModule(nn.Module):
             Tensor containing the predictions of the next 'output_chunk_length' points in the last
             'output_chunk_length' entries of the tensor. The entries before contain the data points
             leading up to the first prediction, all in chronological order.
+            The output contain one value
         """
 
         super(_TCNModule, self).__init__()
@@ -207,7 +208,6 @@ class _TCNModule(nn.Module):
 
         x = x.transpose(1, 2)
         x = x.view(batch_size, self.input_chunk_length, self.target_size, self.nr_params)
-        # x = x.view(batch_size, self.input_chunk_length, self.target_size)
 
         return x
 
@@ -359,7 +359,7 @@ class TCNModel(TorchParametricProbabilisticForecastingModel, PastCovariatesTorch
             output = self.model(x)
             return self.likelihood.sample(output)
         else:
-            return self.model(x)
+            return self.model(x).squeeze(dim=-1)
 
     @property
     def first_prediction_index(self) -> int:

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -134,7 +134,7 @@ class _TCNModule(nn.Module):
         target_size
             The dimensionality of the output time series.
         nr_params
-            The number of parameters of the likelihood (or 1)
+            The number of parameters of the likelihood (or 1 if no likelihood is used).
         input_chunk_length
             The length of the input time series.
         target_length
@@ -163,7 +163,6 @@ class _TCNModule(nn.Module):
             Tensor containing the predictions of the next 'output_chunk_length' points in the last
             'output_chunk_length' entries of the tensor. The entries before contain the data points
             leading up to the first prediction, all in chronological order.
-            The output contain one value
         """
 
         super(_TCNModule, self).__init__()

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -237,8 +237,6 @@ class _TFTModule(nn.Module):
         # output processing -> no dropout at this late stage
         self.pre_output_gan = _GateAddNorm(self.hidden_size, dropout=None)
 
-        # self.output_layer = \
-        #     nn.ModuleList([nn.Linear(self.hidden_size, self.loss_size) for _ in range(self.n_targets)])
         self.output_layer = nn.Linear(self.hidden_size, self.n_targets * self.loss_size)
 
     @property
@@ -487,26 +485,8 @@ class _TFTModule(nn.Module):
 
         # generate output for n_targets and loss_size elements for loss evaluation
         
-        # out = [
-        #     output_layer(out[:, encoder_length:] if self.full_attention else out) for output_layer in self.output_layer
-        # ]
         out = self.output_layer(out[:, encoder_length:] if self.full_attention else out)
-
         out = out.view(batch_size, self.output_chunk_length, self.n_targets, self.loss_size)
-
-        # stack output
-        """
-        if isinstance(self.likelihood, QuantileRegression):
-            # loss_size > 1 for losses such as QuantileLoss
-            # returns shape (n_samples, n_timesteps, n_targets, n_losses)
-            out = torch.cat([out_i.unsqueeze(dim_variable) for out_i in out], dim=dim_variable)
-        elif self.likelihood is not None or self.loss_size == 1 and self.n_targets > 1:
-            # returns shape (n_samples, n_timesteps, n_likelihood_params/n_targets)
-            out = torch.cat(out, dim=dim_variable)
-        else:  # self.loss_size == 1 and self.n_targets == 1
-            # returns shape (n_samples, n_timesteps, 1) for univariate
-            out = out[0]
-        """
 
         # TODO: (Darts) remember this in case we want to output interpretation
         # return self.to_network_output(

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1050,6 +1050,10 @@ class TorchParametricProbabilisticForecastingModel(TorchForecastingModel, ABC):
         and it is passed to the superclass via calling super().__init__. If the likelihood is not
         provided, the model is considered as deterministic.
 
+        All TorchParametricProbabilisticForecastingModel's must produce outputs of shape
+        (batch_size, n_timesteps, n_components, n_params). I.e., there's an extra dimension
+        to store the distribution's parameters.
+
         Parameters
         ----------
         likelihood
@@ -1062,17 +1066,18 @@ class TorchParametricProbabilisticForecastingModel(TorchForecastingModel, ABC):
         return self.likelihood is not None
 
     def _compute_loss(self, output, target):
+        # output is of shape (batch_size, n_timesteps, n_components, n_params)
         if self.likelihood:
             return self.likelihood.compute_loss(output, target)
         else:
-            return super()._compute_loss(output, target)
+            # If there's no likelihood, nr_params=1 and we need to squeeze out the 
+            # last dimension for properly computing the loss.
+            return super()._compute_loss(output, target.squeeze(dim=-1))
 
     @abstractmethod
-    def _produce_predict_output(self, input):
+    def _produce_predict_output(self, x):
         """
         This method has to be implemented by all children.
-
-        TODO: rename parameter as it shadows input name
         """
         pass
 

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1071,8 +1071,8 @@ class TorchParametricProbabilisticForecastingModel(TorchForecastingModel, ABC):
             return self.likelihood.compute_loss(output, target)
         else:
             # If there's no likelihood, nr_params=1 and we need to squeeze out the 
-            # last dimension for properly computing the loss.
-            return super()._compute_loss(output, target.squeeze(dim=-1))
+            # last dimension of model output, for properly computing the loss.
+            return super()._compute_loss(output.squeeze(dim=-1), target)
 
     @abstractmethod
     def _produce_predict_output(self, x):

--- a/darts/tests/test_block_RNN.py
+++ b/darts/tests/test_block_RNN.py
@@ -21,7 +21,8 @@ if TORCH_AVAILABLE:
         pd_series = pd.Series(range(100), index=times)
         series: TimeSeries = TimeSeries.from_series(pd_series)
         module = _BlockRNNModule('RNN', input_size=1, output_chunk_length=1, hidden_dim=25,
-                                 num_layers=1, num_layers_out_fc=[], dropout=0)
+                                 target_size=1, nr_params=1, num_layers=1, 
+                                 num_layers_out_fc=[], dropout=0)
 
         def test_creation(self):
             with self.assertRaises(ValueError):

--- a/darts/tests/test_probabilistic_models.py
+++ b/darts/tests/test_probabilistic_models.py
@@ -145,7 +145,7 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
                       (ContinuousBernoulliLikelihood(), bounded_series, 0.1, 0.1),
                       (HalfNormalLikelihood(), real_pos_series, 0.3, 8),
                       (LogNormalLikelihood(), real_pos_series, 0.3, 1),
-                      (WeibullLikelihood(), real_pos_series, 0.2, 2),
+                      (WeibullLikelihood(), real_pos_series, 0.2, 2.5),
                       (QuantileRegression(), real_series, 0.2, 1))
 
         def test_likelihoods_and_resulting_mean_forecasts(self):

--- a/darts/tests/test_transformer_model.py
+++ b/darts/tests/test_transformer_model.py
@@ -26,6 +26,7 @@ if TORCH_AVAILABLE:
                                     input_chunk_length=1,
                                     output_chunk_length=1,
                                     output_size=1,
+                                    nr_params=1,
                                     d_model=512,
                                     nhead=8,
                                     num_encoder_layers=6,

--- a/darts/utils/likelihood_models.py
+++ b/darts/utils/likelihood_models.py
@@ -264,7 +264,7 @@ class PoissonLikelihood(Likelihood):
         return 1
 
     def _params_from_output(self, model_output):
-        lmbda = self.softplus(model_output)
+        lmbda = self.softplus(model_output.squeeze(dim=-1))
         return lmbda
 
 
@@ -360,7 +360,7 @@ class BernoulliLikelihood(Likelihood):
         return 1
 
     def _params_from_output(self, model_output: torch.Tensor):
-        p = self.sigmoid(model_output)
+        p = self.sigmoid(model_output.squeeze(dim=-1))
         return p
 
 
@@ -515,7 +515,7 @@ class ContinuousBernoulliLikelihood(Likelihood):
         return 1
 
     def _params_from_output(self, model_output: torch.Tensor):
-        lmbda = self.sigmoid(model_output)
+        lmbda = self.sigmoid(model_output.squeeze(dim=-1))
         return lmbda
 
 
@@ -561,7 +561,7 @@ class DirichletLikelihood(Likelihood):
         return 1  # 1 parameter per component
 
     def _params_from_output(self, model_output):
-        alphas = self.softmax(model_output)  # take softmax over components
+        alphas = self.softmax(model_output.squeeze(dim=-1))  # take softmax over components
         return alphas
 
 
@@ -606,7 +606,7 @@ class ExponentialLikelihood(Likelihood):
         return 1
 
     def _params_from_output(self, model_output: torch.Tensor):
-        lmbda = self.softplus(model_output)
+        lmbda = self.softplus(model_output.squeeze(dim=-1))
         return lmbda
 
 
@@ -701,7 +701,7 @@ class GeometricLikelihood(Likelihood):
         return 1
 
     def _params_from_output(self, model_output: torch.Tensor):
-        p = self.sigmoid(model_output)
+        p = self.sigmoid(model_output.squeeze(dim=-1))
         return p
 
 
@@ -795,7 +795,7 @@ class HalfNormalLikelihood(Likelihood):
         return 1
 
     def _params_from_output(self, model_output: torch.Tensor):
-        sigma = self.softplus(model_output)
+        sigma = self.softplus(model_output.squeeze(dim=-1))
         return sigma
 
 

--- a/darts/utils/likelihood_models.py
+++ b/darts/utils/likelihood_models.py
@@ -1024,7 +1024,6 @@ class QuantileRegression(Likelihood):
         dim_q = 3
 
         batch_size, length = model_output.shape[:2]
-        model_output = model_output.view(batch_size, length, -1, len(self.quantiles))
         device = model_output.device
 
         # test if torch model forward produces correct output and store quantiles tensor

--- a/darts/utils/likelihood_models.py
+++ b/darts/utils/likelihood_models.py
@@ -212,9 +212,10 @@ class GaussianLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output):
-        output_size = model_output.shape[-1]
+        # output_size = model_output.shape[-1]
         # mu = model_output[:, :, :output_size // 2]
         # sigma = self.softplus(model_output[:, :, output_size // 2:])
+
         mu = model_output[:,:,:,0]
         sigma = self.softplus(model_output[:,:,:,1])
         return mu, sigma

--- a/darts/utils/likelihood_models.py
+++ b/darts/utils/likelihood_models.py
@@ -212,12 +212,8 @@ class GaussianLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output):
-        # output_size = model_output.shape[-1]
-        # mu = model_output[:, :, :output_size // 2]
-        # sigma = self.softplus(model_output[:, :, output_size // 2:])
-
-        mu = model_output[:,:,:,0]
-        sigma = self.softplus(model_output[:,:,:,1])
+        mu = model_output[:, :, :, 0]
+        sigma = self.softplus(model_output[:, :, :, 1])
         return mu, sigma
 
 
@@ -314,9 +310,8 @@ class NegativeBinomialLikelihood(Likelihood):
         return distr.sample()
 
     def _params_from_output(self, model_output):
-        output_size = model_output.shape[-1]
-        mu = self.softplus(model_output[:, :, :output_size // 2])
-        alpha = self.softplus(model_output[:, :, output_size // 2:])
+        mu = self.softplus(model_output[:, :, :, 0])
+        alpha = self.softplus(model_output[:, :, :, 1])
         return mu, alpha
 
     @property
@@ -415,9 +410,8 @@ class BetaLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output):
-        output_size = model_output.shape[-1]
-        alpha = self.softplus(model_output[:, :, :output_size // 2])
-        beta = self.softplus(model_output[:, :, output_size // 2:])
+        alpha = self.softplus(model_output[:, :, :, 0])
+        beta = self.softplus(model_output[:, :, :, 1])
         return alpha, beta
 
 
@@ -474,9 +468,8 @@ class CauchyLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output):
-        output_size = model_output.shape[-1]
-        xzero = model_output[:, :, :output_size // 2]
-        gamma = self.softplus(model_output[:, :, output_size // 2:])
+        xzero = model_output[:, :, :, 0]
+        gamma = self.softplus(model_output[:, :, :, 1])
         return xzero, gamma
 
 
@@ -662,9 +655,8 @@ class GammaLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output: torch.Tensor):
-        output_size = model_output.shape[-1]
-        alpha = self.softplus(model_output[:, :, :output_size // 2])
-        beta = self.softplus(model_output[:, :, output_size // 2:])
+        alpha = self.softplus(model_output[:, :, :, 0])
+        beta = self.softplus(model_output[:, :, :, 1])
         return alpha, beta
 
 
@@ -757,9 +749,8 @@ class GumbelLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output: torch.Tensor):
-        output_size = model_output.shape[-1]
-        mu = model_output[:, :, :output_size // 2]
-        beta = self.softplus(model_output[:, :, output_size // 2:])
+        mu = model_output[:, :, :, 0]
+        beta = self.softplus(model_output[:, :, :, 1])
         return mu, beta
 
 
@@ -852,9 +843,8 @@ class LaplaceLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output: torch.Tensor):
-        output_size = model_output.shape[-1]
-        mu = model_output[:, :, :output_size // 2]
-        b = self.softplus(model_output[:, :, output_size // 2:])
+        mu = model_output[:, :, :, 0]
+        b = self.softplus(model_output[:, :, :, 1])
         return mu, b
 
 
@@ -902,9 +892,8 @@ class LogNormalLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output):
-        output_size = model_output.shape[-1]
-        mu = model_output[:, :, :output_size // 2]
-        sigma = self.softplus(model_output[:, :, output_size // 2:])
+        mu = model_output[:, :, :, 0]
+        sigma = self.softplus(model_output[:, :, :, 1])
         return mu, sigma
 
 
@@ -947,9 +936,8 @@ class WeibullLikelihood(Likelihood):
         return 2
 
     def _params_from_output(self, model_output: torch.Tensor):
-        output_size = model_output.shape[-1]
-        lmbda = self.softplus(model_output[:, :, :output_size // 2])
-        k = self.softplus(model_output[:, :, output_size // 2:])
+        lmbda = self.softplus(model_output[:, :, :, 0])
+        k = self.softplus(model_output[:, :, :, 1])
         return lmbda, k
 
 

--- a/darts/utils/likelihood_models.py
+++ b/darts/utils/likelihood_models.py
@@ -213,8 +213,10 @@ class GaussianLikelihood(Likelihood):
 
     def _params_from_output(self, model_output):
         output_size = model_output.shape[-1]
-        mu = model_output[:, :, :output_size // 2]
-        sigma = self.softplus(model_output[:, :, output_size // 2:])
+        # mu = model_output[:, :, :output_size // 2]
+        # sigma = self.softplus(model_output[:, :, output_size // 2:])
+        mu = model_output[:,:,:,0]
+        sigma = self.softplus(model_output[:,:,:,1])
         return mu, sigma
 
 


### PR DESCRIPTION
This is a probabilistic version of N-BEATS. N-BEATS is more tricky than the other models to make it probabilistic, because of the way the forecasts are built internally.

The way I've done it is by changing the dimensionality of the tensors returned by the blocks, from `(target_length,)` to `(target_length, nr_params)`, and then reshaping everything correctly to have the parameters at the right place in the output tensors. It requires care, because the time dimension may already contain interleaved dimensions of multivariate series (as N-BEATS is all univariate internally), but I think this is a way to do it that respects the architectural benefits of N-BEATS. There might still be better ways to do it, though.

I've tested with multivariate series, and also with/without generic architecture (see an example with a QuantileRegression Likelihood below).

* Still to do: write a couple of unit tests

![image](https://user-images.githubusercontent.com/4806678/141532349-b81dedba-4fe5-4386-af30-7bddf86e44f9.png)

