### PR TITLE
Feat/set up flake8

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Migrate code style to Black
 3416fc7fb1986687d800ab06594c901f93879e44
+# Fix flake8 issues
+96125f839c115e49d44699ab7d911e8413d4d0b6

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -15,6 +15,10 @@ jobs:
         uses: psf/black@stable
         with:
           version: "21.12b0"
+      - name: "3. Lint using flake8"
+        uses: py-actions/flake8@v2
+        with:
+          flake8-version: "4.0.1"
 
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,6 +15,10 @@ jobs:
         uses: psf/black@stable
         with:
           version: "21.12b0"
+      - name: "3. Lint using flake8"
+        uses: py-actions/flake8@v2
+        with:
+          flake8-version: "4.0.1"
 
   tests:
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,9 @@ repos:
     hooks:
       - id: black-jupyter
         language_version: python3
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+        language_version: python3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,4 @@ To ensure you don't need to worry about formatting when contributing, it is reco
 - [Black integration in Git](https://black.readthedocs.io/en/stable/integrations/source_version_control.html):
     1. Install the pre-commit hook using `pre-commit install`
     2. Black will automatically format all files before committing
+    3. This will also enable flake8 linting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ and discuss it with some of the core team.
         * `refactor/`
         * …
     * Work on your update
-7. Check that your code passes all the tests and design new unit tests if needed: `./gradlew unitTest_all`.
+7. Check that your code passes all the tests and design new unit tests if needed: `./gradlew test_all`.
 8. Verify your tests coverage by running `./gradlew coverageTest`
     * Additionally you can generate an xml report and use VSCode Coverage gutter to identify untested 
     lines with `./coverage.sh xml`

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,5 +6,5 @@ testfixtures==6.17.1
 pytest-cov
 
 # linters
-flake8
+flake8==4.0.1
 black[jupyter]==21.12b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,5 @@ exclude =
     __pycache__,
     .pytest_cache,
     __init__.py
-ignore = W503
 max-line-length = 120
+extend-ignore = E203


### PR DESCRIPTION
Fixes #718.

- Sets up flake8 to be compatible with Black
- Enforces flake8 in CI
- Add flake8 pre-commit hook

TODO:
- [x] Add .git-blame-ignore-revs file for commit applying black to codebase (see #748)
- [x] Add more pre-commit documentation