### PR TITLE
Fix/revert numpydoc docstrings

### DIFF
--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -502,28 +502,32 @@ def plot_acf(
 ) -> None:
     """
     Plots the ACF of `ts`, highlighting it at lag `m`, with corresponding significance interval.
-    This function uses the `Statsmodels module <https://github.com/statsmodels/statsmodels>`_.
+    Uses :func:`statsmodels.tsa.stattools.acf` [1]_
 
     Parameters
     ----------
-    ts : TimeSeries
+    ts
         The TimeSeries whose ACF should be plotted.
-    m : int, optional
+    m
         Optionally, a time lag to highlight on the plot.
-    max_lag : int, default: 24
+    max_lag
         The maximal lag order to consider.
-    alpha : float, default: 0.05
+    alpha
         The confidence interval to display.
-    bartlett_confint : bool, default: True
+    bartlett_confint
         The boolean value indicating whether the confidence interval should be
         calculated using Bartlett's formula. If set to True, the confidence interval
         can be used in the model identification stage for fitting ARIMA models.
         If set to False, the confidence interval can be used to test for randomness
         (i.e. there is no time dependence in the data) of the data.
-    fig_size : tuple of int, default: (10, 5)
+    fig_size
         The size of the figure to be displayed.
-    axis : plt.axis, optional
+    axis
         Optionally, an axis object to plot the ACF on.
+
+    References
+    ----------
+    .. [1] https://www.statsmodels.org/dev/generated/statsmodels.tsa.stattools.acf.html
     """
 
     ts._assert_univariate()
@@ -584,17 +588,17 @@ def plot_pacf(
 ) -> None:
     """
     Plots the Partial ACF of `ts`, highlighting it at lag `m`, with corresponding significance interval.
-    This function uses the `Statsmodels module <https://github.com/statsmodels/statsmodels>`_.
+    Uses :func:`statsmodels.tsa.stattools.pacf` [1]_
 
     Parameters
     ----------
-    ts : TimeSeries
+    ts
         The TimeSeries whose ACF should be plotted.
-    m : int, optional
+    m
         Optionally, a time lag to highlight on the plot.
-    max_lag : int, default: 24
+    max_lag
         The maximal lag order to consider.
-    method : str, default: "ywadjusted"
+    method
         The method to be used for the PACF calculation.
         - | "yw" or "ywadjusted" : Yule-Walker with sample-size adjustment in
           | denominator for acovf. Default.
@@ -608,12 +612,16 @@ def plot_pacf(
           correction.
         - "ldb" or "ldbiased" : Levinson-Durbin recursion without bias
           correction.
-    alpha : float, default: 0.05
+    alpha
         The confidence interval to display.
-    fig_size : tuple of int, default: (10, 5)
+    fig_size
         The size of the figure to be displayed.
-    axis : plt.axis, optional
+    axis
         Optionally, an axis object to plot the ACF on.
+
+    References
+    ----------
+    .. [1] https://www.statsmodels.org/dev/generated/statsmodels.tsa.stattools.pacf.html
     """
 
     ts._assert_univariate()
@@ -759,7 +767,7 @@ def plot_residuals_analysis(
         Univariate TimeSeries instance representing residuals.
     num_bins
         Optionally, an integer value determining the number of bins in the histogram.
-    fill_nan:
+    fill_nan
         A boolean value indicating whether NaN values should be filled in the residuals.
     """
 

--- a/darts/utils/timeseries_generation.py
+++ b/darts/utils/timeseries_generation.py
@@ -378,26 +378,26 @@ def autoregressive_timeseries(
 
     Parameters
     ----------
-    coef : list of float
+    coef
         The autoregressive coefficients used for calculating the next time step.
         series[t] = coef[-1] * series[t-1] + coef[-2] * series[t-2] + ... + coef[0] * series[t-len(coef)]
-    start_values : list of float, default: np.ones(len(coef))
+    start_values
         The starting values used for calculating the first few values for which no lags exist yet.
         series[0] = coef[-1] * starting_values[-1] + coef[-2] * starting_values[-2] + ... + coef[0] * starting_values[0]
-    start : pd.Timestamp or int, default: pd.Timestamp('2000-01-01')
+    start
         The start of the returned TimeSeries' index. If a pandas Timestamp is passed, the TimeSeries will have a pandas
         DatetimeIndex. If an integer is passed, the TimeSeries will have a pandas Int64Index index. Works only with
         either `length` or `end`.
-    end : pd.Timestamp or int, optional
+    end
         Optionally, the end of the returned index. Works only with either `start` or `length`. If `start` is
         set, `end` must be of same type as `start`. Else, it can be either a pandas Timestamp or an integer.
-    length : int, optional
+    length
         Optionally, the length of the returned index. Works only with either `start` or `end`.
-    freq : str, default: 'D'
+    freq
         The time difference between two adjacent entries in the returned TimeSeries. Only effective if `start` is a
         pandas Timestamp. A DateOffset alias is expected; see
         `docs <https://pandas.pydata.org/pandas-docs/stable/user_guide/TimeSeries.html#dateoffset-objects>`_.
-    column_name : str, default: 'autoregressive'
+    column_name
         Optionally, the name of the value column for the returned TimeSeries
 
     Returns


### PR DESCRIPTION
### Summary

Updated docstrings for some statistics and time series generation functions to have docs look more uniform:
- reverted numpydoc docstring formatting (type hints in docstring)
- added references where links were previously in the description of the function