### PR TITLE
fixed bug in historical forecasts not training model for first time i…

### DIFF
--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -435,7 +435,7 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
 
             # train_cov = covariates.drop_after(pred_time) if covariates else None
 
-            if retrain:
+            if retrain or not self._fit_called:
                 self._fit_wrapper(
                     series=train,
                     past_covariates=past_covariates,


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #994.

### Summary
- fixes bug where models were not trained for the first time with `retrain=False`
