### PR TITLE
Change some relative imports into absolute

### DIFF
--- a/darts/dataprocessing/dtw/dtw.py
+++ b/darts/dataprocessing/dtw/dtw.py
@@ -4,8 +4,8 @@ import copy
 
 from .window import Window, CRWindow, NoWindow
 from .cost_matrix import CostMatrix
-from ...timeseries import TimeSeries
-from ...logging import get_logger, raise_if_not, raise_if
+from darts import TimeSeries
+from darts.logging import get_logger, raise_if_not, raise_if
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/dtw/window.py
+++ b/darts/dataprocessing/dtw/window.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Tuple
 from dataclasses import dataclass
 import numpy as np
-from ...logging import raise_if_not, raise_if
+from darts.logging import raise_if_not, raise_if
 from abc import ABC, abstractmethod
 from math import tan, atan
 import array

--- a/darts/datasets/dataset_loaders.py
+++ b/darts/datasets/dataset_loaders.py
@@ -8,7 +8,7 @@ import pandas as pd
 import numpy as np
 import requests
 
-from ..timeseries import TimeSeries
+from darts import TimeSeries
 
 
 @dataclass

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -7,10 +7,10 @@ Some metrics to compare time series.
 
 import numpy as np
 
-from ..timeseries import TimeSeries
+from darts import TimeSeries
 from darts.utils import _parallel_apply, _build_tqdm_iterator
-from ..utils.statistics import check_seasonality
-from ..logging import raise_if_not, get_logger, raise_log
+from darts.utils.statistics import check_seasonality
+from darts.logging import raise_if_not, get_logger, raise_log
 from warnings import warn
 from typing import Optional, Callable, Sequence, Union, Tuple
 from inspect import signature

--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -3,7 +3,7 @@ Models
 ------
 """
 
-from ..logging import get_logger
+from darts.logging import get_logger
 
 logger = get_logger(__name__)
 

--- a/darts/tests/models/forecasting/test_encoders.py
+++ b/darts/tests/models/forecasting/test_encoders.py
@@ -22,7 +22,7 @@ from darts.logging import get_logger
 logger = get_logger(__name__)
 
 try:
-    from ..models import TFTModel
+    from darts.models import TFTModel
 
     TORCH_AVAILABLE = True
 except ImportError:

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -12,7 +12,7 @@ from darts.logging import get_logger
 logger = get_logger(__name__)
 
 try:
-    from ..models import RNNModel, TCNModel, NBEATSModel
+    from darts.models import RNNModel, TCNModel, NBEATSModel
 
     TORCH_AVAILABLE = True
 except ImportError:

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -12,7 +12,7 @@ from darts.utils.timeseries_generation import linear_timeseries
 logger = get_logger(__name__)
 
 try:
-    from ..models import (
+    from darts.models import (
         BlockRNNModel,
         TCNModel,
         TransformerModel,

--- a/darts/tests/models/forecasting/test_local_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_local_forecasting_models.py
@@ -63,7 +63,7 @@ dual_models = [ARIMA()]
 
 
 try:
-    from ..models import Prophet
+    from darts.models import Prophet
 
     models.append((Prophet(), 13.5))
     dual_models.append(Prophet())
@@ -71,7 +71,7 @@ except ImportError:
     logger.warning("Prophet not installed - will be skipping Prophet tests")
 
 try:
-    from ..models import AutoARIMA
+    from darts.models import AutoARIMA
 
     models.append((AutoARIMA(), 12.2))
     dual_models.append(AutoARIMA())
@@ -81,7 +81,7 @@ except ImportError:
     PMDARIMA_AVAILABLE = False
 
 try:
-    from ..models import TCNModel  # noqa: F401
+    from darts.models import TCNModel  # noqa: F401
 
     TORCH_AVAILABLE = True
 except ImportError:

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 try:
     import torch
-    from ..models import (
+    from darts.models import (
         RNNModel,
         TCNModel,
         TransformerModel,

--- a/darts/tests/models/forecasting/test_prophet.py
+++ b/darts/tests/models/forecasting/test_prophet.py
@@ -6,7 +6,7 @@ from darts.logging import get_logger
 logger = get_logger(__name__)
 
 try:
-    from ..models import Prophet
+    from darts.models import Prophet
 
     PROPHET_AVAILABLE = True
 except ImportError:

--- a/darts/tests/test_datasets.py
+++ b/darts/tests/test_datasets.py
@@ -1119,7 +1119,7 @@ if TORCH_AVAILABLE:
             )
 
         def test_get_matching_index(self):
-            from ..utils.data.utils import _get_matching_index
+            from darts.utils.data.utils import _get_matching_index
 
             # Check dividable freq
             times1 = pd.date_range(start="20100101", end="20100330", freq="D")

--- a/darts/utils/data/horizon_based_dataset.py
+++ b/darts/utils/data/horizon_based_dataset.py
@@ -6,8 +6,8 @@ Horizon-Based Training Dataset
 from typing import Union, Optional, Sequence, Tuple
 import numpy as np
 
-from ...logging import raise_if_not, get_logger
-from ...timeseries import TimeSeries
+from darts.logging import raise_if_not, get_logger
+from darts import TimeSeries
 from .training_dataset import PastCovariatesTrainingDataset
 from .utils import CovariateType
 

--- a/darts/utils/data/inference_dataset.py
+++ b/darts/utils/data/inference_dataset.py
@@ -9,8 +9,8 @@ from abc import ABC, abstractmethod
 from torch.utils.data import Dataset
 from typing import Union, Sequence, Optional, Tuple
 
-from ...timeseries import TimeSeries
-from ...logging import raise_if_not
+from darts import TimeSeries
+from darts.logging import raise_if_not
 from .utils import CovariateType
 
 

--- a/darts/utils/data/sequential_dataset.py
+++ b/darts/utils/data/sequential_dataset.py
@@ -6,7 +6,7 @@ Sequential Training Dataset
 from typing import Union, Sequence, Optional, Tuple
 import numpy as np
 
-from ...timeseries import TimeSeries
+from darts import TimeSeries
 from .utils import CovariateType
 from .training_dataset import (PastCovariatesTrainingDataset,
                                FutureCovariatesTrainingDataset,

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -14,7 +14,7 @@ from .training_dataset import (TrainingDataset,
                                DualCovariatesTrainingDataset,
                                MixedCovariatesTrainingDataset,
                                SplitCovariatesTrainingDataset)
-from darts.utils import raise_if_not
+from darts.logging import raise_if_not
 
 
 class PastCovariatesShiftedDataset(PastCovariatesTrainingDataset):

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -6,7 +6,7 @@ Shifted Training Dataset
 from typing import Union, Sequence, Optional, Tuple
 import numpy as np
 
-from ...timeseries import TimeSeries
+from darts import TimeSeries
 from .utils import CovariateType
 from .training_dataset import (TrainingDataset,
                                PastCovariatesTrainingDataset,
@@ -14,7 +14,7 @@ from .training_dataset import (TrainingDataset,
                                DualCovariatesTrainingDataset,
                                MixedCovariatesTrainingDataset,
                                SplitCovariatesTrainingDataset)
-from ..utils import raise_if_not
+from darts.utils import raise_if_not
 
 
 class PastCovariatesShiftedDataset(PastCovariatesTrainingDataset):

--- a/darts/utils/data/training_dataset.py
+++ b/darts/utils/data/training_dataset.py
@@ -9,8 +9,8 @@ import numpy as np
 
 from typing import Tuple, Optional, Dict
 from .utils import CovariateType
-from ...logging import get_logger, raise_if_not
-from ...timeseries import TimeSeries
+from darts.logging import get_logger, raise_if_not
+from darts import TimeSeries
 
 logger = get_logger(__name__)
 SampleIndexType = Tuple[int, int, int, int, int, int]

--- a/darts/utils/data/utils.py
+++ b/darts/utils/data/utils.py
@@ -2,8 +2,8 @@ import pandas as pd
 from enum import Enum
 from typing import Union
 
-from ...timeseries import TimeSeries
-from ...logging import raise_if_not
+from darts import TimeSeries
+from darts.logging import raise_if_not
 
 # Those freqs can be used to divide Time deltas (the others can't):
 DIVISIBLE_FREQS = {'D', 'H', 'T', 'min', 'S', 'L', 'ms', 'U', 'us', 'N'}

--- a/darts/utils/model_selection.py
+++ b/darts/utils/model_selection.py
@@ -5,7 +5,7 @@ Utilities that help in model selection e.g. by splitting a dataset.
 """
 
 from typing import Sequence, Optional, Union, Tuple
