### PR TITLE
fix typo in timeseries

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -649,7 +649,7 @@ class TimeSeries:
         else:
             raise_if_not(
                 isinstance(df.index, VALID_INDEX_TYPES),
-                "If time_col is not specified, the DataFrame must be indexed either with"
+                "If time_col is not specified, the DataFrame must be indexed either with "
                 "a DatetimeIndex, or with a RangeIndex.",
                 logger,
             )


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1115.

### Summary

https://github.com/unit8co/darts/blob/caccce1dc71f58180142d96e70bf06024d68798f/darts/timeseries.py#L652

It would be 

> ValueError: If time_col is not specified, the DataFrame must be indexed either witha DatetimeIndex, or with a RangeIndex.

, which `witha` should be `with a`.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

None

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
