### PR TITLE
remove logger.setLevel()

### DIFF
--- a/darts/logging.py
+++ b/darts/logging.py
@@ -22,8 +22,6 @@ def get_logger(name):
     """
 
     logger = logging.getLogger(name)
-    # default logging level is logging.INFO
-    logger.setLevel(logging.INFO)
 
     return logger
 

--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -26,7 +26,7 @@ try:
     from darts.models.forecasting.auto_arima import AutoARIMA
     from darts.models.forecasting.tbats import BATS, TBATS
 except ModuleNotFoundError:
-    logger.info(
+    logger.warning(
         "Support for AutoARIMA, BATS and TBATS is not available."
         "To enable it, install u8darts[pmdarima] or u8darts[all]."
     )
@@ -36,7 +36,7 @@ try:
 except ModuleNotFoundError:
     pass
     """
-    logger.info(
+    logger.warning(
         "Support for Facebook Prophet is not available. "
         "To enable it, install the prophet package in your environment; see "
         "https://facebook.github.io/prophet/docs/installation.html"
@@ -53,7 +53,7 @@ try:
     from darts.models.forecasting.transformer_model import TransformerModel
 
 except ModuleNotFoundError:
-    logger.info(
+    logger.warning(
         "Support for Torch based models not available. "
         'To enable them, install "darts", "u8darts[torch]" or "u8darts[all]" (with pip); '
         'or "u8darts-torch" or "u8darts-all" (with conda).'
@@ -62,7 +62,7 @@ except ModuleNotFoundError:
 try:
     from darts.models.forecasting.gradient_boosted_model import LightGBMModel
 except ModuleNotFoundError:
-    logger.info(
+    logger.warning(
         "Support for LightGBM not available."
         "To enable LightGBM support in Darts, follow the detailed "
         "install instructions for LightGBM in the README: "


### PR DESCRIPTION
### Summary

- no usage of `logger.setLevel` in `darts.logging.get_logger` anymore
- users can use `logging.basicConfig()` before importing darts models to decide whether they want the model warning logs