### PR TITLE
Update the model in case it is wrongly wrapped

### DIFF
--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -497,6 +497,10 @@ class RegressionModel(GlobalForecastingModel):
                         self.model = MultiOutputRegressor(
                             self.model, n_jobs=n_jobs_multioutput_wrapper
                         )
+        # assures the model is a single output regressor in case it is wrongly wrapped on a MultiOutputRegressor
+        # this can happen when using a hyperparameter optimizer
+        elif hasatt(self.model, 'estimator') and self.output_chunk_length == 1:
+            self.model = self.model.estimator
 
         # warn if n_jobs_multioutput_wrapper was provided but not used
         if (


### PR DESCRIPTION
In some situations, like when using a hyperparameter optimizer function, the model can be wrapped on a MultiOutputRegressor and keep this model even when its features do not match this Regressor.

<!-- Please mention an issue this pull request addresses. -->
Fixes #.
Add condition to check when the model has only one chunk length (single output regressor) but it is wrapped on a MultiOutputRegressor.

### Summary

In some situations, like when using a hyperparameter optimizer function, the model can be wrapped on a MultiOutputRegressor and keep this model even when its features do not match this Regressor.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

Example of when the old code would fail:

```
from skopt import gp_minimize

# a custom model wrapping the LightGBMModel from darts, but with get_params and set_params, compatible with sklearn.
model = myLightGBM()

def objective_func(**parms):
    model.set_params(**params)
    model.fit(series)
    pred = model.predict(n=5)

# in search_space, suppose output_chunk_length varies from n>1 to 1.
res_gp = gp_minimize(myLightGBM, search_space)

> Raised error: "y must have at least two dimensions for multi-output regression but has only one."

```
<!--Thank you for contributing to darts! -->
