### PR TITLE
change an exception type in timeseries tests

### DIFF
--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -387,7 +387,7 @@ class TimeSeriesTestCase(DartsBaseTestClass):
             )
         )
 
-        with test_case.assertRaises(OverflowError):
+        with test_case.assertRaises(ValueError):
             test_series.shift(1e6)
 
         seriesM = TimeSeries.from_times_and_values(


### PR DESCRIPTION
Fix one of our unit tests with pandas 1.5.0