### PR TITLE
Fix/support for ReduceLROnPlateau scheduler

### DIFF
--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -892,7 +892,9 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                 loss.backward()
                 self.optimizer.step()
                 total_loss += loss.item()
-            if self.lr_scheduler is not None:
+            if isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
+                self.lr_scheduler.step(loss)
+            elif self.lr_scheduler is not None:
                 self.lr_scheduler.step()
 
             if tb_writer is not None:


### PR DESCRIPTION
Addresses #707. This only adds limited support for `ReduceLROnPlateau` in the sense that it only takes the training loss as `metrics` argument to its `step()` method. To add, say, validation loss we would have to change a few more things since the lr_scheduler is called at every epoch of the training loop, whereas new validation losses are not necessarily computed everytime. I guess it's not worth spending too much time on this considering the new PTL refactoring.