### PR TITLE
Fix/1214 overwrite min series length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Darts is still in an early development phase, and we cannot always guarantee bac
 - Added support for retraining model(s) every `n` iteration and on custom condition in `historical_forecasts` method of `ForecastingModel` abstract class. Addressed issues [#135](https://github.com/unit8co/darts/issues/135) and [#623](https://github.com/unit8co/darts/issues/623) by [Francesco Bruzzesi](https://github.com/fbruzzesi).
 - New LayerNorm alternatives, RMSNorm and LayerNormNoBias [#1113](https://github.com/unit8co/darts/issues/1113) by [Greg DeVos](https://github.com/gdevos010).
 - Fixed type hinting for ExponentialSmoothing model [#1185](https://https://github.com/unit8co/darts/pull/1185) by [Rijk van der Meulen](https://github.com/rijkvandermeulen)
-
+- Overwrite min_train_series_length for Catboost and LightGBM [#1214](https://https://github.com/unit8co/darts/pull/1214) by [Anne de Vries](https://github.com/anne-devries).
 [Full Changelog](https://github.com/unit8co/darts/compare/0.21.0...master)
 
 

--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -18,16 +18,16 @@ logger = get_logger(__name__)
 
 class CatBoostModel(RegressionModel, _LikelihoodMixin):
     def __init__(
-        self,
-        lags: Union[int, list] = None,
-        lags_past_covariates: Union[int, List[int]] = None,
-        lags_future_covariates: Union[Tuple[int, int], List[int]] = None,
-        output_chunk_length: int = 1,
-        add_encoders: Optional[dict] = None,
-        likelihood: str = None,
-        quantiles: List = None,
-        random_state: Optional[int] = None,
-        **kwargs,
+            self,
+            lags: Union[int, list] = None,
+            lags_past_covariates: Union[int, List[int]] = None,
+            lags_future_covariates: Union[Tuple[int, int], List[int]] = None,
+            output_chunk_length: int = 1,
+            add_encoders: Optional[dict] = None,
+            likelihood: str = None,
+            quantiles: List = None,
+            random_state: Optional[int] = None,
+            **kwargs,
     ):
         """CatBoost Model
 
@@ -125,16 +125,16 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
         return f"CatBoostModel(lags={self.lags})"
 
     def fit(
-        self,
-        series: Union[TimeSeries, Sequence[TimeSeries]],
-        past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        val_series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        val_past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        val_future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        max_samples_per_ts: Optional[int] = None,
-        verbose: Optional[Union[int, bool]] = 0,
-        **kwargs,
+            self,
+            series: Union[TimeSeries, Sequence[TimeSeries]],
+            past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+            future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+            val_series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+            val_past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+            val_future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+            max_samples_per_ts: Optional[int] = None,
+            verbose: Optional[Union[int, bool]] = 0,
+            **kwargs,
     ):
         """
         Fits/trains the model using the provided list of features time series and the target time series.
@@ -206,7 +206,7 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
         return self
 
     def _predict_and_sample(
-        self, x: np.ndarray, num_samples: int, **kwargs
+            self, x: np.ndarray, num_samples: int, **kwargs
     ) -> np.ndarray:
         """Override of RegressionModel's predict method,
         to allow for the probabilistic case
@@ -222,3 +222,14 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
 
     def _is_probabilistic(self) -> bool:
         return self.likelihood is not None
+
+    @property
+    def min_train_series_length(self) -> int:
+        # Catboost requires a minimum of 2 train samples, therefore the min_train_series_length should be one more than
+        # for other regression models
+        return max(
+            3,
+            -self.lags["target"][0] + self.output_chunk_length + 1
+            if "target" in self.lags
+            else self.output_chunk_length,
+        )

--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -18,16 +18,16 @@ logger = get_logger(__name__)
 
 class CatBoostModel(RegressionModel, _LikelihoodMixin):
     def __init__(
-            self,
-            lags: Union[int, list] = None,
-            lags_past_covariates: Union[int, List[int]] = None,
-            lags_future_covariates: Union[Tuple[int, int], List[int]] = None,
-            output_chunk_length: int = 1,
-            add_encoders: Optional[dict] = None,
-            likelihood: str = None,
-            quantiles: List = None,
-            random_state: Optional[int] = None,
-            **kwargs,
+        self,
+        lags: Union[int, list] = None,
+        lags_past_covariates: Union[int, List[int]] = None,
+        lags_future_covariates: Union[Tuple[int, int], List[int]] = None,
+        output_chunk_length: int = 1,
+        add_encoders: Optional[dict] = None,
+        likelihood: str = None,
+        quantiles: List = None,
+        random_state: Optional[int] = None,
+        **kwargs,
     ):
         """CatBoost Model
 
@@ -125,16 +125,16 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
         return f"CatBoostModel(lags={self.lags})"
 
     def fit(
-            self,
-            series: Union[TimeSeries, Sequence[TimeSeries]],
-            past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-            future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-            val_series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-            val_past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-            val_future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-            max_samples_per_ts: Optional[int] = None,
-            verbose: Optional[Union[int, bool]] = 0,
-            **kwargs,
+        self,
+        series: Union[TimeSeries, Sequence[TimeSeries]],
+        past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        val_series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        val_past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        val_future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        max_samples_per_ts: Optional[int] = None,
+        verbose: Optional[Union[int, bool]] = 0,
+        **kwargs,
     ):
         """
         Fits/trains the model using the provided list of features time series and the target time series.
@@ -206,7 +206,7 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
         return self
 
     def _predict_and_sample(
-            self, x: np.ndarray, num_samples: int, **kwargs
+        self, x: np.ndarray, num_samples: int, **kwargs
     ) -> np.ndarray:
         """Override of RegressionModel's predict method,
         to allow for the probabilistic case

--- a/darts/models/forecasting/gradient_boosted_model.py
+++ b/darts/models/forecasting/gradient_boosted_model.py
@@ -203,3 +203,14 @@ class LightGBMModel(RegressionModel, _LikelihoodMixin):
 
     def _is_probabilistic(self) -> bool:
         return self.likelihood is not None
+
+    @property
+    def min_train_series_length(self) -> int:
+        # LightGBM requires a minimum of 2 train samples, therefore the min_train_series_length should be one more than
+        # for other regression models
+        return max(
+            3,
+            -self.lags["target"][0] + self.output_chunk_length + 1
+            if "target" in self.lags
+            else self.output_chunk_length,
+        )


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1214 .

### Summary

overwrite min_train_series_length in gradient_boosted_model and catboost_model:
max(3, -self.lags["target"][0] + self.output_chunk_length + 1)

### Other Information

@hrzn re-opened this PR with only my changes, sorry for that!

<!--Thank you for contributing to darts! -->
