### PR TITLE
Fix/#1185 corrected type hinting ExponentialSmoothing model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Darts is still in an early development phase, and we cannot always guarantee bac
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
 - Added support for retraining model(s) every `n` iteration and on custom condition in `historical_forecasts` method of `ForecastingModel` abstract class. Addressed issues [#135](https://github.com/unit8co/darts/issues/135) and [#623](https://github.com/unit8co/darts/issues/623) by [Francesco Bruzzesi](https://github.com/fbruzzesi).
 - New LayerNorm alternatives, RMSNorm and LayerNormNoBias [#1113](https://github.com/unit8co/darts/issues/1113) by [Greg DeVos](https://github.com/gdevos010).
+- Fixed type hinting for ExponentialSmoothing model [#1185](https://https://github.com/unit8co/darts/pull/1185) by [Rijk van der Meulen](https://github.com/rijkvandermeulen)
 
 [Full Changelog](https://github.com/unit8co/darts/compare/0.21.0...master)
 

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -34,7 +34,7 @@ class ExponentialSmoothing(ForecastingModel):
         <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.ExponentialSmoothing.html>`_;
         we refer to this link for the original and more complete documentation of the parameters.
 
-        `model_mode` must be a ``ModelMode`` Enum member. You can access the Enum with
+        `trend` must be a ``ModelMode`` Enum member. You can access the Enum with
          ``from darts.utils.utils import ModelMode``.
         `seasonal` must be a ``SeasonalityMode`` Enum member. You can access the Enum with
         ``from darts.utils.utils import SeasonalityMode``.

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -21,7 +21,7 @@ class ExponentialSmoothing(ForecastingModel):
         self,
         trend: Optional[ModelMode] = ModelMode.ADDITIVE,
         damped: Optional[bool] = False,
-        seasonal: Optional[ModelMode] = SeasonalityMode.ADDITIVE,
+        seasonal: Optional[SeasonalityMode] = SeasonalityMode.ADDITIVE,
         seasonal_periods: Optional[int] = None,
         random_state: int = 0,
         **fit_kwargs,

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -36,7 +36,7 @@ class ExponentialSmoothing(ForecastingModel):
 
         `model_mode` must be a ``ModelMode`` Enum member. You can access the Enum with
          ``from darts.utils.utils import ModelMode``.
-        `season_mode` must be a ``SeasonalityMode`` Enum member. You can access the Enum with
+        `seasonal` must be a ``SeasonalityMode`` Enum member. You can access the Enum with
         ``from darts.utils.utils import SeasonalityMode``.
 
         ``ExponentialSmoothing(trend=ModelMode.NONE, seasonal=SeasonalityMode.NONE)`` corresponds to a single

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -34,7 +34,10 @@ class ExponentialSmoothing(ForecastingModel):
         <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.ExponentialSmoothing.html>`_;
         we refer to this link for the original and more complete documentation of the parameters.
 
-        `model_mode` must be a ``ModelMode`` Enum member. You can access the Enum with ``from darts import ModelMode``.
+        `model_mode` must be a ``ModelMode`` Enum member. You can access the Enum with
+         ``from darts.utils.utils import ModelMode``.
+        `season_mode` must be a ``SeasonalityMode`` Enum member. You can access the Enum with
+        ``from darts.utils.utils import SeasonalityMode``.
 
         ``ExponentialSmoothing(trend=ModelMode.NONE, seasonal=SeasonalityMode.NONE)`` corresponds to a single
         exponential smoothing.


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes mistake in type hinting ExponentialSmoothing model

### Summary

`seasonal: Optional[SeasonalityMode]` iso `seasonal: Optional[ModelMode]`

### Other Information

Potentially useful to add mypy to pipeline and pre-commit hooks?

<!--Thank you for contributing to darts! -->
