### PR TITLE
replaced new LinearLR scheduler (only available with torch >= 1.10.0)…

### DIFF
--- a/darts/models/forecasting/block_rnn_model.py
+++ b/darts/models/forecasting/block_rnn_model.py
@@ -78,9 +78,6 @@ class _BlockRNNModule(PLPastCovariatesModule):
 
         super().__init__(**kwargs)
 
-        # required for all modules -> saves hparams for checkpoints
-        self.save_hyperparameters()
-
         # Defining parameters
         self.hidden_dim = hidden_dim
         self.n_layers = num_layers

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -358,9 +358,6 @@ class _NBEATSModule(PLPastCovariatesModule):
         """
         super().__init__(**kwargs)
 
-        # required for all modules -> saves hparams for checkpoints
-        self.save_hyperparameters()
-
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.nr_params = nr_params

--- a/darts/models/forecasting/nhits.py
+++ b/darts/models/forecasting/nhits.py
@@ -347,9 +347,6 @@ class _NHiTSModule(PLPastCovariatesModule):
         """
         super().__init__(**kwargs)
 
-        # required for all modules -> saves hparams for checkpoints
-        self.save_hyperparameters()
-
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.nr_params = nr_params

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -75,6 +75,9 @@ class PLForecastingModule(pl.LightningModule, ABC):
         """
         super().__init__()
 
+        # save hyper parameters for saving/loading
+        self.save_hyperparameters()
+
         raise_if(
             input_chunk_length is None or output_chunk_length is None,
             "Both `input_chunk_length` and `output_chunk_length` must be passed to `PLForecastingModule`",

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -73,9 +73,6 @@ class _RNNModule(PLDualCovariatesModule):
         # RNNModule doesn't really need input and output_chunk_length for PLModule
         super().__init__(**kwargs)
 
-        # required for all modules -> saves hparams for checkpoints
-        self.save_hyperparameters()
-
         # Defining parameters
         self.target_size = target_size
         self.nr_params = nr_params

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -183,9 +183,6 @@ class _TCNModule(PLPastCovariatesModule):
 
         super().__init__(**kwargs)
 
-        # required for all modules -> saves hparams for checkpoints
-        self.save_hyperparameters()
-
         # Defining parameters
         self.input_size = input_size
         self.n_filters = num_filters

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -88,9 +88,6 @@ class _TFTModule(PLMixedCovariatesModule):
 
         super().__init__(**kwargs)
 
-        # required for all modules -> saves hparams for checkpoints
-        self.save_hyperparameters()
-
         self.n_targets, self.loss_size = output_dim
         self.variables_meta = variables_meta
         self.hidden_size = hidden_size

--- a/darts/models/forecasting/transformer_model.py
+++ b/darts/models/forecasting/transformer_model.py
@@ -124,9 +124,6 @@ class _TransformerModule(PLPastCovariatesModule):
 
         super().__init__(**kwargs)
 
-        # required for all modules -> saves hparams for checkpoints
-        self.save_hyperparameters()
-
         self.input_size = input_size
         self.target_size = output_size
         self.nr_params = nr_params

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -324,7 +324,7 @@ if TORCH_AVAILABLE:
             series = TimeSeries.from_series(pd_series)
 
             lr_schedulers = [
-                (torch.optim.lr_scheduler.LinearLR, {}),
+                (torch.optim.lr_scheduler.StepLR, {"step_size": 10}),
                 (
                     torch.optim.lr_scheduler.ReduceLROnPlateau,
                     {"threshold": 0.001, "monitor": "train_loss"},


### PR DESCRIPTION
Fixes #915

### Summary

- replaced LinearLR tests (only available for torch>=1.10.0) scheduler with StepLR (available from torch>=1.8.0)
- moved save_hyperparameters() repetition into parent class PLForecastingModule