### PR TITLE
Fix encoder transformer and remove absolute index encoder

### DIFF
--- a/darts/models/forecasting/block_rnn_model.py
+++ b/darts/models/forecasting/block_rnn_model.py
@@ -239,7 +239,7 @@ class BlockRNNModel(PastCovariatesTorchModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -64,7 +64,7 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/gradient_boosted_model.py
+++ b/darts/models/forecasting/gradient_boosted_model.py
@@ -68,7 +68,7 @@ class LightGBMModel(RegressionModel, _LikelihoodMixin):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/linear_regression_model.py
+++ b/darts/models/forecasting/linear_regression_model.py
@@ -66,7 +66,7 @@ class LinearRegressionModel(RegressionModel, _LikelihoodMixin):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -659,7 +659,7 @@ class NBEATSModel(PastCovariatesTorchModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/nhits.py
+++ b/darts/models/forecasting/nhits.py
@@ -595,7 +595,7 @@ class NHiTSModel(PastCovariatesTorchModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/random_forest.py
+++ b/darts/models/forecasting/random_forest.py
@@ -71,7 +71,7 @@ class RandomForest(RegressionModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -87,7 +87,7 @@ class RegressionModel(GlobalForecastingModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -318,7 +318,7 @@ class RNNModel(DualCovariatesTorchModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -360,7 +360,7 @@ class TCNModel(PastCovariatesTorchModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -799,7 +799,7 @@ class TFTModel(MixedCovariatesTorchModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -187,7 +187,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/models/forecasting/transformer_model.py
+++ b/darts/models/forecasting/transformer_model.py
@@ -448,7 +448,7 @@ class TransformerModel(PastCovariatesTorchModel):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }

--- a/darts/tests/explainability/test_shap_explainer.py
+++ b/darts/tests/explainability/test_shap_explainer.py
@@ -28,7 +28,7 @@ class ShapExplainerTestCase(DartsBaseTestClass):
     add_encoders = {
         "cyclic": {"past": ["month", "day"]},
         "datetime_attribute": {"future": ["hour", "dayofweek"]},
-        "position": {"past": ["absolute"], "future": ["relative"]},
+        "position": {"past": ["relative"], "future": ["relative"]},
         "custom": {"past": [lambda idx: (idx.year - 1950) / 50]},
         "transformer": Scaler(scaler),
     }
@@ -281,14 +281,14 @@ class ShapExplainerTestCase(DartsBaseTestClass):
         self.assertEqual(len(explanation), 537)
 
         # list of foregrounds: encoders have to be corrected first.
-        # results = shap_explain.explain(
-        #     foreground_series=[self.target_ts, self.target_ts[:100]],
-        #     foreground_past_covariates=[self.past_cov_ts, self.past_cov_ts[:40]],
-        #     foreground_future_covariates=[self.fut_cov_ts, self.fut_cov_ts[:40]],
-        # )
-        # ts_res = results.get_explanation(horizon=2, component="power")
+        results = shap_explain.explain(
+            foreground_series=[self.target_ts, self.target_ts[:100]],
+            foreground_past_covariates=[self.past_cov_ts, self.past_cov_ts[:40]],
+            foreground_future_covariates=[self.fut_cov_ts, self.fut_cov_ts[:40]],
+        )
+        ts_res = results.get_explanation(horizon=2, component="power")
 
-        # self.assertEqual(len(ts_res), 2)
+        self.assertEqual(len(ts_res), 2)
         # explain with a new foreground, minimum required. We should obtain one
         # timeseries with only one time element
         results = shap_explain.explain(
@@ -322,30 +322,30 @@ class ShapExplainerTestCase(DartsBaseTestClass):
             "0_past_cov_lag-3",
             "1_past_cov_lag-3",
             "2_past_cov_lag-3",
-            "month_sin_past_cov_lag-3",
-            "month_cos_past_cov_lag-3",
-            "day_sin_past_cov_lag-3",
-            "day_cos_past_cov_lag-3",
-            "absolute_idx_past_cov_lag-3",
-            "custom_past_cov_lag-3",
+            "darts_enc_pc_cyc_month_sin_past_cov_lag-3",
+            "darts_enc_pc_cyc_month_cos_past_cov_lag-3",
+            "darts_enc_pc_cyc_day_sin_past_cov_lag-3",
+            "darts_enc_pc_cyc_day_cos_past_cov_lag-3",
+            "darts_enc_pc_pos_relative_past_cov_lag-3",
+            "darts_enc_pc_cus_custom_past_cov_lag-3",
             "0_past_cov_lag-2",
             "1_past_cov_lag-2",
             "2_past_cov_lag-2",
-            "month_sin_past_cov_lag-2",
-            "month_cos_past_cov_lag-2",
-            "day_sin_past_cov_lag-2",
-            "day_cos_past_cov_lag-2",
-            "absolute_idx_past_cov_lag-2",
-            "custom_past_cov_lag-2",
+            "darts_enc_pc_cyc_month_sin_past_cov_lag-2",
+            "darts_enc_pc_cyc_month_cos_past_cov_lag-2",
+            "darts_enc_pc_cyc_day_sin_past_cov_lag-2",
+            "darts_enc_pc_cyc_day_cos_past_cov_lag-2",
+            "darts_enc_pc_pos_relative_past_cov_lag-2",
+            "darts_enc_pc_cus_custom_past_cov_lag-2",
             "0_past_cov_lag-1",
             "1_past_cov_lag-1",
             "2_past_cov_lag-1",
-            "month_sin_past_cov_lag-1",
-            "month_cos_past_cov_lag-1",
-            "day_sin_past_cov_lag-1",
-            "day_cos_past_cov_lag-1",
-            "absolute_idx_past_cov_lag-1",
-            "custom_past_cov_lag-1",
+            "darts_enc_pc_cyc_month_sin_past_cov_lag-1",
+            "darts_enc_pc_cyc_month_cos_past_cov_lag-1",
+            "darts_enc_pc_cyc_day_sin_past_cov_lag-1",
+            "darts_enc_pc_cyc_day_cos_past_cov_lag-1",
+            "darts_enc_pc_pos_relative_past_cov_lag-1",
+            "darts_enc_pc_cus_custom_past_cov_lag-1",
             "0_fut_cov_lag0",
             "1_fut_cov_lag0",
             "hour_fut_cov_lag0",

--- a/darts/tests/models/forecasting/test_covariate_index_generators.py
+++ b/darts/tests/models/forecasting/test_covariate_index_generators.py
@@ -74,23 +74,23 @@ class CovariateIndexGeneratorTestCase(DartsBaseTestClass):
     def helper_test_index_types(self, ig: CovariateIndexGenerator):
         """test the index type of generated index"""
         # pd.DatetimeIndex
-        idx = ig.generate_train_series(self.target_time, self.cov_time_train)
+        idx, _ = ig.generate_train_series(self.target_time, self.cov_time_train)
         self.assertTrue(isinstance(idx, pd.DatetimeIndex))
-        idx = ig.generate_inference_series(
+        idx, _ = ig.generate_inference_series(
             self.n_short, self.target_time, self.cov_time_inf_short
         )
         self.assertTrue(isinstance(idx, pd.DatetimeIndex))
-        idx = ig.generate_train_series(self.target_time, None)
+        idx, _ = ig.generate_train_series(self.target_time, None)
         self.assertTrue(isinstance(idx, pd.DatetimeIndex))
 
         # pd.RangeIndex
-        idx = ig.generate_train_series(self.target_int, self.cov_int_train)
+        idx, _ = ig.generate_train_series(self.target_int, self.cov_int_train)
         self.assertTrue(isinstance(idx, pd.RangeIndex))
-        idx = ig.generate_inference_series(
+        idx, _ = ig.generate_inference_series(
             self.n_short, self.target_int, self.cov_int_inf_short
         )
         self.assertTrue(isinstance(idx, pd.RangeIndex))
-        idx = ig.generate_train_series(self.target_int, None)
+        idx, _ = ig.generate_train_series(self.target_int, None)
         self.assertTrue(isinstance(idx, pd.RangeIndex))
 
     def helper_test_index_generator_train(self, ig: CovariateIndexGenerator):
@@ -100,24 +100,24 @@ class CovariateIndexGeneratorTestCase(DartsBaseTestClass):
         """
         # pd.DatetimeIndex
         # generated index must be equal to input covariate index
-        idx = ig.generate_train_series(self.target_time, self.cov_time_train)
+        idx, _ = ig.generate_train_series(self.target_time, self.cov_time_train)
         self.assertTrue(idx.equals(self.cov_time_train.time_index))
         # generated index must be equal to input covariate index
-        idx = ig.generate_train_series(self.target_time, self.cov_time_train_short)
+        idx, _ = ig.generate_train_series(self.target_time, self.cov_time_train_short)
         self.assertTrue(idx.equals(self.cov_time_train_short.time_index))
         # generated index must be equal to input target index when no covariates are defined
-        idx = ig.generate_train_series(self.target_time, None)
+        idx, _ = ig.generate_train_series(self.target_time, None)
         self.assertTrue(idx.equals(self.cov_time_train.time_index))
 
         # integer index
         # generated index must be equal to input covariate index
-        idx = ig.generate_train_series(self.target_int, self.cov_int_train)
+        idx, _ = ig.generate_train_series(self.target_int, self.cov_int_train)
         self.assertTrue(idx.equals(self.cov_int_train.time_index))
         # generated index must be equal to input covariate index
-        idx = ig.generate_train_series(self.target_time, self.cov_int_train_short)
+        idx, _ = ig.generate_train_series(self.target_time, self.cov_int_train_short)
         self.assertTrue(idx.equals(self.cov_int_train_short.time_index))
         # generated index must be equal to input target index when no covariates are defined
-        idx = ig.generate_train_series(self.target_int, None)
+        idx, _ = ig.generate_train_series(self.target_int, None)
         self.assertTrue(idx.equals(self.cov_int_train.time_index))
 
     def helper_test_index_generator_inference(self, ig, is_past=False):
@@ -134,7 +134,7 @@ class CovariateIndexGeneratorTestCase(DartsBaseTestClass):
         """
 
         # check generated inference index without passing covariates when n <= output_chunk_length
-        idx = ig.generate_inference_series(self.n_short, self.target_time, None)
+        idx, _ = ig.generate_inference_series(self.n_short, self.target_time, None)
         if is_past:
             n_out = self.input_chunk_length
             last_idx = self.target_time.end_time()
@@ -146,7 +146,7 @@ class CovariateIndexGeneratorTestCase(DartsBaseTestClass):
         self.assertTrue(idx[-1] == last_idx)
 
         # check generated inference index without passing covariates when n > output_chunk_length
-        idx = ig.generate_inference_series(self.n_long, self.target_time, None)
+        idx, _ = ig.generate_inference_series(self.n_long, self.target_time, None)
         if is_past:
             n_out = self.input_chunk_length + self.n_long - self.output_chunk_length
             last_idx = (
@@ -160,19 +160,19 @@ class CovariateIndexGeneratorTestCase(DartsBaseTestClass):
         self.assertTrue(len(idx) == n_out)
         self.assertTrue(idx[-1] == last_idx)
 
-        idx = ig.generate_inference_series(
+        idx, _ = ig.generate_inference_series(
             self.n_short, self.target_time, self.cov_time_inf_short
         )
         self.assertTrue(idx.equals(self.cov_time_inf_short.time_index))
-        idx = ig.generate_inference_series(
+        idx, _ = ig.generate_inference_series(
             self.n_long, self.target_time, self.cov_time_inf_long
         )
         self.assertTrue(idx.equals(self.cov_time_inf_long.time_index))
-        idx = ig.generate_inference_series(
+        idx, _ = ig.generate_inference_series(
             self.n_short, self.target_int, self.cov_int_inf_short
         )
         self.assertTrue(idx.equals(self.cov_int_inf_short.time_index))
-        idx = ig.generate_inference_series(
+        idx, _ = ig.generate_inference_series(
             self.n_long, self.target_int, self.cov_int_inf_long
         )
         self.assertTrue(idx.equals(self.cov_int_inf_long.time_index))

--- a/darts/tests/models/forecasting/test_encoders.py
+++ b/darts/tests/models/forecasting/test_encoders.py
@@ -770,7 +770,7 @@ class EncoderTestCase(DartsBaseTestClass):
         input_chunk_length = 12
         output_chunk_length = 6
 
-        # ===> test absolute position encoder <===
+        # ===> test callable index encoder <===
         encoder_params = {
             "custom": {"past": [lambda index: index.year, lambda index: index.year - 1]}
         }

--- a/darts/utils/data/encoder_base.py
+++ b/darts/utils/data/encoder_base.py
@@ -4,7 +4,6 @@ Encoder Base Classes
 """
 
 from abc import ABC, abstractmethod
-from enum import Enum, auto
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -20,18 +19,11 @@ EncoderOutputType = Optional[Union[Sequence[TimeSeries], List[TimeSeries]]]
 logger = get_logger(__name__)
 
 
-class ReferenceIndexType(Enum):
-    PREDICTION = auto()
-    START = auto()
-    NONE = auto()
-
-
 class CovariateIndexGenerator(ABC):
     def __init__(
         self,
         input_chunk_length: int,
         output_chunk_length: int,
-        reference_index_type: ReferenceIndexType = ReferenceIndexType.NONE,
     ):
         """
         Parameters
@@ -40,19 +32,14 @@ class CovariateIndexGenerator(ABC):
             The length of the emitted past series.
         output_chunk_length
             The length of the emitted future series.
-        reference_index
-            If a reference index should be saved, set `reference_index` to one of `(ReferenceIndexType.PREDICTION,
-            ReferenceIndexType.START)`
         """
         self.input_chunk_length = input_chunk_length
         self.output_chunk_length = output_chunk_length
-        self.reference_index_type = reference_index_type
-        self.reference_index: Optional[Tuple[int, Union[pd.Timestamp, int]]] = None
 
     @abstractmethod
     def generate_train_series(
         self, target: TimeSeries, covariate: Optional[TimeSeries] = None
-    ) -> SupportedIndex:
+    ) -> Tuple[SupportedIndex, pd.Timestamp]:
         """
         Implement a method that extracts the required covariate index for training.
 
@@ -68,7 +55,7 @@ class CovariateIndexGenerator(ABC):
     @abstractmethod
     def generate_inference_series(
         self, n: int, target: TimeSeries, covariate: Optional[TimeSeries] = None
-    ) -> SupportedIndex:
+    ) -> Tuple[SupportedIndex, pd.Timestamp]:
         """
         Implement a method that extracts the required covariate index for prediction.
 
@@ -98,25 +85,18 @@ class PastCovariateIndexGenerator(CovariateIndexGenerator):
 
     def generate_train_series(
         self, target: TimeSeries, covariate: Optional[TimeSeries] = None
-    ) -> SupportedIndex:
+    ) -> Tuple[SupportedIndex, pd.Timestamp]:
 
         super().generate_train_series(target, covariate)
-
-        # save a reference index if specified
-        if (
-            self.reference_index_type is not ReferenceIndexType.NONE
-            and self.reference_index is None
-        ):
-            if self.reference_index_type is ReferenceIndexType.PREDICTION:
-                self.reference_index = (len(target) - 1, target.end_time())
-            else:  # save the time step before start of target series
-                self.reference_index = (-1, target.start_time() - target.freq)
-
-        return covariate.time_index if covariate is not None else target.time_index
+        target_end = target.end_time()
+        return (
+            covariate.time_index if covariate is not None else target.time_index,
+            target_end,
+        )
 
     def generate_inference_series(
         self, n: int, target: TimeSeries, covariate: Optional[TimeSeries] = None
-    ) -> SupportedIndex:
+    ) -> Tuple[SupportedIndex, pd.Timestamp]:
         """For prediction (`n` is given) with past covariates we have to distinguish between two cases:
         1)  If past covariates are given, we can use them as reference
         2)  If past covariates are missing, we need to generate a time index that starts `input_chunk_length`
@@ -124,13 +104,19 @@ class PastCovariateIndexGenerator(CovariateIndexGenerator):
         """
 
         super().generate_inference_series(n, target, covariate)
+        target_end = target.end_time()
         if covariate is not None:
-            return covariate.time_index
+            return covariate.time_index, target_end
         else:
-            return generate_index(
-                start=target.end_time() - target.freq * (self.input_chunk_length - 1),
-                length=self.input_chunk_length + max(0, n - self.output_chunk_length),
-                freq=target.freq,
+            return (
+                generate_index(
+                    start=target.end_time()
+                    - target.freq * (self.input_chunk_length - 1),
+                    length=self.input_chunk_length
+                    + max(0, n - self.output_chunk_length),
+                    freq=target.freq,
+                ),
+                target_end,
             )
 
     @property
@@ -143,42 +129,39 @@ class FutureCovariateIndexGenerator(CovariateIndexGenerator):
 
     def generate_train_series(
         self, target: TimeSeries, covariate: Optional[TimeSeries] = None
-    ) -> SupportedIndex:
+    ) -> Tuple[SupportedIndex, pd.Timestamp]:
         """For training (when `n` is `None`) we can simply use the future covariates (if available) or target as
         reference to extract the time index.
         """
 
         super().generate_train_series(target, covariate)
-
-        # save a reference index if specified
-        if (
-            self.reference_index_type is not ReferenceIndexType.NONE
-            and self.reference_index is None
-        ):
-            if self.reference_index_type is ReferenceIndexType.PREDICTION:
-                self.reference_index = (len(target) - 1, target.end_time())
-            else:  # save the time step before start of target series
-                self.reference_index = (-1, target.start_time() - target.freq)
-
-        return covariate.time_index if covariate is not None else target.time_index
+        target_end = target.end_time()
+        return (
+            covariate.time_index if covariate is not None else target.time_index,
+            target_end,
+        )
 
     def generate_inference_series(
         self, n: int, target: TimeSeries, covariate: Optional[TimeSeries] = None
-    ) -> SupportedIndex:
+    ) -> Tuple[SupportedIndex, pd.Timestamp]:
         """For prediction (`n` is given) with future covariates we have to distinguish between two cases:
         1)  If future covariates are given, we can use them as reference
         2)  If future covariates are missing, we need to generate a time index that starts `input_chunk_length`
             before the end of `target` and ends `max(n, output_chunk_length)` after the end of `target`
         """
         super().generate_inference_series(n, target, covariate)
-
+        target_end = target.end_time()
         if covariate is not None:
-            return covariate.time_index
+            return covariate.time_index, target_end
         else:
-            return generate_index(
-                start=target.end_time() - target.freq * (self.input_chunk_length - 1),
-                length=self.input_chunk_length + max(n, self.output_chunk_length),
-                freq=target.freq,
+            return (
+                generate_index(
+                    start=target.end_time()
+                    - target.freq * (self.input_chunk_length - 1),
+                    length=self.input_chunk_length + max(n, self.output_chunk_length),
+                    freq=target.freq,
+                ),
+                target_end,
             )
 
     @property
@@ -323,14 +306,17 @@ class SingleEncoder(Encoder, ABC):
         self._components = pd.Index([])
 
     @abstractmethod
-    def _encode(self, index: SupportedIndex, dtype: np.dtype) -> TimeSeries:
+    def _encode(
+        self, index: SupportedIndex, target_end: pd.Timestamp, dtype: np.dtype
+    ) -> TimeSeries:
         """Single Encoders must implement an _encode() method to encode the index.
 
         Parameters
         ----------
         index
             The index generated from `self.index_generator` for either the train or inference dataset.
-            :param dtype:
+        target_end
+            The end time of the target series.
         dtype
             The dtype of the encoded index
         """
@@ -360,8 +346,10 @@ class SingleEncoder(Encoder, ABC):
         covariate = self._drop_encoded_components(covariate, self.components)
 
         # generate index and encodings
-        index = self.index_generator.generate_train_series(target, covariate)
-        encoded = self._encode(index, target.dtype)
+        index, target_end = self.index_generator.generate_train_series(
+            target, covariate
+        )
+        encoded = self._encode(index, target_end, target.dtype)
 
         # optionally, merge encodings with original `covariate` series
         encoded = (
@@ -415,8 +403,10 @@ class SingleEncoder(Encoder, ABC):
         covariate = self._drop_encoded_components(covariate, self.components)
 
         # generate index and encodings
-        index = self.index_generator.generate_inference_series(n, target, covariate)
-        encoded = self._encode(index, target.dtype)
+        index, target_end = self.index_generator.generate_inference_series(
+            n, target, covariate
+        )
+        encoded = self._encode(index, target_end, target.dtype)
 
         # optionally, merge encodings with original `covariate` series
         encoded = (

--- a/darts/utils/data/encoder_base.py
+++ b/darts/utils/data/encoder_base.py
@@ -504,14 +504,20 @@ class SequentialEncoderTransformer:
         """
         if not self.fit_called:
             self._update_mask(covariate)
-            transformed = self.transformer.fit_transform(
-                covariate, component_mask=self.transform_mask
-            )
+            if any(self.transform_mask):
+                transformed = self.transformer.fit_transform(
+                    covariate, component_mask=self.transform_mask
+                )
+            else:
+                transformed = covariate
             self._fit_called = True
         else:
-            transformed = self.transformer.transform(
-                covariate, component_mask=self.transform_mask
-            )
+            if any(self.transform_mask):
+                transformed = self.transformer.transform(
+                    covariate, component_mask=self.transform_mask
+                )
+            else:
+                transformed = covariate
         return transformed
 
     def _update_mask(self, covariate: List[TimeSeries]) -> None:

--- a/darts/utils/data/encoder_base.py
+++ b/darts/utils/data/encoder_base.py
@@ -451,7 +451,7 @@ class SingleEncoder(Encoder, ABC):
         * attribute: the attribute used for the underlying encoder. Some examples:
             * "month_sin", "month_cos" (for "cyc")
             * "month" (for "dta")
-            * "absolute", "relative" (for "pos")
+            * "relative" (for "pos")
             * "custom" (for "cus")
         """
         return f"darts_enc_{self.index_generator.base_component_name}"

--- a/darts/utils/data/encoders.py
+++ b/darts/utils/data/encoders.py
@@ -152,12 +152,10 @@ from darts.utils.data.encoder_base import (
     Encoder,
     FutureCovariateIndexGenerator,
     PastCovariateIndexGenerator,
-    ReferenceIndexType,
     SequentialEncoderTransformer,
     SingleEncoder,
     SupportedIndex,
 )
-from darts.utils.data.utils import _index_diff
 from darts.utils.timeseries_generation import datetime_attribute_timeseries
 from darts.utils.utils import seq2series, series2seq
 
@@ -172,7 +170,7 @@ VALID_ENCODER_DTYPES = (str, Sequence)
 
 TRANSFORMER_KEYS = ["transformer"]
 VALID_TRANSFORMER_DTYPES = FittableDataTransformer
-INTEGER_INDEX_ATTRIBUTES = ["absolute", "relative"]
+INTEGER_INDEX_ATTRIBUTES = ["relative"]
 
 
 class CyclicTemporalEncoder(SingleEncoder):
@@ -198,9 +196,11 @@ class CyclicTemporalEncoder(SingleEncoder):
         super().__init__(index_generator)
         self.attribute = attribute
 
-    def _encode(self, index: SupportedIndex, dtype: np.dtype) -> TimeSeries:
+    def _encode(
+        self, index: SupportedIndex, target_end: pd.Timestamp, dtype: np.dtype
+    ) -> TimeSeries:
         """applies cyclic encoding from `datetime_attribute_timeseries()` to `self.attribute` of `index`."""
-        super()._encode(index, dtype)
+        super()._encode(index, target_end, dtype)
         return datetime_attribute_timeseries(
             index,
             attribute=self.attribute,
@@ -303,9 +303,11 @@ class DatetimeAttributeEncoder(SingleEncoder):
         super().__init__(index_generator)
         self.attribute = attribute
 
-    def _encode(self, index: SupportedIndex, dtype: np.dtype) -> TimeSeries:
+    def _encode(
+        self, index: SupportedIndex, target_end: pd.Timestamp, dtype: np.dtype
+    ) -> TimeSeries:
         """Applies cyclic encoding from `datetime_attribute_timeseries()` to `self.attribute` of `index`."""
-        super()._encode(index, dtype)
+        super()._encode(index, target_end, dtype)
         return datetime_attribute_timeseries(
             index,
             attribute=self.attribute,
@@ -394,67 +396,32 @@ class IntegerIndexEncoder(SingleEncoder):
             An instance of `CovariateIndexGenerator` with methods `generate_train_series()` and
             `generate_inference_series()`. Used to generate the index for encoders.
         attribute
-            Either 'absolute' or 'relative'. If 'absolute', the generated encoded values will range from (0, inf)
-            and the train target series will be used as a reference to set the 0-index. If 'relative', the generated
-            encoded values will range from (-inf, inf) and the train target series end time will be used as a reference
-            to evaluate the relative index positions.
+            Currently only 'relative' is supported. The generated encoded values will range from (-inf, inf) and the
+            target series end time will be used as a reference to evaluate the relative index positions.
         """
         raise_if_not(
             isinstance(attribute, str) and attribute in INTEGER_INDEX_ATTRIBUTES,
             f"Encountered invalid encoder argument `{attribute}` for encoder `position`. "
-            f'Attribute must be one of `("absolute", "relative")`.',
+            f'Attribute must be `"relative"`.',
             logger,
         )
-
         super().__init__(index_generator)
 
         self.attribute = attribute
-        self.reference_index: Optional[
-            Tuple[int, Optional[Union[pd.Timestamp, int]]]
-        ] = None
-        self.was_called = False
 
-    def _encode(self, index: SupportedIndex, dtype: np.dtype) -> TimeSeries:
+    def _encode(
+        self, index: SupportedIndex, target_end: pd.Timestamp, dtype: np.dtype
+    ) -> TimeSeries:
         """Applies cyclic encoding from `datetime_attribute_timeseries()` to `self.attribute` of `index`.
-        1)  for attribute=='absolute', the reference point/index is one step before start of the train target series
-        2)  for attribute=='relative', the reference point/index is the overall prediction/forecast index
+        For attribute=='relative', the reference point/index is the prediction/forecast index of the target series.
         """
-        super()._encode(index, dtype)
-
-        # load reference index from index_generators
-        if not self.was_called:
-            self.reference_index = self.index_generator.reference_index
-            self.was_called = True
-
-        current_start_value = index[0]
-
-        # extract reference index
-        reference_index, reference_value = self.reference_index
-
-        # get the difference between last index and reference index for each case
-        index_diff = _index_diff(
-            self=current_start_value, other=reference_value, freq=index.freq
-        )
-        # set the start integer index value for the current index
-        current_start_index = (
-            reference_index - index_diff
-            if self.attribute == "absolute"
-            else -index_diff
-        )
-
-        encoded = TimeSeries.from_times_and_values(
+        idx_larger_end = (index <= target_end).sum() - 1
+        super()._encode(index, target_end, dtype)
+        return TimeSeries.from_times_and_values(
             times=index,
-            values=np.arange(current_start_index, current_start_index + len(index)),
+            values=np.arange(-idx_larger_end, -idx_larger_end + len(index)),
             columns=[self.base_component_name + self.attribute],
         ).astype(np.dtype(dtype))
-
-        # update reference index for 'absolute' case to avoid having to evaluate longer differences (cost-intensive)
-        if self.attribute == "absolute":
-            self.reference_index = (
-                current_start_index + len(encoded) - 1,
-                encoded.time_index[-1],
-            )
-        return encoded
 
     @property
     def accept_transformer(self) -> List[bool]:
@@ -488,22 +455,13 @@ class PastIntegerIndexEncoder(IntegerIndexEncoder):
         output_chunk_length
             The length of the emitted future series.
         attribute
-            Either 'absolute' or 'relative'. If 'absolute', the generated encoded values will range from (0, inf)
-            and the train target series will be used as a reference to set the 0-index. If 'relative', the generated
-            encoded values will range from (-inf, inf) and the train target series end time will be used as a reference
-            to evaluate the relative index positions.
+            Currently only 'relative' is supported. The generated encoded values will range from (-inf, inf) and the
+            target series end time will be used as a reference to evaluate the relative index positions.
         """
-        reference_index_type = (
-            ReferenceIndexType.PREDICTION
-            if attribute == "relative"
-            else ReferenceIndexType.START
-        )
-
         super().__init__(
             index_generator=PastCovariateIndexGenerator(
                 input_chunk_length,
                 output_chunk_length,
-                reference_index_type=reference_index_type,
             ),
             attribute=attribute,
         )
@@ -525,22 +483,13 @@ class FutureIntegerIndexEncoder(IntegerIndexEncoder):
         output_chunk_length
             The length of the emitted future series.
         attribute
-            Either 'absolute' or 'relative'. If 'absolute', the generated encoded values will range from (0, inf)
-            and the train target series will be used as a reference to set the 0-index. If 'relative', the generated
-            encoded values will range from (-inf, inf) and the train target series end time will be used as a reference
-            to evaluate the relative index positions.
+            Currently only 'relative' is supported. The generated encoded values will range from (-inf, inf) and the
+            target series end time will be used as a reference to evaluate the relative index positions.
         """
-        reference_index_type = (
-            ReferenceIndexType.PREDICTION
-            if attribute == "relative"
-            else ReferenceIndexType.START
-        )
-
         super().__init__(
             index_generator=FutureCovariateIndexGenerator(
                 input_chunk_length,
                 output_chunk_length,
-                reference_index_type=reference_index_type,
             ),
             attribute=attribute,
         )
@@ -576,9 +525,11 @@ class CallableIndexEncoder(SingleEncoder):
 
         self.attribute = attribute
 
-    def _encode(self, index: SupportedIndex, dtype: np.dtype) -> TimeSeries:
+    def _encode(
+        self, index: SupportedIndex, target_end: pd.Timestamp, dtype: np.dtype
+    ) -> TimeSeries:
         """Apply the user-defined callable to encode the index"""
-        super()._encode(index, dtype)
+        super()._encode(index, target_end, dtype)
 
         return TimeSeries.from_times_and_values(
             times=index,

--- a/darts/utils/data/encoders.py
+++ b/darts/utils/data/encoders.py
@@ -72,12 +72,11 @@ The SingleEncoders from {X}{SingleEncoder} are:
             'dayofweek', 'day_of_week', 'hour', 'minute', 'second', 'microsecond', 'nanosecond', 'quarter',
             'dayofyear', 'day_of_year', 'week', 'weekofyear', 'week_of_year').
 *   `IntegerIndexEncoder`
-        Adds absolute or relative index positions as integer values (positions) derived from `series` time index.
+        Adds the relative index positions as integer values (positions) derived from `series` time index.
         `series` can either have a pd.DatetimeIndex or an integer index.
 
         attribute
-            Either 'absolute' or 'relative'.
-            'absolute' will generate position values ranging from 0 to inf where 0 is set at the start of `series`.
+            Currently, only 'relative' is supported.
             'relative' will generate position values relative to the forecasting/prediction point. Values range
             from -inf to inf where 0 is set at the forecasting point.
 *   `CallableIndexEncoder`
@@ -128,7 +127,7 @@ TorchForecastingModel (this is only meant to illustrate many features at once).
     add_encoders = {
         'cyclic': {'future': ['month']},
         'datetime_attribute': {'future': ['hour', 'dayofweek']},
-        'position': {'past': ['absolute'], 'future': ['relative']},
+        'position': {'past': ['relative'], 'future': ['relative']},
         'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
         'transformer': Scaler()
     }
@@ -426,7 +425,7 @@ class IntegerIndexEncoder(SingleEncoder):
     @property
     def accept_transformer(self) -> List[bool]:
         """`IntegerIndexEncoder` accepts transformations. Note that transforming 'relative' `IntegerIndexEncoder`
-        will return an 'absolute' index."""
+        will return the absolute position (in the transformed space)."""
         return [True]
 
     @property
@@ -671,7 +670,7 @@ class SequentialEncoder(Encoder):
                 add_encoders={
                     'cyclic': {'future': ['month']},
                     'datetime_attribute': {'past': ['hour'], 'future': ['year', 'dayofweek']},
-                    'position': {'past': ['absolute'], 'future': ['relative']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
                     'transformer': Scaler()
                 }
@@ -1087,7 +1086,7 @@ class SequentialEncoder(Encoder):
         Raises
         ------
         ValueError
-            1) if the outermost key is other than (`past`, `future`, `absolute`)
+            1) if the outermost key is other than (`past`, `future`)
             2) if the innermost values are other than type `str` or `Sequence`
         """
 


### PR DESCRIPTION
### Summary
Fixes the following issues:
- encoder transformer failed when only using a cyclic encoder
- encoder transformer was fit on all series encodings from fit(). This lead to bad results when the series used at predict() do not represent the same series. Now the transformer is globally fit on all observed values per encoded component
- Removed absolute index position encoder and only keep relative index position encoder. Relative basically carries the same information as absolute just that it uses the end of the target series as the reference point. This also makes more sense for transformations, as the maximum value is always 0 when fitting. Users can always implement their own absolute idx logic through the „custom“ encoder (CallableIndexEncoder)