### PR TITLE
fix/torchmodel_prediction_large_n

### DIFF
--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -288,7 +288,7 @@ class _TFTModule(nn.Module):
         prediction_index = encoder_length - 1
         index[:encoder_length] = index[:encoder_length] / prediction_index
         index[encoder_length:] = index[encoder_length:] / prediction_index
-        return index.resize(1, len(index), 1).repeat(batch_size, 1, 1)
+        return index.reshape(1, len(index), 1).repeat(batch_size, 1, 1)
 
     @staticmethod
     def get_attention_mask_full(time_steps: int,

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1233,62 +1233,81 @@ class PastCovariatesTorchModel(TorchForecastingModel, ABC):
         inpt = torch.cat([past_target, past_covariate], dim=2) if past_covariate is not None else past_target
         return self.model(inpt)
 
-    def _get_batch_prediction(self, n: int, input_batch: Tuple, roll_size: int) -> Tensor:
-        past_target, past_covariates, cov_future = input_batch
-        input_series = torch.cat([past_target, past_covariates], dim=2) if past_covariates is not None else past_target
+    def _get_batch_prediction(self, n: int, input_batch: Tuple, roll_size: int) -> torch.Tensor:
+        """
+        Feeds PastCovariatesTorchModel with input and output chunks of a PastCovariatesSequentialDataset to farecast
+        the next `n` target values per target variable.
 
-        batch_prediction = []
+        Parameters:
+        ----------
+        n
+            prediction length
+        input_batch
+            (past_target, past_covariates, future_past_covariates)
+        roll_size
+            roll input arrays after every sequence by `roll_size`. Initially, `roll_size` is equivalent to
+            `self.output_chunk_length`
+        """
+        dim_component = 2
+        past_target, past_covariates, future_past_covariates = input_batch
 
-        # TODO: remove this "first_prediction_index" and move it into the models that need it
-        out = self._produce_predict_output(input_series)[:, self.first_prediction_index:, :]
+        n_targets = past_target.shape[dim_component]
+        n_past_covs = past_covariates.shape[dim_component] if not past_covariates is None else 0
 
-        batch_prediction.append(out[:, :roll_size, :])
+        input_past = torch.cat(
+            [ds for ds in [past_target, past_covariates] if ds is not None],
+            dim=dim_component
+        )
+
+        out = self._produce_predict_output(input_past)[:, self.first_prediction_index:, :]
+
+        batch_prediction = [out[:, :roll_size, :]]
         prediction_length = roll_size
 
         while prediction_length < n:
+            # we want the last prediction to end exactly at `n` into the future.
+            # this means we may have to truncate the previous prediction and step
+            # back the roll size for the last chunk
+            if prediction_length + self.output_chunk_length > n:
+                spillover_prediction_length = prediction_length + self.output_chunk_length - n
+                roll_size -= spillover_prediction_length
+                prediction_length -= spillover_prediction_length
+                batch_prediction[-1] = batch_prediction[-1][:, :roll_size, :]
 
+            # ==========> PAST INPUT <==========
             # roll over input series to contain latest target and covariate
-            input_series = torch.roll(input_series, -roll_size, 1)
+            input_past = torch.roll(input_past, -roll_size, 1)
 
             # update target input to include next `roll_size` predictions
             if self.input_chunk_length >= roll_size:
-                input_series[:, -roll_size:, :self.output_dim] = out[:, :roll_size, :]
+                input_past[:, -roll_size:, :n_targets] = out[:, :roll_size, :]
             else:
-                input_series[:, :, :self.output_dim] = out[:, -self.input_chunk_length:, :]
+                input_past[:, :, :n_targets] = out[:, -self.input_chunk_length:, :]
 
-            # update covariates to include next `roll_size` predictions into the future
-            if cov_future is not None and self.input_chunk_length >= roll_size:
-                input_series[:, -roll_size:, self.output_dim:] = (
-                    cov_future[:, prediction_length - roll_size:prediction_length, :]
+            # set left and right boundaries for extracting future elements
+            if self.input_chunk_length >= roll_size:
+                left_past, right_past = prediction_length - roll_size, prediction_length
+            else:
+                left_past, right_past = prediction_length - self.input_chunk_length, prediction_length
+
+            # update past covariates to include next `roll_size` future past covariates elements
+            if n_past_covs and self.input_chunk_length >= roll_size:
+                input_past[:, -roll_size:, n_targets:n_targets + n_past_covs] = (
+                    future_past_covariates[:, left_past:right_past, :]
                 )
-            elif cov_future is not None:
-                input_series[:, :, self.output_dim:] = (
-                    cov_future[:, prediction_length - self.input_chunk_length:prediction_length, :]
+            elif n_past_covs:
+                input_past[:, :, n_targets:n_targets + n_past_covs] = (
+                    future_past_covariates[:, left_past:right_past, :]
                 )
 
             # take only last part of the output sequence where needed
-            out = self._produce_predict_output(input_series)[:, self.first_prediction_index:, :]
-
-            # update predictions depending on how many data points have been predicted
-            if prediction_length <= n - self.output_chunk_length - roll_size:
-                batch_prediction.append(out[:, :roll_size, :])
-                prediction_length += roll_size
-            elif prediction_length < n - self.output_chunk_length:
-                # if we produce have `n - output_chunk_length < #predictions < n` we want to only use
-                # the predictions and covariates necessary to exactly reach `n - output_chunk_length`,
-                # so that the final forecast produces exactly the right number of predictions to reach `n`
-                spillover_prediction_length = (prediction_length + roll_size) - (n - self.output_chunk_length)
-                roll_size -= spillover_prediction_length
-                batch_prediction.append(out[:, :roll_size, :])
-                prediction_length += roll_size
-            else:
-                batch_prediction.append(out)
-                prediction_length += self.output_chunk_length
+            out = self._produce_predict_output(input_past)[:, self.first_prediction_index:, :]
+            batch_prediction.append(out)
+            prediction_length += self.output_chunk_length
 
         # bring predictions into desired format and drop unnecessary values
         batch_prediction = torch.cat(batch_prediction, dim=1)
         batch_prediction = batch_prediction[:, :n, :]
-
         return batch_prediction
 
 

--- a/darts/tests/test_global_forecasting_models.py
+++ b/darts/tests/test_global_forecasting_models.py
@@ -12,9 +12,11 @@ from darts.utils.timeseries_generation import linear_timeseries
 logger = get_logger(__name__)
 
 try:
-    from ..models import BlockRNNModel, TCNModel, TransformerModel, NBEATSModel, RNNModel
+    from ..models import BlockRNNModel, TCNModel, TransformerModel, NBEATSModel, RNNModel, TFTModel
     from darts.utils.likelihood_models import GaussianLikelihood
-    from darts.models.forecasting.torch_forecasting_model import DualCovariatesTorchModel
+    from darts.models.forecasting.torch_forecasting_model import (PastCovariatesTorchModel,
+                                                                  DualCovariatesTorchModel,
+                                                                  MixedCovariatesTorchModel)
     import torch
     TORCH_AVAILABLE = True
 except ImportError:
@@ -28,11 +30,13 @@ if TORCH_AVAILABLE:
     models_cls_kwargs_errs = [
         (BlockRNNModel, {'model': 'RNN', 'hidden_size': 10, 'n_rnn_layers': 1, 'batch_size': 32, 'n_epochs': 10}, 180.),
         (RNNModel, {'model': 'RNN', 'hidden_dim': 10, 'batch_size': 32, 'n_epochs': 10}, 180.),
-        (RNNModel, {'training_length': 12, 'n_epochs': 10, 'likelihood': GaussianLikelihood()}, 80),
+        (RNNModel, {'training_length': 12, 'n_epochs': 10, 'likelihood': GaussianLikelihood()}, 80.),
         (TCNModel, {'n_epochs': 10, 'batch_size': 32}, 240.),
         (TransformerModel, {'d_model': 16, 'nhead': 2, 'num_encoder_layers': 2, 'num_decoder_layers': 2,
                             'dim_feedforward': 16, 'batch_size': 32, 'n_epochs': 10}, 180.),
-        (NBEATSModel, {'num_stacks': 4, 'num_blocks': 1, 'num_layers': 2, 'layer_widths': 12, 'n_epochs': 10}, 180.)
+        (NBEATSModel, {'num_stacks': 4, 'num_blocks': 1, 'num_layers': 2, 'layer_widths': 12, 'n_epochs': 10}, 180.),
+        (TFTModel, {'hidden_size': 16, 'lstm_layers': 1, 'num_attention_heads': 4, 'add_relative_index': True,
+                    'n_epochs': 10}, 100.)
     ]
 
     class GlobalForecastingModelsTestCase(DartsBaseTestClass):
@@ -217,6 +221,30 @@ if TORCH_AVAILABLE:
 
             with self.assertRaises(ValueError):
                 model.predict_from_dataset(n=1, input_series_dataset=unsupported_type)
+
+        def test_prediction_with_different_n(self):
+            # test model predictions for n < out_len, n == out_len and n > out_len
+            for model_cls, kwargs, err in models_cls_kwargs_errs:
+                model = model_cls(input_chunk_length=IN_LEN, output_chunk_length=OUT_LEN, **kwargs)
+
+                self.assertTrue(isinstance(model, (PastCovariatesTorchModel,
+                                                   DualCovariatesTorchModel,
+                                                   MixedCovariatesTorchModel)),
+                                'unit test not yet defined for the given {X}CovariatesTorchModel.')
+
+                if isinstance(model, PastCovariatesTorchModel):
+                    past_covs, future_covs = self.covariates, None
+                elif isinstance(model, DualCovariatesTorchModel):
+                    past_covs, future_covs = None, self.covariates
+                else:
+                    past_covs, future_covs = self.covariates, self.covariates
+
+                model.fit(self.target_past, past_covariates=past_covs, future_covariates=future_covs, epochs=1)
+
+                # test prediction for n < out_len, n == out_len and n > out_len
+                for n in [OUT_LEN - 1, OUT_LEN, 2 * OUT_LEN - 1]:
+                    pred = model.predict(n=n, past_covariates=past_covs, future_covariates=future_covs)
+                    self.assertEqual(len(pred), n)
 
         def test_same_result_with_different_n_jobs(self):
             for model_cls, kwargs, err in models_cls_kwargs_errs:


### PR DESCRIPTION
PastCovariatesTorchModels (such as NBEATSModel) prediction failed when `n > output_chunk_length` AND `n` not being a multiple of `output_chunk_length`.

Fixes #673.

### Summary

- refactored `_get_batch_prediction()` for PastCovariatesTorchModel by taking TFTModels implementation for past covariates.
- added unit tests
- fixed deprecation warning in TFTModel
- added TFTModel to global forecasting model unit tests