### PR TITLE
Add the default_formatting parameter to plot_residuals_analysis

### DIFF
--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -847,7 +847,10 @@ def plot_hist(
 
 
 def plot_residuals_analysis(
-    residuals: TimeSeries, num_bins: int = 20, fill_nan: bool = True, default_formatting: bool = True
+    residuals: TimeSeries,
+    num_bins: int = 20,
+    fill_nan: bool = True,
+    default_formatting: bool = True,
 ) -> None:
     """Plots data relevant to residuals.
 

--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -847,7 +847,7 @@ def plot_hist(
 
 
 def plot_residuals_analysis(
-    residuals: TimeSeries, num_bins: int = 20, fill_nan: bool = True
+    residuals: TimeSeries, num_bins: int = 20, fill_nan: bool = True, default_formatting: bool = True
 ) -> None:
     """Plots data relevant to residuals.
 
@@ -865,6 +865,8 @@ def plot_residuals_analysis(
         Optionally, an integer value determining the number of bins in the histogram.
     fill_nan
         A boolean value indicating whether NaN values should be filled in the residuals.
+    default_formatting
+        Whether or not to use the darts default scheme.
     """
 
     residuals._assert_univariate()
@@ -905,7 +907,7 @@ def plot_residuals_analysis(
 
     # plot ACF
     ax3 = fig.add_subplot(gs[1:, :1])
-    plot_acf(residuals, axis=ax3)
+    plot_acf(residuals, axis=ax3, default_formatting=default_formatting)
     ax3.set_ylabel("ACF value")
     ax3.set_xlabel("lag")
     ax3.set_title("ACF")


### PR DESCRIPTION
### Summary

In my last PR it looks like I forgot to add default_formatting to plot_residual_analysis. Below are before and after changes of what this PR enables:

Before:
<img width="794" alt="Screen Shot 2022-09-19 at 7 22 13 PM" src="https://user-images.githubusercontent.com/72827203/191089230-10f8845d-38a8-4719-a8d5-e01f3d4c5aba.png">

After:
<img width="800" alt="Screen Shot 2022-09-19 at 7 23 24 PM" src="https://user-images.githubusercontent.com/72827203/191089243-860aed22-1b6b-45e5-bbf9-1566d936ddee.png">
