### PR TITLE
Feat/future covariate slicing

### DIFF
--- a/darts/models/forecasting/arima.py
+++ b/darts/models/forecasting/arima.py
@@ -58,8 +58,9 @@ class ARIMA(DualCovariatesForecastingModel):
             return f'ARIMA{self.order}'
         return f'SARIMA{self.order}x{self.seasonal_order}'
 
-    def fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
-        super().fit(series, future_covariates)
+    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None) -> None:
+
+        super()._fit(series, future_covariates)
         m = staARIMA(
             self.training_series.values(),
             exog=future_covariates.values() if future_covariates else None,
@@ -69,16 +70,16 @@ class ARIMA(DualCovariatesForecastingModel):
         )
         self.model = m.fit()
 
-    def predict(self, n: int,
-                future_covariates: Optional[TimeSeries] = None,
-                num_samples: int = 1):
+    def _predict(self, n: int,
+                 future_covariates: Optional[TimeSeries] = None,
+                 num_samples: int = 1) -> TimeSeries:
 
         if num_samples > 1 and self.trend:
             logger.warn('Trends are not well supported yet for getting probabilistic forecasts with ARIMA.'
                         'If you run into issues, try calling fit() with num_samples=1 or removing the trend from'
                         'your model.')
 
-        super().predict(n, future_covariates, num_samples)
+        super()._predict(n, future_covariates, num_samples)
 
         if num_samples == 1:
             forecast = self.model.forecast(steps=n,

--- a/darts/models/forecasting/auto_arima.py
+++ b/darts/models/forecasting/auto_arima.py
@@ -41,16 +41,16 @@ class AutoARIMA(DualCovariatesForecastingModel):
     def __str__(self):
         return 'Auto-ARIMA'
 
-    def fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
-        super().fit(series, future_covariates)
+    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+        super()._fit(series, future_covariates)
         series = self.training_series
         self.model.fit(series.values(),
                        X=future_covariates.values() if future_covariates else None)
 
-    def predict(self, n: int,
-                future_covariates: Optional[TimeSeries] = None,
-                num_samples: int = 1):
-        super().predict(n, future_covariates, num_samples)
+    def _predict(self, n: int,
+                 future_covariates: Optional[TimeSeries] = None,
+                 num_samples: int = 1):
+        super()._predict(n, future_covariates, num_samples)
         forecast = self.model.predict(n_periods=n,
                                       X=future_covariates.values() if future_covariates else None)
         return self._build_forecast_series(forecast)
@@ -61,7 +61,6 @@ class AutoARIMA(DualCovariatesForecastingModel):
 
     def _supports_range_index(self) -> bool:
         raise_if(self.trend and self.trend != "c",
-            "'trend' is not None. Range indexing is not supported in that case.",
-            logger
-        )
+                 "'trend' is not None. Range indexing is not supported in that case.",
+                 logger)
         return True

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -871,12 +871,10 @@ class DualCovariatesForecastingModel(ForecastingModel, ABC):
 
     _expect_covariate = False
 
-    @abstractmethod
     def fit(self,
             series: TimeSeries,
-            future_covariates: Optional[TimeSeries] = None
-            ) -> None:
-        """ Fits/trains the model on the provided series
+            future_covariates: Optional[TimeSeries] = None) -> None:
+        """ Fits/trains the model on the provided series.
 
         Defines behavior that should happen when calling the `fit()` method for the forecasting models handling
         optional future covariates (exogenous variables).
@@ -890,19 +888,34 @@ class DualCovariatesForecastingModel(ForecastingModel, ABC):
             some models as an input.
         """
 
-        # TODO: is this really needed or could we find a workaround?
         if future_covariates is not None:
+            if not series.has_same_time_as(future_covariates):
+                # fit() expects future_covariates to have same time as the target, so we intersect it here
+                future_covariates = future_covariates.slice_intersect(series)
+
             raise_if_not(series.has_same_time_as(future_covariates),
-                         'The target series and the future_covariates series must have the same time index.')
+                         "The provided `future_covariates` series must contain at least the same time steps/indices "
+                         "as the target `series`.",
+                         logger)
             self._expect_covariate = True
+
         super().fit(series)
 
+        self._fit(series, future_covariates=future_covariates)
+
     @abstractmethod
+    def _fit(self,
+             series: TimeSeries,
+             future_covariates: Optional[TimeSeries] = None) -> None:
+        """Fits/trains the model on the provided series.
+        DualCovariatesModels must implement the fit logic in this method.
+        """
+        pass
+
     def predict(self,
                 n: int,
                 future_covariates: Optional[TimeSeries] = None,
-                num_samples: int = 1
-                ) -> TimeSeries:
+                num_samples: int = 1) -> TimeSeries:
         """ Forecasts values for a certain number of time steps after the end of the series.
 
         If some future covariates were specified during the training, they must also be specified here.
