### PR TITLE
Feat/more losses

### DIFF
--- a/darts/tests/utils/test_losses.py
+++ b/darts/tests/utils/test_losses.py
@@ -1,49 +1,41 @@
-import numpy as np
+import torch
 
-from darts.dataprocessing.transformers import Scaler
-from darts.datasets import AirPassengersDataset
-from darts.metrics import smape
-from darts.models import NBEATSModel
 from darts.tests.base_test_class import DartsBaseTestClass
-from darts.utils.losses import MapeLoss, SmapeLoss
+from darts.utils.losses import MAELoss, MapeLoss, SmapeLoss
 
 
 class LossesTestCase(DartsBaseTestClass):
-    air = AirPassengersDataset().load().astype(np.float32)
-    scaler = Scaler()
-    air_s = scaler.fit_transform(air)
-    air_train, air_val = air_s[:-36], air_s[-36:]
+    x = torch.tensor([1.1, 2.2, 0.6345, -1.436])
+    y = torch.tensor([1.5, 0.5])
+
+    def helper_test_loss(self, exp_loss_val, exp_w_grad, loss_fn):
+        W = torch.tensor([[0.1, -0.2, 0.3, -0.4], [-0.8, 0.7, -0.6, 0.5]])
+        W.requires_grad = True
+        y_hat = W @ self.x
+        lval = loss_fn(y_hat, self.y)
+        lval.backward()
+
+        print(lval)
+        self.assertTrue(torch.allclose(lval, exp_loss_val, atol=1e-3))
+        self.assertTrue(torch.allclose(W.grad, exp_w_grad, atol=1e-3))
 
     def test_smape_loss(self):
