### PR TITLE
MultiOutputRegressor that handles validation data in fit()

### DIFF
--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -31,12 +31,15 @@ import numpy as np
 import pandas as pd
 from catboost import CatBoostRegressor
 from sklearn.linear_model import LinearRegression
-from sklearn.multioutput import MultiOutputRegressor
 
 from darts.logging import get_logger, raise_if, raise_if_not, raise_log
 from darts.models.forecasting.forecasting_model import GlobalForecastingModel
 from darts.timeseries import TimeSeries
+from darts.utils.multioutput import MultiOutputRegressor
 from darts.utils.utils import _check_quantiles
+
+# from sklearn.multioutput import MultiOutputRegressor
+
 
 logger = get_logger(__name__)
 

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -38,9 +38,6 @@ from darts.timeseries import TimeSeries
 from darts.utils.multioutput import MultiOutputRegressor
 from darts.utils.utils import _check_quantiles
 
-# from sklearn.multioutput import MultiOutputRegressor
-
-
 logger = get_logger(__name__)
 
 

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor
 from sklearn.linear_model import LinearRegression
-from sklearn.multioutput import MultiOutputRegressor
 
 import darts
 from darts import TimeSeries
@@ -24,6 +23,9 @@ from darts.models.forecasting.forecasting_model import GlobalForecastingModel
 from darts.tests.base_test_class import DartsBaseTestClass
 from darts.utils import timeseries_generation as tg
 from darts.utils.data.encoders import FutureCyclicEncoder, PastDatetimeAttributeEncoder
+
+# from sklearn.multioutput import MultiOutputRegressor
+from darts.utils.multioutput import MultiOutputRegressor
 
 logger = get_logger(__name__)
 
@@ -725,6 +727,23 @@ class RegressionModelsTestCase(DartsBaseTestClass):
                 self.assertFalse(isinstance(model.model, MultiOutputRegressor))
             else:
                 self.assertTrue(isinstance(model.model, MultiOutputRegressor))
+
+    def test_multioutput_validation(self):
+
+        models = [
+            LightGBMModel(lags=4, output_chunk_length=1),
+            LightGBMModel(lags=4, output_chunk_length=2),
+            CatBoostModel(lags=4, output_chunk_length=1),
+            CatBoostModel(lags=4, output_chunk_length=2),
+        ]
+
+        train, val = self.sine_univariate1.split_after(0.6)
+
+        for model in models:
+            # without validation
+            model.fit(series=train, val_series=None)
+            # with validation
+            model.fit(series=train, val_series=val)
 
     def test_regression_model(self):
         lags = 12

--- a/darts/utils/multioutput.py
+++ b/darts/utils/multioutput.py
@@ -1,0 +1,93 @@
+from joblib import Parallel
+from sklearn.base import is_classifier
+from sklearn.multioutput import MultiOutputRegressor as sk_MultiOutputRegressor
+from sklearn.multioutput import _fit_estimator
+from sklearn.utils.fixes import delayed
+from sklearn.utils.multiclass import check_classification_targets
+from sklearn.utils.validation import _check_fit_params, has_fit_parameter
+
+
+class MultiOutputRegressor(sk_MultiOutputRegressor):
+    """
+    :class:`sklearn.utils.multioutput.MultiOutputRegressor` with a modified ``fit()`` method that also slices
+    validation data correctly. The validation data has to be passed as parameter ``eval_set`` in ``**fit_params``.
+    """
+
+    def fit(self, X, y, sample_weight=None, **fit_params):
+        """Fit the model to data, separately for each output variable.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+
+        y : {array-like, sparse matrix} of shape (n_samples, n_outputs)
+            Multi-output targets. An indicator matrix turns on multilabel
+            estimation.
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights. If `None`, then samples are equally weighted.
+            Only supported if the underlying regressor supports sample
+            weights.
+
+        **fit_params : dict of string -> object
+            Parameters passed to the ``estimator.fit`` method of each step.
+
+            .. versionadded:: 0.23
+
+        Returns
+        -------
+        self : object
+            Returns a fitted instance.
+        """
+
+        if not hasattr(self.estimator, "fit"):
+            raise ValueError("The base estimator should implement a fit method")
+
+        y = self._validate_data(X="no_validation", y=y, multi_output=True)
+
+        if is_classifier(self):
+            check_classification_targets(y)
+
+        if y.ndim == 1:
+            raise ValueError(
+                "y must have at least two dimensions for "
+                "multi-output regression but has only one."
+            )
+
+        if sample_weight is not None and not has_fit_parameter(
+            self.estimator, "sample_weight"
+        ):
+            raise ValueError("Underlying estimator does not support sample weights.")
+
+        fit_params_validated = _check_fit_params(X, fit_params)
+
+        if "eval_set" in fit_params_validated.keys():
+            # with validation set
+            (X_val, y_val) = fit_params_validated.pop("eval_set")
+            self.estimators_ = Parallel(n_jobs=self.n_jobs)(
+                delayed(_fit_estimator)(
+                    self.estimator,
+                    X,
+                    y[:, i],
+                    sample_weight,
+                    eval_set=(X_val, y_val[:, i]),
+                    **fit_params_validated
+                )
+                for i in range(y.shape[1])
+            )
+        else:
+            # without validation set
+            self.estimators_ = Parallel(n_jobs=self.n_jobs)(
+                delayed(_fit_estimator)(
+                    self.estimator, X, y[:, i], sample_weight, **fit_params_validated
+                )
+                for i in range(y.shape[1])
+            )
+
+        if hasattr(self.estimators_[0], "n_features_in_"):
+            self.n_features_in_ = self.estimators_[0].n_features_in_
+        if hasattr(self.estimators_[0], "feature_names_in_"):
+            self.feature_names_in_ = self.estimators_[0].feature_names_in_
+
+        return self


### PR DESCRIPTION
Addresses #1144 

### Summary

This PR solves an issue where validation data that was passed to the `LightGBMModel` or the `CatBoostModel` in `fit()` wasn't handled correctly by the original sklearn `MultiOutputRegressor`.

The solution is a slightly modified `MultiOutputRegressor` class that slices the validation data together with the training data.

- Added `MultiOutputRegressor` in `darts.utils.multioutput` that inherits from sklearn `MultiOutputRegressor` and overwrites its `fit()` method
- `MultiOutpuRegressor.fit()` now slices validation data together with training data as long as it is passed in the parameter `eval_set` as part of `**fit_params`
- Added unit tests that check for this case