### PR TITLE
reset ptl trainer when loading torch models

### DIFF
--- a/darts/models/components/transformer.py
+++ b/darts/models/components/transformer.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+
+from darts.utils.torch import MonteCarloDropout
+
+
+class CustomFeedForwardEncoderLayer(nn.TransformerEncoderLayer):
+    """Overwrites the PyTorch TransformerEncoderLayer to use Darts' Position-wise Feed-Forward variants."""
+
+    def __init__(self, ffn: nn.Module, dropout: float, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        ffn
+            One of Darts' Position-wise Feed-Forward Network variants from darts.models.components.glu_variants
+        dropout
+            Fraction of neurons affected by Dropout (default=0.1).
+        args
+            positional arguments from torch.nn.TransformerEncoderLayer.
+        kwargs
+            keyword arguments from torch.nn.TransformerEncoderLayer. `activation` will have no effect.
+        """
+        super().__init__(*args, **kwargs)
+        self.ffn = ffn
+        self.dropout = MonteCarloDropout(dropout)
+
+    # overwrite the feed forward block
+    def _ff_block(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.ffn(x)
+        return self.dropout(x)
+
+
+class CustomFeedForwardDecoderLayer(nn.TransformerDecoderLayer):
+    """Overwrites the PyTorch TransformerDecoderLayer to use Darts' custom Position Wise Feed Forward Layers."""
+
+    def __init__(self, ffn: nn.Module, dropout: float, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        ffn
+            One of Darts' Position-wise Feed-Forward Network variants from darts.models.components.glu_variants
+        dropout
+            Fraction of neurons affected by Dropout (default=0.1).
+        args
+            positional arguments from torch.nn.TransformerEncoderLayer.
+        kwargs
+            keyword arguments from torch.nn.TransformerEncoderLayer. `activation` will have no effect.
+        """
+        super().__init__(*args, **kwargs)
+        self.ffn = ffn
+        self.dropout = MonteCarloDropout(dropout)
+
+    # overwrite the feed forward block
+    def _ff_block(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.ffn(x)
+        return self.dropout(x)

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1355,7 +1355,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         path_ptl_ckpt = base_path + "_ptl-ckpt.pth.tar"
         if os.path.exists(path_ptl_ckpt):
             model.model = model.model.__class__.load_from_checkpoint(path_ptl_ckpt)
-            model.trainer = model.model.trainer
+            model.trainer = None
 
         return model
 

--- a/darts/tests/models/forecasting/test_transformer_model.py
+++ b/darts/tests/models/forecasting/test_transformer_model.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 
 import pandas as pd
+import torch.nn as nn
 
 from darts import TimeSeries
 from darts.logging import get_logger
@@ -13,6 +14,8 @@ logger = get_logger(__name__)
 try:
     from darts.models.forecasting.transformer_model import (
         TransformerModel,
+        _CustomFeedForwardDecoderLayer,
+        _CustomFeedForwardEncoderLayer,
         _TransformerModule,
     )
 
@@ -118,14 +121,28 @@ if TORCH_AVAILABLE:
                 )
                 model1.fit(self.series, epochs=1)
 
-            # internal activation function
+            # internal activation function uses PyTorch TransformerEncoderLayer
             model2 = TransformerModel(
                 input_chunk_length=1, output_chunk_length=1, activation="gelu"
             )
             model2.fit(self.series, epochs=1)
+            assert isinstance(
+                model2.model.transformer.encoder.layers[0], nn.TransformerEncoderLayer
+            )
+            assert isinstance(
+                model2.model.transformer.decoder.layers[0], nn.TransformerDecoderLayer
+            )
 
-            # glue variant FFN
+            # glue variant FFN uses our custom _FeedForwardEncoderLayer
             model3 = TransformerModel(
                 input_chunk_length=1, output_chunk_length=1, activation="SwiGLU"
             )
             model3.fit(self.series, epochs=1)
+            assert isinstance(
+                model3.model.transformer.encoder.layers[0],
+                _CustomFeedForwardEncoderLayer,
+            )
+            assert isinstance(
+                model3.model.transformer.decoder.layers[0],
+                _CustomFeedForwardDecoderLayer,
+            )

--- a/darts/tests/models/forecasting/test_transformer_model.py
+++ b/darts/tests/models/forecasting/test_transformer_model.py
@@ -12,10 +12,12 @@ from darts.utils import timeseries_generation as tg
 logger = get_logger(__name__)
 
 try:
+    from darts.models.components.transformer import (
+        CustomFeedForwardDecoderLayer,
+        CustomFeedForwardEncoderLayer,
+    )
     from darts.models.forecasting.transformer_model import (
         TransformerModel,
-        _CustomFeedForwardDecoderLayer,
-        _CustomFeedForwardEncoderLayer,
         _TransformerModule,
     )
 
@@ -140,9 +142,9 @@ if TORCH_AVAILABLE:
             model3.fit(self.series, epochs=1)
             assert isinstance(
                 model3.model.transformer.encoder.layers[0],
-                _CustomFeedForwardEncoderLayer,
+                CustomFeedForwardEncoderLayer,
             )
             assert isinstance(
                 model3.model.transformer.decoder.layers[0],
-                _CustomFeedForwardDecoderLayer,
+                CustomFeedForwardDecoderLayer,
             )


### PR DESCRIPTION
Fixes #1116.

### Summary

- Fixes error when loading TorchForecastingModels where trainer is not associated with a model.
- fixed issue where custom feed forward moduels were ignored in previous PyTorch version