### PR TITLE
Fix wrong seasonality basis generator for NBEATS

### DIFF
--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -50,11 +50,11 @@ class _SeasonalityGenerator(nn.Module):
         super().__init__()
         half_minus_one = int(target_length / 2 - 1)
         cos_vectors = [
-            torch.cos(torch.arange(target_length) * 2 * np.pi * i)
+            torch.cos(torch.arange(target_length) / target_length * 2 * np.pi * i)
             for i in range(1, half_minus_one + 1)
         ]
         sin_vectors = [
-            torch.sin(torch.arange(target_length) * 2 * np.pi * i)
+            torch.sin(torch.arange(target_length) / target_length * 2 * np.pi * i)
             for i in range(1, half_minus_one + 1)
         ]
 


### PR DESCRIPTION
Fixes https://github.com/unit8co/darts/issues/803.

### Summary

It fixes wrong seasonality basis vectors generated for NBEATS interpretable model. Now the basis vectors are normalized by the horizon length as it is done in the paper.

### Other Information

--