### PR TITLE
fix/prophet_freq_conversion

### DIFF
--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -5,6 +5,7 @@ Facebook Prophet
 
 from typing import Optional, Union, List
 
+import re
 import logging
 import prophet
 import numpy as np
@@ -307,34 +308,43 @@ class Prophet(DualCovariatesForecastingModel):
         freq
             frequency string of the underlying TimeSeries's time index (pd.DateTimeIndex.freq_str)
         """
+
+        # this regex extracts all digits from `freq`: exp: '30S' -> 30
+        freq_times = re.findall(r'\d+', freq)
+        freq_times = 1 if not freq_times else int(freq_times[0])
+
+        # this regex extracts all characters and '-' from `freq` and then extracts left string from '-'
+        # exp: 'W-SUN' -> 'W', '30S' -> 'S'
+        freq = ''.join(re.split('[^a-zA-Z-]*', freq)).split('-')[0]
+
         seconds_per_day = 86400
-        if freq == ['A', 'BYS', 'BA', 'RE'] or freq.startswith(('A', 'BYS', 'BA', 'RE-')):  # year
+        if freq in ['A', 'BA', 'Y', 'BY', 'RE'] or freq.startswith(('A', 'BA', 'Y', 'BY', 'RE')):  # year
             days = 365.25
-        elif freq == ['Q', 'BQ', 'REQ'] or freq.startswith(('Q', 'BQ', 'REQ')):  # quarter
+        elif freq in ['Q', 'BQ', 'REQ'] or freq.startswith(('Q', 'BQ', 'REQ')):  # quarter
             days = 3 * 30.4375
         elif freq in ['M', 'BM', 'CBM', 'SM'] or freq.startswith(('M', 'BM', 'BS', 'CBM', 'SM')):  # month
             days = 30.4375
-        elif freq in 'W' or freq.startswith('W-'):  # week
+        elif freq in ['W']:  # week
             days = 7.
-        elif freq in ['B', 'C'] or freq.startswith(('B-', 'C-')):  # business day
+        elif freq in ['B', 'C']:  # business day
             days = 1 * 7/5
-        elif freq in ['D'] or freq.startswith('D-'):  # day
+        elif freq in ['D']:  # day
             days = 1.
-        elif freq in ['H', 'BH', 'CBH'] or freq.startswith(('H', 'BH', 'CBH')):  # hour
+        elif freq in ['H', 'BH', 'CBH']:  # hour
             days = 1/24
-        elif freq in ['T', 'min'] or freq.startswith(('H', 'BH', 'CBH')):  # minute
+        elif freq in ['T', 'min']:  # minute
             days = 1/(24 * 60)
-        elif freq == 'S' or freq.startswith('S'):  # second
+        elif freq in ['S']:  # second
             days = 1/seconds_per_day
-        elif freq in ['L', 'ms'] or freq.startswith(('L', 'ms')):  # millisecond
+        elif freq in ['L', 'ms']:  # millisecond
             days = 1/(seconds_per_day * 10**3)
-        elif freq == ['U', 'us'] or freq.startswith(('U', 'us')):  # microsecond
+        elif freq in ['U', 'us']:  # microsecond
             days = 1/(seconds_per_day * 10**6)
-        elif freq == 'N' or freq.startswith('N'):  # nanosecond
+        elif freq in ['N']:  # nanosecond
             days = 1/(seconds_per_day * 10**9)
         else:
             raise ValueError("freq {} not understood. Please report if you think this is in error.".format(freq))
-        return days
+        return freq_times * days
 
     def _supports_range_index(self) -> bool:
         """Prophet does not support integer range index."""


### PR DESCRIPTION
Fixes #666.

### Summary

- fixed bug with bad conditions in Prophet._freq_to_str()
- fixed bug where multiplier * `freq_str` like '30S' was not correctly converted before