### PR TITLE
fixed non contiguous error when using lstm_layers > 1 on gpu

### DIFF
--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -482,11 +482,15 @@ class _TFTModule(nn.Module):
 
         # LSTM
         # calculate initial state
-        input_hidden = self.static_context_hidden_encoder_grn(static_embedding).expand(
-            self.lstm_layers, -1, -1
+        input_hidden = (
+            self.static_context_hidden_encoder_grn(static_embedding)
+            .expand(self.lstm_layers, -1, -1)
+            .contiguous()
         )
-        input_cell = self.static_context_cell_encoder_grn(static_embedding).expand(
-            self.lstm_layers, -1, -1
+        input_cell = (
+            self.static_context_cell_encoder_grn(static_embedding)
+            .expand(self.lstm_layers, -1, -1)
+            .contiguous()
         )
 
         # run local lstm encoder


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #722, #730

- fixes TFTModel non contiguous error with `lstm_layers > 1` on GPU.
- no performance losses observed