### PR TITLE
Fix for pandas.Int64Index is deprecated and will be removed from pandas in a future version

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4076,9 +4076,7 @@ class TimeSeries:
 
             # restore a RangeIndex if needed:
             time_idx = xa_.get_index(self._time_dim)
-            if time_idx.is_integer() and not isinstance(
-                time_idx, pd.RangeIndex
-            ):
+            if time_idx.is_integer() and not isinstance(time_idx, pd.RangeIndex):
                 xa_ = xa_.assign_coords(
                     {self._time_dim: pd.RangeIndex(start=key, stop=key + 1)}
                 )

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4076,7 +4076,7 @@ class TimeSeries:
 
             # restore a RangeIndex if needed:
             time_idx = xa_.get_index(self._time_dim)
-            if isinstance(time_idx, pd.Int64Index) and not isinstance(
+            if isinstance(time_idx, pd.Index) and not isinstance(
                 time_idx, pd.RangeIndex
             ):
                 xa_ = xa_.assign_coords(

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4076,7 +4076,7 @@ class TimeSeries:
 
             # restore a RangeIndex if needed:
             time_idx = xa_.get_index(self._time_dim)
-            if isinstance(time_idx, pd.Index) and not isinstance(
+            if time_idx.is_integer() and not isinstance(
                 time_idx, pd.RangeIndex
             ):
                 xa_ = xa_.assign_coords(


### PR DESCRIPTION
```
FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.
  from pandas import MultiIndex, Int64Index
```