-from ..timeseries import TimeSeries
+from darts import TimeSeries
 
 MODEL_AWARE = 'model-aware'
 SIMPLE = 'simple'

--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -14,8 +14,8 @@ from statsmodels.tsa.seasonal import seasonal_decompose
 from statsmodels.tsa.stattools import acf, pacf, grangercausalitytests, adfuller, kpss
 
 from warnings import warn
-from ..logging import raise_log, get_logger, raise_if_not, raise_if
-from ..timeseries import TimeSeries
+from darts.logging import raise_log, get_logger, raise_if_not, raise_if
+from darts import TimeSeries
 from .missing_values import fill_missing_values
 from .utils import SeasonalityMode, ModelMode
 

--- a/darts/utils/timeseries_generation.py
+++ b/darts/utils/timeseries_generation.py
@@ -11,8 +11,8 @@ import numpy as np
 import pandas as pd
 import holidays
 
-from ..timeseries import TimeSeries
-from ..logging import raise_if_not, get_logger, raise_log, raise_if
+from darts import TimeSeries
+from darts.logging import raise_if_not, get_logger, raise_log, raise_if
 
 logger = get_logger(__name__)
 

--- a/darts/utils/torch.py
+++ b/darts/utils/torch.py
@@ -10,7 +10,7 @@ from sklearn.utils import check_random_state
 from torch.random import fork_rng, manual_seed
 from numpy.random import randint
 
-from ..logging import raise_if_not, get_logger
+from darts.logging import raise_if_not, get_logger
 
 T = TypeVar('T')
 logger = get_logger(__name__)

--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -5,8 +5,8 @@ Additional util functions
 import pandas as pd
 import numpy as np
 
-from ..timeseries import TimeSeries
-from ..logging import raise_log, get_logger, raise_if_not, raise_if
+from darts import TimeSeries
+from darts.logging import raise_log, get_logger, raise_if_not, raise_if
 from typing import List, Callable, TypeVar, Iterator, Tuple
 from IPython import get_ipython
 from tqdm import tqdm


### PR DESCRIPTION
We had some imports using relative paths. Sometimes those were wrong which was causing tests to be skipped. These changes increase coverage from 85% to 91%.