### PR TITLE
Feat/stochastic inputs

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1176,6 +1176,28 @@ class TimeSeries:
         else:
             return self._xa.values[:, :, sample]
 
+    def random_component_values(self, copy=True) -> np.array:
+        """
+        Return a 2-D array of shape (time, component), containing the values for
+        one sample taken uniformly at random among this series' samples.
+
+        Parameters
+        ----------
+        copy
+            Whether to return a copy of the values, otherwise returns a view.
+            Leave it to True unless you know what you are doing.
+
+        Returns
+        -------
+        numpy.ndarray
+            The values composing one sample taken at random from the time series.
+        """
+        sample = np.random.randint(low=0, high=self.n_components)
+        if copy:
+            return np.copy(self._xa.values[:, :, sample])
+        else:
+            return self._xa.values[:, :, sample]
+
     def all_values(self, copy=True) -> np.ndarray:
         """
         Return a 3-D array of dimension (time, component, sample),

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1192,7 +1192,7 @@ class TimeSeries:
         numpy.ndarray
             The values composing one sample taken at random from the time series.
         """
-        sample = np.random.randint(low=0, high=self.n_components)
+        sample = np.random.randint(low=0, high=self.n_samples)
         if copy:
             return np.copy(self._xa.values[:, :, sample])
         else:

--- a/darts/utils/data/horizon_based_dataset.py
+++ b/darts/utils/data/horizon_based_dataset.py
@@ -109,7 +109,7 @@ class HorizonBasedDataset(PastCovariatesTrainingDataset):
         # determine the index of the time series.
         ts_idx = idx // self.nr_samples_per_ts
         ts_target = self.target_series[ts_idx]
-        target_vals = ts_target.values(copy=False)
+        target_vals = ts_target.random_component_values(copy=False)
 
         raise_if_not(
             len(target_vals)
@@ -168,7 +168,9 @@ class HorizonBasedDataset(PastCovariatesTrainingDataset):
                 f"({idx}-th sample)",
             )
 
-            covariate = ts_covariate.values(copy=False)[cov_start:cov_end]
+            covariate = ts_covariate.random_component_values(copy=False)[
+                cov_start:cov_end
+            ]
 
             raise_if_not(
                 len(covariate) == len(past_target),

--- a/darts/utils/data/inference_dataset.py
+++ b/darts/utils/data/inference_dataset.py
@@ -163,7 +163,9 @@ class GenericInferenceDataset(InferenceDataset):
         )
 
         # extract past target values
-        past_target = target_series.values(copy=False)[-self.input_chunk_length :]
+        past_target = target_series.random_component_values(copy=False)[
+            -self.input_chunk_length :
+        ]
 
         # optionally, extract covariates
         cov_past, cov_future = None, None
@@ -181,7 +183,9 @@ class GenericInferenceDataset(InferenceDataset):
             )
 
             # extract covariate values and split into a past (historic) and future part
-            covariate = covariate_series.values(copy=False)[cov_start:cov_end]
+            covariate = covariate_series.random_component_values(copy=False)[
+                cov_start:cov_end
+            ]
             if self.input_chunk_length != 0:  # regular models
                 cov_past, cov_future = (
                     covariate[: self.input_chunk_length],

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -522,7 +522,7 @@ class GenericShiftedDataset(TrainingDataset):
         # determine the index of the time series.
         ts_idx = idx // self.max_samples_per_ts
         ts_target = self.target_series[ts_idx]
-        target_vals = ts_target.values(copy=False)
+        target_vals = ts_target.random_component_values(copy=False)
 
         # determine the actual number of possible samples in this time series
         n_samples_in_ts = len(target_vals) - self.size_of_both_chunks + 1
@@ -582,7 +582,9 @@ class GenericShiftedDataset(TrainingDataset):
                 f"that don't extend far enough into the future. ({idx}-th sample)",
             )
 
-            covariate = ts_covariate.values(copy=False)[cov_start:cov_end]
+            covariate = ts_covariate.random_component_values(copy=False)[
+                cov_start:cov_end
+            ]
 
             raise_if_not(
                 len(covariate)


### PR DESCRIPTION
Handle stochastic series for `fit()` and `predict()` in Torch-based models.

When fitting: a sample is drawn from the series uniformly at random (instead of taking always the 1st sample, as before). This way the training procedure can naturally be carried over the stochastic samples.

When predicting: *one* sample is drawn from the series uniformly at random. Unfortunately at the moment it would be quite complicated to batch the forward passes over all of a series' samples, so each call to `predict()` will only return the forecast related to this one sample. However, calling `sample()` many times and concatenating the results allows to get stochastic forecasts even with deterministic models (not using a likelihood) when predicting stochastic series (or using stochastic covariates). Here's an example:

<img width="707" alt="image" src="https://user-images.githubusercontent.com/4806678/156600687-bbee315c-9c0a-4c76-88cc-04ee057a5378.png">
