### PR TITLE
Recognize DARTS_CONFIGURE_MATPLOTLIB=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Darts is still in an early development phase and we cannot always guarantee back
 
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
 [Full Changelog](https://github.com/unit8co/darts/compare/0.19.0...master)
+### For users of the library:
+
+**Improved**
+- Option to avoid global matplotlib configuration changes.
+  [#924](https://github.com/unit8co/darts/pull/924) by [Mike Richman](https://github.com/zgana).
 
 ## [0.19.0](https://github.com/unit8co/darts/tree/0.19.0) (2022-04-13)
 ### For users of the library:

--- a/darts/__init__.py
+++ b/darts/__init__.py
@@ -3,6 +3,8 @@ darts
 -----
 """
 
+import os
+
 import matplotlib as mpl
 from matplotlib import cycler
 
@@ -37,4 +39,5 @@ u8plots_mplstyle = {
 }
 
 
-mpl.rcParams.update(u8plots_mplstyle)
+if os.getenv("DARTS_CONFIGURE_MATPLOTLIB", "1") != "0":
+    mpl.rcParams.update(u8plots_mplstyle)


### PR DESCRIPTION


<!-- Please mention an issue this pull request addresses. -->
Fixes #892.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

This PR makes it possible to import darts without changing the global matplotlib configuration.

* By default, darts still applies matplotlib configurations
* If the environment variable DARTS_CONFIGURE_MATPLOTLIB=0 is set, then darts.u8plots_mplstyle is still defined but not applied.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

Normally it would be best to add tests of the new behavior, but it's difficult to test behavior in the root `__init__.py`.  Both the pre-existing behavior and the adjustment here would be easier to test if the plotting configuration were factored out into some helper module.  That would be a larger (though still fairly small) change.

A larger question would be: _should_ darts change the global matplotlib configuration by default?  Making this opt-in would obviously cause an aesthetic mismatch for anyone following documentation produced prior to that change.  But it would arguably be cleaner (and more testable) to require e.g. `darts.apply_u8plots_mplstyle()` or otherwise respect users' matplotlibrc.

<!--Thank you for contributing to darts! -->
