### PR TITLE
fix/notebooks_save_checkpoints

### DIFF
--- a/examples/07-Transformer-examples.ipynb
+++ b/examples/07-Transformer-examples.ipynb
@@ -154,7 +154,7 @@
     "    dropout = 0.1,\n",
     "    activation = \"relu\",\n",
     "    random_state=42,\n",
-    "    save_checkpotins=True\n",
+    "    save_checkpoints=True\n",
     ")"
    ]
   },


### PR DESCRIPTION
fixes #566

fixed spelling mistake in ./examples/07-Transformer-examples.ipynb