### PR TITLE
fix/backtest_tests_random_state

### DIFF
--- a/darts/tests/test_TFT.py
+++ b/darts/tests/test_TFT.py
@@ -39,16 +39,16 @@ if TORCH_AVAILABLE:
             ts_integer_index = TimeSeries.from_values(values=ts_time_index.values())
 
             # model requires future covariates without cyclic encoding
-            model = TFTModel(input_chunk_length=1, output_chunk_length=1, random_state=0)
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1)
             with self.assertRaises(ValueError):
                 model.fit(ts_time_index, verbose=False)
 
             # should work with cyclic encoding for time index
-            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_cyclic_encoder='hour', random_state=0)
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_cyclic_encoder='hour')
             model.fit(ts_time_index, verbose=False)
 
             # should work with relative index both with time index and integer index
-            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_relative_index=True, random_state=0)
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1, add_relative_index=True)
             model.fit(ts_time_index, verbose=False)
             model.fit(ts_integer_index, verbose=False)
 

--- a/darts/tests/test_backtesting.py
+++ b/darts/tests/test_backtesting.py
@@ -155,6 +155,8 @@ class BacktestingTestCase(DartsBaseTestClass):
 
     @unittest.skipUnless(TORCH_AVAILABLE, "requires torch")
     def test_backtest_regression(self):
+        np.random.seed(4)
+
         gaussian_series = gt(mean=2, length=50)
         sine_series = st(length=50)
         features = gaussian_series.stack(sine_series)


### PR DESCRIPTION
### Summary
- fixed bug where backtest unit tests had a chance to fail due to randomness of gaussian timeseries