### PR TITLE
Issue 651: Renamed hidden_size parameter in BlockRNNModel to hidden_dim

### DIFF
--- a/darts/models/forecasting/block_rnn_model.py
+++ b/darts/models/forecasting/block_rnn_model.py
@@ -130,7 +130,7 @@ class BlockRNNModel(PastCovariatesTorchModel):
         input_chunk_length: int,
         output_chunk_length: int,
         model: Union[str, nn.Module] = "RNN",
-        hidden_size: int = 25,
+        hidden_dim: int = 25,
         n_rnn_layers: int = 1,
         hidden_fc_sizes: Optional[List] = None,
         dropout: float = 0.0,
@@ -162,8 +162,9 @@ class BlockRNNModel(PastCovariatesTorchModel):
             Either a string specifying the RNN module type ("RNN", "LSTM" or "GRU"),
             or a PyTorch module with the same specifications as
             :class:`darts.models.block_rnn_model._BlockRNNModule`.
-        hidden_size
+        hidden_dim
             Size for feature maps for each hidden RNN layer (:math:`h_n`).
+            In Darts version <= 0.21, hidden_dim was referred as hidden_size.
         n_rnn_layers
             Number of layers in the RNN module.
         hidden_fc_sizes
@@ -321,7 +322,7 @@ class BlockRNNModel(PastCovariatesTorchModel):
 
         self.rnn_type_or_module = model
         self.hidden_fc_sizes = hidden_fc_sizes
-        self.hidden_size = hidden_size
+        self.hidden_dim = hidden_dim
         self.n_rnn_layers = n_rnn_layers
         self.dropout = dropout
 
@@ -346,7 +347,7 @@ class BlockRNNModel(PastCovariatesTorchModel):
                 input_size=input_dim,
                 target_size=output_dim,
                 nr_params=nr_params,
-                hidden_dim=self.hidden_size,
+                hidden_dim=self.hidden_dim,
                 num_layers=self.n_rnn_layers,
                 num_layers_out_fc=hidden_fc_sizes,
                 dropout=self.dropout,

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -49,7 +49,7 @@ if TORCH_AVAILABLE:
             BlockRNNModel,
             {
                 "model": "RNN",
-                "hidden_size": 10,
+                "hidden_dim": 10,
                 "n_rnn_layers": 1,
                 "batch_size": 32,
                 "n_epochs": 10,

--- a/examples/04-RNN-examples.ipynb
+++ b/examples/04-RNN-examples.ipynb
@@ -482,7 +482,7 @@
     "    model=\"GRU\",\n",
     "    input_chunk_length=125,\n",
     "    output_chunk_length=36,\n",
-    "    hidden_size=10,\n",
+    "    hidden_dim=10,\n",
     "    n_rnn_layers=1,\n",
     "    batch_size=32,\n",
     "    n_epochs=100,\n",


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Issue #651 

### Summary
Renamed the hidden_size parameter to hidden_dim in BlockRNNModel to match it with RNNModel