-        model = NBEATSModel(
-            input_chunk_length=24,
-            output_chunk_length=12,
-            num_stacks=4,
-            num_blocks=1,
-            layer_widths=64,
-            loss_fn=SmapeLoss(),
-            random_state=42,
+        exp_val = torch.tensor(0.7753)
+        exp_grad = torch.tensor(
+            [[-0.2843, -0.5685, -0.1640, 0.3711], [-0.5859, -1.1718, -0.3380, 0.7649]]
         )
-
-        model.fit(self.air_train, epochs=150)
-
-        pred = model.predict(n=36)
-
-        self.assertLess(smape(pred, self.air_s), 16.5)
+        self.helper_test_loss(exp_val, exp_grad, SmapeLoss())
 
     def test_mape_loss(self):
-        model = NBEATSModel(
-            input_chunk_length=24,
-            output_chunk_length=12,
-            num_stacks=4,
-            num_blocks=1,
-            layer_widths=64,
-            loss_fn=MapeLoss(),
-            random_state=42,
+        exp_val = torch.tensor(1.2937)
+        exp_grad = torch.tensor(
+            [[-0.3667, -0.7333, -0.2115, 0.4787], [-1.1000, -2.2000, -0.6345, 1.4360]]
         )
+        self.helper_test_loss(exp_val, exp_grad, MapeLoss())
 
-        model.fit(self.air_train, epochs=100)
-
-        pred = model.predict(n=36)
-
-        self.assertLess(smape(pred, self.air_s), 13.5)
+    def test_mae_loss(self):
+        exp_val = torch.tensor(1.0020)
+        exp_grad = torch.tensor(
+            [[-0.5500, -1.1000, -0.3173, 0.7180], [-0.5500, -1.1000, -0.3173, 0.7180]]
+        )
+        self.helper_test_loss(exp_val, exp_grad, MAELoss())

--- a/darts/tests/utils/test_losses.py
+++ b/darts/tests/utils/test_losses.py
@@ -29,7 +29,6 @@ class LossesTestCase(DartsBaseTestClass):
 
         pred = model.predict(n=36)
 
-        print("error")
         self.assertLess(smape(pred, self.air_s), 12.0)
 
     def test_mape_loss(self):
@@ -47,5 +46,4 @@ class LossesTestCase(DartsBaseTestClass):
 
         pred = model.predict(n=36)
 
-        print("error")
-        self.assertLess(smape(pred, self.air_s), 11.0)
+        self.assertLess(smape(pred, self.air_s), 13.5)

--- a/darts/tests/utils/test_losses.py
+++ b/darts/tests/utils/test_losses.py
@@ -15,7 +15,6 @@ class LossesTestCase(DartsBaseTestClass):
         lval = loss_fn(y_hat, self.y)
         lval.backward()
 
-        print(lval)
         self.assertTrue(torch.allclose(lval, exp_loss_val, atol=1e-3))
         self.assertTrue(torch.allclose(W.grad, exp_w_grad, atol=1e-3))
 

--- a/darts/tests/utils/test_losses.py
+++ b/darts/tests/utils/test_losses.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from darts.dataprocessing.transformers import Scaler
+from darts.datasets import AirPassengersDataset
+from darts.metrics import smape
+from darts.models import NBEATSModel
+from darts.tests.base_test_class import DartsBaseTestClass
+from darts.utils.losses import MapeLoss, SmapeLoss
+
+
+class LossesTestCase(DartsBaseTestClass):
+    air = AirPassengersDataset().load().astype(np.float32)
+    scaler = Scaler()
+    air_s = scaler.fit_transform(air)
+    air_train, air_val = air_s[:-36], air_s[-36:]
+
+    def test_smape_loss(self):
+        model = NBEATSModel(
+            input_chunk_length=24,
+            output_chunk_length=12,
+            num_stacks=4,
+            num_blocks=1,
+            layer_widths=64,
+            loss_fn=SmapeLoss(),
+            random_state=42,
+        )
+
+        model.fit(self.air_train, epochs=150)
+
+        pred = model.predict(n=36)
+
+        print("error")
+        self.assertLess(smape(pred, self.air_s), 12.0)
+
+    def test_mape_loss(self):
+        model = NBEATSModel(
+            input_chunk_length=24,
+            output_chunk_length=12,
+            num_stacks=4,
+            num_blocks=1,
+            layer_widths=64,
+            loss_fn=MapeLoss(),
+            random_state=42,
+        )
+
+        model.fit(self.air_train, epochs=100)
+
+        pred = model.predict(n=36)
+
+        print("error")
+        self.assertLess(smape(pred, self.air_s), 11.0)

--- a/darts/tests/utils/test_losses.py
+++ b/darts/tests/utils/test_losses.py
@@ -29,7 +29,7 @@ class LossesTestCase(DartsBaseTestClass):
 
         pred = model.predict(n=36)
 
-        self.assertLess(smape(pred, self.air_s), 12.0)
+        self.assertLess(smape(pred, self.air_s), 13.5)
 
     def test_mape_loss(self):
         model = NBEATSModel(

--- a/darts/tests/utils/test_losses.py
+++ b/darts/tests/utils/test_losses.py
@@ -29,7 +29,7 @@ class LossesTestCase(DartsBaseTestClass):
 
         pred = model.predict(n=36)
 
-        self.assertLess(smape(pred, self.air_s), 13.5)
+        self.assertLess(smape(pred, self.air_s), 16.5)
 
     def test_mape_loss(self):
         model = NBEATSModel(

--- a/darts/utils/losses.py
+++ b/darts/utils/losses.py
@@ -52,41 +52,6 @@ class SmapeLoss(nn.Module):
         return torch.mean(_divide_no_nan(num, denom))
 
 
-class SmapeLossM3(nn.Module):
-    """
-    sMAPE loss as defined in the context of the M3 competition, in "Appendix A" of
-    http://www.forecastingprinciples.com/files/pdf/Makridakia-The%20M3%20Competition.pdf
-
-    Given a time series of actual values :math:`y_t` and a time series of predicted values :math:`\\hat{y}_t`
-        both of length :math:`T`, it is computed as
-
-        .. math::
-            \\frac{1}{T}
-            \\sum_{t=1}^{T}{\\frac{\\left| y_t - \\hat{y}_t \\right|}
-                                  {y_t + \\hat{y}_t} }.
-
-        The results of divisions yielding NaN or Inf are replaced by 0.
-
-        Parameters
-        ----------
-        block_denom_grad
-            Whether to stop the gradient in the denomitator
-    """
-
-    def __init__(self, block_denom_grad: bool = True):
-        super().__init__()
-        self.block_denom_grad = block_denom_grad
-
-    def forward(self, inpt, tgt):
-        num = torch.abs(inpt - tgt)
-        if self.block_denom_grad:
-            with torch.no_grad():
-                denom = tgt + inpt
-        else:
-            denom = tgt + inpt
-        return torch.mean(_divide_no_nan(num, denom))
-
-
 class MapeLoss(nn.Module):
     """
     MAPE loss as defined in: https://en.wikipedia.org/wiki/Mean_absolute_percentage_error

--- a/darts/utils/losses.py
+++ b/darts/utils/losses.py
@@ -23,7 +23,7 @@ def _divide_no_nan(a, b):
 class SmapeLoss(nn.Module):
     def __init__(self, block_denom_grad: bool = True):
         """
-        sMAPE loss as defined in https://robjhyndman.com/hyndsight/smape/ (Makridakis 1993)
+        sMAPE loss as defined in https://robjhyndman.com/hyndsight/smape/ (Chen and Yang 2004)
 
         Given a time series of actual values :math:`y_t` and a time series of predicted values :math:`\\hat{y}_t`
         both of length :math:`T`, it is computed as

--- a/darts/utils/losses.py
+++ b/darts/utils/losses.py
@@ -54,7 +54,7 @@ class SmapeLoss(nn.Module):
 
 
 class MapeLoss(nn.Module):
-    def __init__(self, keep_denom: bool = False):
+    def __init__(self, keep_denom: bool = True):
         """
         MAPE loss as defined in: https://en.wikipedia.org/wiki/Mean_absolute_percentage_error.
 
@@ -69,20 +69,11 @@ class MapeLoss(nn.Module):
         100 usually used for computing MAPE values, as it impacts only the magnitude of the gradients
         and not their direction.
 
-        By default, the denominator is not considered and the loss is computed as
-
-        .. math::
-            \\frac{1}{T}
-            \\sum_{t=1}^{T}{\\left| y_t - \\hat{y}_t \\right|}.
-
-        Since the denominator is a constant w.r.t. the model parameters,
-        this only impacts the magnitude of the gradients.
-
         Parameters
         ----------
         keep_denom
             Whether to keep the denominator (:math:`y_t`) in the MAPE computation; otherwise,
-            only the numerator is computed for the loss.
+            only the numerator is computed for the loss (making it equivalent to MAE).
         """
         super().__init__()
         self.keep_denom = keep_denom
@@ -93,3 +84,21 @@ class MapeLoss(nn.Module):
             return torch.mean(_divide_no_nan(num, tgt))
         else:
             return torch.mean(num)
+
+
+class MAELoss(nn.Module):
+    def __init__(self):
+        """
+        MAE loss as defined in: https://en.wikipedia.org/wiki/Mean_absolute_error.
+
+        Given a time series of actual values :math:`y_t` and a time series of predicted values :math:`\\hat{y}_t`
+        both of length :math:`T`, it is computed as
+
+        .. math::
+            \\frac{1}{T}
+            \\sum_{t=1}^{T}{\\left| y_t - \\hat{y}_t \\right|}.
+        """
+        super().__init__()
+
+    def forward(self, inpt, tgt):
+        return torch.mean(torch.abs(tgt - inpt))

--- a/darts/utils/losses.py
+++ b/darts/utils/losses.py
@@ -1,0 +1,99 @@
+"""
+PyTorch Loss Functions
+----------------------
+"""
+# Inspiration: https://github.com/ElementAI/N-BEATS/blob/master/common/torch/losses.py
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+
+def _divide_no_nan(a, b):
+    """
+    a/b where the resulted NaN or Inf are replaced by 0.
+    """
+    result = a / b
+    result[result != result] = 0.0
+    result[result == np.inf] = 0.0
+    return result
+
+
+class SmapeLoss(nn.Module):
+    def __init__(self, block_denom_grad: bool = True):
+        """
+        sMAPE loss as defined in https://robjhyndman.com/hyndsight/smape/ (Makridakis 1993)
+
+        Given a time series of actual values :math:`y_t` and a time series of predicted values :math:`\\hat{y}_t`
+        both of length :math:`T`, it is computed as
+
+        .. math::
+            \\frac{1}{T}
+            \\sum_{t=1}^{T}{\\frac{\\left| y_t - \\hat{y}_t \\right|}
+                                  {\\left| y_t \\right| + \\left| \\hat{y}_t \\right|} }.
+
+        The results of divisions yielding NaN or Inf are replaced by 0.
+
+        Parameters
+        ----------
+        block_denom_grad
+            Whether to stop the gradient in the denomitator
+        """
+        super().__init__()
+        self.block_denom_grad = block_denom_grad
+
+    def forward(self, inpt, tgt):
+        num = torch.abs(tgt - inpt)
+        if self.block_denom_grad:
+            with torch.no_grad():
+                denom = torch.abs(tgt) + torch.abs(inpt)
+        else:
+            denom = torch.abs(tgt) + torch.abs(inpt)
+        return torch.mean(_divide_no_nan(num, denom))
+
+
+class SmapeLossM3(nn.Module):
+    """
+    sMAPE loss as defined in the context of the M3 competition, in "Appendix A" of
+    http://www.forecastingprinciples.com/files/pdf/Makridakia-The%20M3%20Competition.pdf
+
+    Given a time series of actual values :math:`y_t` and a time series of predicted values :math:`\\hat{y}_t`
+        both of length :math:`T`, it is computed as
+
+        .. math::
+            \\frac{1}{T}
+            \\sum_{t=1}^{T}{\\frac{\\left| y_t - \\hat{y}_t \\right|}
+                                  {y_t + \\hat{y}_t} }.
+
+        The results of divisions yielding NaN or Inf are replaced by 0.
+
+        Parameters
+        ----------
+        block_denom_grad
+            Whether to stop the gradient in the denomitator
+    """
+
+    def __init__(self, block_denom_grad: bool = True):
+        super().__init__()
+        self.block_denom_grad = block_denom_grad
+
+    def forward(self, inpt, tgt):
+        num = torch.abs(inpt - tgt)
+        if self.block_denom_grad:
+            with torch.no_grad():
+                denom = tgt + inpt
+        else:
+            denom = tgt + inpt
+        return torch.mean(_divide_no_nan(num, denom))
+
+
+class MapeLoss(nn.Module):
+    """
+    MAPE loss as defined in: https://en.wikipedia.org/wiki/Mean_absolute_percentage_error
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inpt, tgt):
+        return torch.mean(torch.abs(inpt - tgt))

--- a/darts/utils/losses.py
+++ b/darts/utils/losses.py
@@ -72,7 +72,7 @@ class MapeLoss(nn.Module):
         super().__init__()
 
     def forward(self, inpt, tgt):
-        return torch.mean(_divide_no_nan(torch.abs(tgt - inpt), tgt))
+        return torch.mean(torch.abs(_divide_no_nan(tgt - inpt, tgt)))
 
 
 class MAELoss(nn.Module):

--- a/darts/utils/losses.py
+++ b/darts/utils/losses.py
@@ -16,6 +16,7 @@ def _divide_no_nan(a, b):
     result = a / b
     result[result != result] = 0.0
     result[result == np.inf] = 0.0
+    result[result == np.NINF] = 0.0
     return result
 
 

--- a/darts/utils/losses.py
+++ b/darts/utils/losses.py
@@ -54,7 +54,7 @@ class SmapeLoss(nn.Module):
 
 
 class MapeLoss(nn.Module):
-    def __init__(self, keep_denom: bool = True):
+    def __init__(self):
         """
         MAPE loss as defined in: https://en.wikipedia.org/wiki/Mean_absolute_percentage_error.
 
@@ -68,22 +68,11 @@ class MapeLoss(nn.Module):
         The results of divisions yielding NaN or Inf are replaced by 0. Note that we drop the coefficient of
         100 usually used for computing MAPE values, as it impacts only the magnitude of the gradients
         and not their direction.
-
-        Parameters
-        ----------
-        keep_denom
-            Whether to keep the denominator (:math:`y_t`) in the MAPE computation; otherwise,
-            only the numerator is computed for the loss (making it equivalent to MAE).
         """
         super().__init__()
-        self.keep_denom = keep_denom
 
     def forward(self, inpt, tgt):
-        num = torch.abs(tgt - inpt)
-        if self.keep_denom:
-            return torch.mean(_divide_no_nan(num, tgt))
-        else:
-            return torch.mean(num)
+        return torch.mean(_divide_no_nan(torch.abs(tgt - inpt), tgt))
 
 
 class MAELoss(nn.Module):
@@ -97,6 +86,8 @@ class MAELoss(nn.Module):
         .. math::
             \\frac{1}{T}
             \\sum_{t=1}^{T}{\\left| y_t - \\hat{y}_t \\right|}.
+
+        Note that this is the same as torch.nn.L1Loss.
         """
         super().__init__()
 


### PR DESCRIPTION
Add two new PyTorch loss functions (`SmapeLoss` and `MapeLoss`), which can provide different criteria and could for instance be used to replicate some of the M3/M4 competition results.