### PR TITLE
Feat/extend map to stochastic

### DIFF
--- a/darts/tests/dataprocessing/transformers/test_boxcox.py
+++ b/darts/tests/dataprocessing/transformers/test_boxcox.py
@@ -40,7 +40,7 @@ class BoxCoxTestCase(unittest.TestCase):
         self.assertNotEqual(lmbda1, lmbda2)
 
     def test_boxcox_transform(self):
-        log_mapper = Mapper(lambda x: log(x))
+        log_mapper = Mapper(lambda x: np.log(x))
         boxcox = BoxCox(lmbda=0)
 
         transformed1 = log_mapper.transform(self.sine_series)

--- a/darts/tests/dataprocessing/transformers/test_boxcox.py
+++ b/darts/tests/dataprocessing/transformers/test_boxcox.py
@@ -46,7 +46,9 @@ class BoxCoxTestCase(unittest.TestCase):
         transformed1 = log_mapper.transform(self.sine_series)
         transformed2 = boxcox.fit(self.sine_series).transform(self.sine_series)
 
-        self.assertEqual(transformed1, transformed2)
+        np.testing.assert_almost_equal(transformed1.all_values(copy=False), 
+                                       transformed2.all_values(copy=False), 
+                                       decimal=4)
 
     def test_boxcox_inverse(self):
         boxcox = BoxCox()

--- a/darts/tests/dataprocessing/transformers/test_mappers.py
+++ b/darts/tests/dataprocessing/transformers/test_mappers.py
@@ -1,6 +1,8 @@
 import unittest
 import pandas as pd
+import numpy as np
 
+from darts import TimeSeries
 from darts.dataprocessing.transformers.mappers import Mapper, InvertibleMapper
 from darts.utils.timeseries_generation import constant_timeseries, linear_timeseries
 
@@ -82,3 +84,13 @@ class MappersTestCase(unittest.TestCase):
             transformed = self.subtract_month_invertible.transform(data)
             back = self.subtract_month_invertible.inverse_transform(transformed)
             self.assertEqual(back, data)
+
+    def test_invertible_mappers_on_stochastic_series(self):
+        vals = np.random.rand(10, 2, 100) + 2
+        series = TimeSeries.from_values(vals)
+
+        imapper = InvertibleMapper(np.log, np.exp)
+        tr = imapper.transform(series)
+        inv_tr = imapper.inverse_transform(tr)
+
+        np.testing.assert_almost_equal(series.all_values(copy=False), inv_tr.all_values(copy=False))

--- a/darts/tests/test_encoders.py
+++ b/darts/tests/test_encoders.py
@@ -79,7 +79,6 @@ class EncoderTestCase(DartsBaseTestClass):
 
     @unittest.skipUnless(TORCH_AVAILABLE, 'Torch not available. SequentialEncoder tests with models will be skipped.')
     def test_sequence_encoder_from_model_params(self):
-        print('was called')
         """test if sequence encoder is initialized properly from model params"""
         # valid encoder model parameters are ('past', 'future') for the main key and datetime attribute for sub keys
         valid_encoder_args = {

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1807,18 +1807,21 @@ class TimeSeries:
             fn: Union[Callable[[np.number], np.number],
                       Callable[[Union[pd.Timestamp, int], np.number], np.number]]) -> 'TimeSeries':  # noqa: E501
         """
-        Applies the function `fn` elementwise to all values in this TimeSeries.
-        Returns a new TimeSeries instance. If `fn` takes 1 argument it is simply applied elementwise.
-        If it takes 2 arguments, it is applied elementwise on the (timestamp, value) tuples.
-
-        At the moment this function works only on deterministic time series (i.e., made of 1 sample).
+        Applies the function `fn` to the underlying NumPy array containing this series' values.
+        Returns a new TimeSeries instance. If `fn` takes 1 argument it is simply applied on the backing array
+        of shape (time, n_components, n_samples).
+        If it takes 2 arguments, it is applied repeteadly on the (ts, value[ts]) tuples, where
+        "ts" denotes a timestamp value, and "value[ts]" denote the array of values at this timestamp, of shape
+        (n_components, n_samples).
 
         Parameters
         ----------
         fn
-            Either a function which takes a value and returns a value ie. `f(x) = y`
-            Or a function which takes a value and its timestamp and returns a value ie. `f(timestamp, x) = y`
-            The type of `timestamp` is either `pd.Timestamp` (if the series is indexed with a DatetimeIndex),
+            Either a function which takes a NumPy array and returns a NumPy array of same shape; 
+            e.g., `lambda x: x ** 2` or `lambda x: x / x.shape[0]`.
+            It can also be a function which takes a timestamp and array, and returns a new array of same shape;
+            e.g., `lambda ts, x: x / ts.days_in_month`.
+            The type of `ts` is either `pd.Timestamp` (if the series is indexed with a DatetimeIndex),
             or an integer otherwise (if the series is indexed with an Int64Index).
 
         Returns
@@ -1843,18 +1846,23 @@ class TimeSeries:
                 raise_log(ValueError("inspect.signature(fn) failed. Try wrapping fn in a lambda, e.g. lambda x: fn(x)"),
                           logger)
 
-        if num_args == 1:  # simple map function f(x)
-            df = self.pd_dataframe().applymap(fn)
+        new_xa = self._xa.copy()
+        if num_args == 1:  # apply fn on values directly
+            new_xa.values = fn(self._xa.values)
+            
         elif num_args == 2:  # map function uses timestamp f(timestamp, x)
-            def apply_fn_wrapper(row):
-                timestamp = row.name
-                return row.map(lambda x: fn(timestamp, x))
-            df = self.pd_dataframe().apply(apply_fn_wrapper, axis=1)
+
+            # Poor man's solution - we iterate over all timestamps 
+            # (not sure there's a better solution here)
+            ars = []
+            for ts in self.time_index:
+                vals = self._xa.sel({self._time_dim: ts})
+                ars.append(np.expand_dims(fn(ts, vals), 0))
+            new_xa.values = np.vstack(ars)
         else:
-            df = None
             raise_log(ValueError("fn must have either one or two arguments"), logger)
 
-        return self.__class__.from_dataframe(df)
+        return self.__class__(new_xa)
 
     def to_json(self) -> str:
         """

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1818,7 +1818,7 @@ class TimeSeries:
         ----------
         fn
             Either a function which takes a NumPy array and returns a NumPy array of same shape; 
-            e.g., `lambda x: x ** 2` or `lambda x: x / x.shape[0]`.
+            e.g., `lambda x: x ** 2`, `lambda x: x / x.shape[0]` or `np.log`.
             It can also be a function which takes a timestamp and array, and returns a new array of same shape;
             e.g., `lambda ts, x: x / ts.days_in_month`.
             The type of `ts` is either `pd.Timestamp` (if the series is indexed with a DatetimeIndex),


### PR DESCRIPTION
`TimeSeries.map()` was not working on stochastic series; this solves the issue. It also slightly changes the API of the method. Now it expects functions that can act on NumPy arrays (rather than on isolated scalars). Most elementwise lambdas (such as `lambda x: x**2`) should keep working though.

It also makes `Mapper`s work properly (incl with inverse transforms on stochastic forecasts).

Fixes: https://github.com/unit8co/darts/issues/684 https://github.com/unit8co/darts/issues/687