### PR TITLE
added check for untrained models for copying of model parameters

### DIFF
--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -26,11 +26,6 @@ class EnsembleModel(GlobalForecastingModel):
         List of forecasting models whose predictions to ensemble
     """
     def __init__(self, models: Union[List[ForecastingModel], List[GlobalForecastingModel]]):
-        raise_if(any([m._fit_called for m in models]),
-                 "Cannot instantiate EnsembleModel with trained/fitted models. "
-                 "Consider resetting all models with `my_model.untrained_model()`",
-                 logger)
-
         raise_if_not(isinstance(models, list) and models,
                      "Cannot instantiate EnsembleModel with an empty list of models",
                      logger)
@@ -42,6 +37,12 @@ class EnsembleModel(GlobalForecastingModel):
         raise_if_not(is_local_ensemble or self.is_global_ensemble,
                      "All models must either be GlobalForecastingModel instances, or none of them should be.",
                      logger)
+
+        raise_if(any([m._fit_called for m in models]),
+                 "Cannot instantiate EnsembleModel with trained/fitted models. "
+                 "Consider resetting all models with `my_model.untrained_model()`",
+                 logger)
+
         super().__init__()
         self.models = models
         self.is_single_series = None

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -26,6 +26,11 @@ class EnsembleModel(GlobalForecastingModel):
         List of forecasting models whose predictions to ensemble
     """
     def __init__(self, models: Union[List[ForecastingModel], List[GlobalForecastingModel]]):
+        raise_if(any([m._fit_called for m in models]),
+                 "Cannot instantiate EnsembleModel with trained/fitted models. "
+                 "Consider resetting all models with `my_model.untrained_model()`",
+                 logger)
+
         raise_if_not(isinstance(models, list) and models,
                      "Cannot instantiate EnsembleModel with an empty list of models",
                      logger)

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -33,6 +33,15 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
     seq1 = [_make_ts(0), _make_ts(10), _make_ts(20)]
     cov1 = [_make_ts(5), _make_ts(15), _make_ts(25)]
 
+    def test_untrained_models(self):
+        model = NaiveDrift()
+        _ = NaiveEnsembleModel([model])
+
+        # trained models should raise error
+        model.fit(self.series1)
+        with self.assertRaises(ValueError):
+            NaiveEnsembleModel([model])
+
     def test_input_models_local_models(self):
         with self.assertRaises(ValueError):
             NaiveEnsembleModel([])


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Addresses #724.

### Summary

- instantiating ensemble models with fitted/trained forecasting model resulted in deepcopy error. 
- added check for untrained models with explanatory error message.