### PR TITLE
Fix catboost with docker image on M1/M2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,6 +102,10 @@ To run the example notebooks without installing our libraries natively on your m
 ```bash
 ./gradlew docker && ./gradlew dockerRun
 ```
+If you are having M1/M2 chipset then you should change the default platform: (unfortunately not all libraries support ARM architecture)
+```bash
+DOCKER_DEFAULT_PLATFORM=linux/amd64 ./gradlew docker && ./gradlew dockerRun
+```
 
 Then copy and paste the URL provided by the docker container into your browser to access Jupyter notebook.
 


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1273 .

### Summary
Add another command in install doc to run docker on m1/m2 machines

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
