### PR TITLE
Make TimeSeries.shift() tests pass on pandas 1.0.5

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1734,6 +1734,8 @@ class TimeSeries:
             new_time_index = self._time_index + n * self.freq
         else:
             new_time_index = self._time_index.map(lambda ts: ts + n * self.freq)
+            if new_time_index.freq is None:
+                new_time_index.freq = self.freq
         new_xa = self._xa.assign_coords({self._xa.dims[0]: new_time_index})
         return self.__class__(new_xa)
 


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #.

### Summary

Currently, TimeSeries.shift(...) fails on pandas 1.0.5 if the frequency cannot be inferred. This fix solves the problem and makes it possible to use darts with pandas 1.0.5

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->