@@ -922,30 +935,46 @@ class DualCovariatesForecastingModel(ForecastingModel, ABC):
         -------
         TimeSeries, a single time series containing the `n` next points after then end of the training series.
         """
+
         if future_covariates is None:
             super().predict(n, num_samples)
-        if self._expect_covariate and future_covariates is None:
-            raise_log(ValueError('The model has been trained with future_covariates variables. Some matching '
-                                 'future_covariates variables have to be provided to `predict()`.'))
 
-        # TODO Here we could maybe slice the series and then check
-        if self._expect_covariate and len(future_covariates) != n:
-            raise_log(ValueError(f'Expecting future_covariates variables with the same length as the'
-                                 f' forecasting horizon ({n}).'))
+        if self._expect_covariate and future_covariates is None:
+            raise_log(ValueError('The model has been trained with `future_covariates` variable. Some matching '
+                                 '`future_covariates` variables have to be provided to `predict()`.'))
+
+        if future_covariates is not None:
+            start = self.training_series.end_time() + self.training_series.freq
+
+            invalid_time_span_error = f"For the given forecasting horizon `n={n}`, the provided `future_covariates` " \
+                                      f"series must contain at least the next `n={n}` time steps/indices after the " \
+                                      f"end of the target `series` that was used to train the model."
+
+            # we raise an error here already to avoid getting error from empty TimeSeries creation
+            raise_if_not(future_covariates.end_time() >= start, invalid_time_span_error, logger)
+
+            future_covariates = future_covariates[start:start + (n - 1) * self.training_series.freq]
+
+            raise_if_not(len(future_covariates) == n and self._expect_covariate, invalid_time_span_error, logger)
+
+        return self._predict(n, future_covariates=future_covariates, num_samples=num_samples)
+
+    @abstractmethod
+    def _predict(self,
+                 n: int,
+                 future_covariates: Optional[TimeSeries] = None,
+                 num_samples: int = 1) -> TimeSeries:
+        """Forecasts values for a certain number of time steps after the end of the series.
+        DualCovariatesModels must implement the predict logic in this method.
+        """
+        pass
 
     def _fit_wrapper(self, series: TimeSeries, past_covariates: Optional[TimeSeries],
                      future_covariates: Optional[TimeSeries]):
-        if future_covariates is not None and not series.has_same_time_as(future_covariates):
-            # fit() expects future_covariates to have same time as the target, so we intersect it here
-            # in case it's longer.
-            future_covariates = future_covariates.slice_intersect(series)
         self.fit(series, future_covariates=future_covariates)
 
     def _predict_wrapper(self, n: int, series: TimeSeries,
                          past_covariates: Optional[TimeSeries],
                          future_covariates: Optional[TimeSeries],
                          num_samples: int) -> TimeSeries:
-        if future_covariates is not None:
-            start = series.end_time() + series.freq
-            future_covariates = future_covariates[start:start + (n - 1) * series.freq]
         return self.predict(n, future_covariates=future_covariates, num_samples=num_samples)

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -87,11 +87,11 @@ class Prophet(DualCovariatesForecastingModel):
     def __str__(self):
         return 'Prophet'
 
-    def fit(self,
-            series: TimeSeries,
-            future_covariates: Optional[TimeSeries] = None) -> None:
+    def _fit(self,
+             series: TimeSeries,
+             future_covariates: Optional[TimeSeries] = None) -> None:
 
-        super().fit(series, future_covariates)
+        super()._fit(series, future_covariates)
         series = self.training_series
 
         fit_df = pd.DataFrame(data={
@@ -120,12 +120,12 @@ class Prophet(DualCovariatesForecastingModel):
 
         execute_and_suppress_output(self.model.fit, logger, logging.WARNING, fit_df)
 
-    def predict(self,
-                n: int,
-                future_covariates: Optional[TimeSeries] = None,
-                num_samples: int = 1) -> TimeSeries:
+    def _predict(self,
+                 n: int,
+                 future_covariates: Optional[TimeSeries] = None,
+                 num_samples: int = 1) -> TimeSeries:
 
-        super().predict(n, future_covariates, num_samples)
+        super()._predict(n, future_covariates, num_samples)
 
         predict_df = self._generate_predict_df(n=n, future_covariates=future_covariates)
 

--- a/darts/tests/test_local_forecasting_models.py
+++ b/darts/tests/test_local_forecasting_models.py
@@ -148,7 +148,6 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
 
             # Test models runnability - proper future covariates slicing
             model.fit(self.ts_gaussian, future_covariates=self.ts_gaussian_long)
-            print(model)
             prediction = model.predict(self.forecasting_horizon, future_covariates=self.ts_gaussian_long)
 
             self.assertTrue(len(prediction) == self.forecasting_horizon)

--- a/darts/tests/test_local_forecasting_models.py
+++ b/darts/tests/test_local_forecasting_models.py
@@ -59,6 +59,7 @@ dual_models = [ARIMA()]
 try:
     from ..models import Prophet
     models.append((Prophet(), 13.5))
+    dual_models.append(Prophet())
 except ImportError:
     logger.warning("Prophet not installed - will be skipping Prophet tests")
 
@@ -89,6 +90,10 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
     # dummy timeseries for runnability tests
     np.random.seed(1)
     ts_gaussian = tg.gaussian_timeseries(length=100, mean=50)
+    # for testing covariate slicing
+    ts_gaussian_long = tg.gaussian_timeseries(length=len(ts_gaussian) + 2 * forecasting_horizon,
+                                              start=ts_gaussian.start_time() - forecasting_horizon * ts_gaussian.freq,
+                                              mean=50)
 
     # real timeseries for functionality tests
     ts_passengers = AirPassengersDataset().load()
@@ -141,14 +146,10 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
     def test_exogenous_variables_support(self):
         for model in dual_models:
 
-            # Test models runnability
-            model.fit(self.ts_gaussian, future_covariates=self.ts_gaussian)
-
-            prediction = model.predict(
-                self.forecasting_horizon,
-                future_covariates=tg.gaussian_timeseries(
-                    length=self.forecasting_horizon,
-                    start=self.ts_gaussian.end_time() + self.ts_gaussian.freq))
+            # Test models runnability - proper future covariates slicing
+            model.fit(self.ts_gaussian, future_covariates=self.ts_gaussian_long)
+            print(model)
+            prediction = model.predict(self.forecasting_horizon, future_covariates=self.ts_gaussian_long)
 
             self.assertTrue(len(prediction) == self.forecasting_horizon)
 
@@ -163,6 +164,7 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
                 model.fit(self.ts_gaussian, future_covariates=self.ts_gaussian[:-1])
             with self.assertRaises(ValueError):
                 model.fit(self.ts_gaussian[1:], future_covariates=self.ts_gaussian[:-1])
+
 
     def test_dummy_series(self):
         values = np.random.uniform(low=-10, high=10, size=100)

--- a/darts/tests/test_local_forecasting_models.py
+++ b/darts/tests/test_local_forecasting_models.py
@@ -165,7 +165,6 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
             with self.assertRaises(ValueError):
                 model.fit(self.ts_gaussian[1:], future_covariates=self.ts_gaussian[:-1])
 
-
     def test_dummy_series(self):
         values = np.random.uniform(low=-10, high=10, size=100)
         ts = TimeSeries.from_dataframe(pd.DataFrame({"V1": values}))


### PR DESCRIPTION
## Summary
- all local forecasting models that support covariates (Prophet, ARIMA, VARIMA, AutoARIMA) now handle covariate slicing themselves.
- this makes it more consistent with the way GlobalForecastingModels handle covariates.