### PR TITLE
fix deepcopy, remove traffic from lfs

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -34,6 +34,7 @@ Read our `user guide on covariates <https://unit8co.github.io/darts/userguide/co
 
 import pickle
 from collections import defaultdict
+from copy import deepcopy
 from inspect import signature
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
@@ -4034,8 +4035,8 @@ class TimeSeries:
     def __copy__(self, deep: bool = True):
         return self.copy()
 
-    def __deepcopy__(self):
-        return self.__class__(self._xa.copy())
+    def __deepcopy__(self, memo):
+        return self.__class__(deepcopy(self._xa, memo))
 
     def __getitem__(
         self,

--- a/datasets/.gitattributes
+++ b/datasets/.gitattributes
@@ -1,1 +1,0 @@
-traffic.csv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
* Fixes https://github.com/unit8co/darts/issues/1261
* Removes `traffic.csv` from git LFS (I had to do it in this same PR otherwise I couldn't commit)
