### PR TITLE
Feat/added 'None' option in ModelMode Enum

### DIFF
--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -35,6 +35,7 @@ class TrendMode(Enum):
 class ModelMode(Enum):
     MULTIPLICATIVE = 'multiplicative'
     ADDITIVE = 'additive'
+    NONE = None
 
 
 # TODO: we do not check the time index here


### PR DESCRIPTION
This is necessary to turn of seasonality or trend in the `ExponentialSmoothing` model