### PR TITLE
Add dedicated LocalForecastingModel and renaming some model classes

### DIFF
--- a/darts/dataprocessing/encoders/__init__.py
+++ b/darts/dataprocessing/encoders/__init__.py
@@ -1,4 +1,8 @@
-# Time Axis Encoders
+"""
+Time Axis Encoders
+------------------
+"""
+
 from .encoders import (
     FutureCallableIndexEncoder,
     FutureCyclicEncoder,

--- a/darts/models/forecasting/arima.py
+++ b/darts/models/forecasting/arima.py
@@ -17,14 +17,14 @@ from statsmodels.tsa.arima.model import ARIMA as staARIMA
 
 from darts.logging import get_logger
 from darts.models.forecasting.forecasting_model import (
-    TransferableDualCovariatesForecastingModel,
+    TransferableFutureCovariatesLocalForecastingModel,
 )
 from darts.timeseries import TimeSeries
 
 logger = get_logger(__name__)
 
 
-class ARIMA(TransferableDualCovariatesForecastingModel):
+class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
     def __init__(
         self,
         p: int = 12,

--- a/darts/models/forecasting/auto_arima.py
+++ b/darts/models/forecasting/auto_arima.py
@@ -8,13 +8,15 @@ from typing import Optional
 from pmdarima import AutoARIMA as PmdAutoARIMA
 
 from darts.logging import get_logger, raise_if
-from darts.models.forecasting.forecasting_model import DualCovariatesForecastingModel
+from darts.models.forecasting.forecasting_model import (
+    FutureCovariatesLocalForecastingModel,
+)
 from darts.timeseries import TimeSeries
 
 logger = get_logger(__name__)
 
 
-class AutoARIMA(DualCovariatesForecastingModel):
+class AutoARIMA(FutureCovariatesLocalForecastingModel):
     def __init__(self, *autoarima_args, **autoarima_kwargs):
         """Auto-ARIMA
 

--- a/darts/models/forecasting/baselines.py
+++ b/darts/models/forecasting/baselines.py
@@ -12,15 +12,15 @@ import numpy as np
 from darts.logging import get_logger, raise_if_not
 from darts.models.forecasting.ensemble_model import EnsembleModel
 from darts.models.forecasting.forecasting_model import (
-    ForecastingModel,
     GlobalForecastingModel,
+    LocalForecastingModel,
 )
 from darts.timeseries import TimeSeries
 
 logger = get_logger(__name__)
 
 
-class NaiveMean(ForecastingModel):
+class NaiveMean(LocalForecastingModel):
     def __init__(self):
         """Naive Mean Model
 
@@ -44,7 +44,7 @@ class NaiveMean(ForecastingModel):
         return self._build_forecast_series(forecast)
 
 
-class NaiveSeasonal(ForecastingModel):
+class NaiveSeasonal(LocalForecastingModel):
     def __init__(self, K: int = 1):
         """Naive Seasonal Model
 
@@ -84,7 +84,7 @@ class NaiveSeasonal(ForecastingModel):
         return self._build_forecast_series(forecast)
 
 
-class NaiveDrift(ForecastingModel):
+class NaiveDrift(LocalForecastingModel):
     def __init__(self):
         """Naive Drift Model
 
@@ -117,7 +117,7 @@ class NaiveDrift(ForecastingModel):
 
 class NaiveEnsembleModel(EnsembleModel):
     def __init__(
-        self, models: Union[List[ForecastingModel], List[GlobalForecastingModel]]
+        self, models: Union[List[LocalForecastingModel], List[GlobalForecastingModel]]
     ):
         """Naive combination model
 

--- a/darts/models/forecasting/croston.py
+++ b/darts/models/forecasting/croston.py
@@ -9,11 +9,13 @@ from statsforecast.models import TSB as CrostonTSB
 from statsforecast.models import CrostonClassic, CrostonOptimized, CrostonSBA
 
 from darts.logging import raise_if, raise_if_not
-from darts.models.forecasting.forecasting_model import DualCovariatesForecastingModel
+from darts.models.forecasting.forecasting_model import (
+    FutureCovariatesLocalForecastingModel,
+)
 from darts.timeseries import TimeSeries
 
 
-class Croston(DualCovariatesForecastingModel):
+class Croston(FutureCovariatesLocalForecastingModel):
     def __init__(
         self, version: str = "classic", alpha_d: float = None, alpha_p: float = None
     ):

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -10,6 +10,7 @@ from darts.logging import get_logger, raise_if, raise_if_not
 from darts.models.forecasting.forecasting_model import (
     ForecastingModel,
     GlobalForecastingModel,
+    LocalForecastingModel,
 )
 from darts.timeseries import TimeSeries
 
@@ -28,9 +29,7 @@ class EnsembleModel(GlobalForecastingModel):
         List of forecasting models whose predictions to ensemble
     """
 
-    def __init__(
-        self, models: Union[List[ForecastingModel], List[GlobalForecastingModel]]
-    ):
+    def __init__(self, models: List[ForecastingModel]):
         raise_if_not(
             isinstance(models, list) and models,
             "Cannot instantiate EnsembleModel with an empty list of models",
@@ -38,9 +37,7 @@ class EnsembleModel(GlobalForecastingModel):
         )
 
         is_local_ensemble = all(
-            isinstance(model, ForecastingModel)
-            and not isinstance(model, GlobalForecastingModel)
-            for model in models
+            isinstance(model, LocalForecastingModel) for model in models
         )
         self.is_global_ensemble = all(
             isinstance(model, GlobalForecastingModel) for model in models
@@ -48,7 +45,7 @@ class EnsembleModel(GlobalForecastingModel):
 
         raise_if_not(
             is_local_ensemble or self.is_global_ensemble,
-            "All models must either be GlobalForecastingModel instances, or none of them should be.",
+            "All models must be of the same type: either GlobalForecastingModel, or LocalForecastingModel.",
             logger,
         )
 
@@ -76,12 +73,12 @@ class EnsembleModel(GlobalForecastingModel):
         """
         raise_if(
             not self.is_global_ensemble and not isinstance(series, TimeSeries),
-            "The models are not GlobalForecastingModel's and do not support training on multiple series.",
+            "The models are of type LocalForecastingModel, which does not support training on multiple series.",
             logger,
         )
         raise_if(
             not self.is_global_ensemble and past_covariates is not None,
-            "The models are not GlobalForecastingModel's and do not support past covariates.",
+            "The models are of type LocalForecastingModel, which does not support past covariates.",
             logger,
         )
 

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -8,7 +8,6 @@ from typing import List, Optional, Sequence, Union
 
 from darts.logging import get_logger, raise_if, raise_if_not
 from darts.models.forecasting.forecasting_model import (
-    ForecastingModel,
     GlobalForecastingModel,
     LocalForecastingModel,
 )
@@ -29,7 +28,9 @@ class EnsembleModel(GlobalForecastingModel):
         List of forecasting models whose predictions to ensemble
     """
 
-    def __init__(self, models: List[ForecastingModel]):
+    def __init__(
+        self, models: Union[List[LocalForecastingModel], List[GlobalForecastingModel]]
+    ):
         raise_if_not(
             isinstance(models, list) and models,
             "Cannot instantiate EnsembleModel with an empty list of models",

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -9,14 +9,14 @@ import numpy as np
 import statsmodels.tsa.holtwinters as hw
 
 from darts.logging import get_logger
-from darts.models.forecasting.forecasting_model import ForecastingModel
+from darts.models.forecasting.forecasting_model import LocalForecastingModel
 from darts.timeseries import TimeSeries
 from darts.utils.utils import ModelMode, SeasonalityMode
 
 logger = get_logger(__name__)
 
 
-class ExponentialSmoothing(ForecastingModel):
+class ExponentialSmoothing(LocalForecastingModel):
     def __init__(
         self,
         trend: Optional[ModelMode] = ModelMode.ADDITIVE,

--- a/darts/models/forecasting/fft.py
+++ b/darts/models/forecasting/fft.py
@@ -10,7 +10,7 @@ import pandas as pd
 from statsmodels.tsa.stattools import acf
 
 from darts.logging import get_logger
-from darts.models.forecasting.forecasting_model import ForecastingModel
+from darts.models.forecasting.forecasting_model import LocalForecastingModel
 from darts.timeseries import TimeSeries
 from darts.utils.missing_values import fill_missing_values
 
@@ -210,7 +210,7 @@ def _crop_to_match_seasons(
     return series
 
 
-class FFT(ForecastingModel):
+class FFT(LocalForecastingModel):
     def __init__(
         self,
         nr_freqs_to_keep: Optional[int] = 10,

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -1073,7 +1073,7 @@ class LocalForecastingModel(ForecastingModel, ABC):
 
     Local Forecasting Models (LFM) are models that can be trained on a single univariate target series only. In Darts,
     most models in this category tend to be simpler statistical models (such as ETS or FFT). LFMs usually train on
-    the entire target series you supplied when calling :func:`fit()` at once. They can also predict in one go with
+    the entire target series supplied when calling :func:`fit()` at once. They can also predict in one go with
     :func:`predict()` for any number of predictions `n` after the end of the training series.
 
     All implementations must implement the `_fit()` and `_predict()` methods.
@@ -1391,7 +1391,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
 
     Future Covariates Local Forecasting Models (FC-LFM) are models that can be trained on a single uni- or multivariate
     target and optional future covariates series. In Darts, most models in this category tend to be simpler statistical
-    models (such as ARIMA). FC-LFMs usually train on the entire target and future covariates series you supplied when
+    models (such as ARIMA). FC-LFMs usually train on the entire target and future covariates series supplied when
     calling :func:`fit()` at once. They can also predict in one go with :func:`predict()` for any number of predictions
     `n` after the end of the training series. When using future covariates, the values for the future `n` prediction
     steps must be given in the covariate series.
@@ -1566,7 +1566,7 @@ class TransferableFutureCovariatesLocalForecastingModel(
     or multivariate target and optional future covariates series. Additionally, at prediction time, it can be applied
     to new data unrelated to the original series used for fitting the model. Currently in Darts, all models in this
     category wrap to statsmodel models such as VARIMA. TFC-LFMs usually train on the entire target and future covariates
-    series you supplied when calling :func:`fit()` at once. They can also predict in one go with :func:`predict()`
+    series supplied when calling :func:`fit()` at once. They can also predict in one go with :func:`predict()`
     for any number of predictions `n` after the end of the training series. When using future covariates, the values
     for the future `n` prediction steps must be given in the covariate series.
 

--- a/darts/models/forecasting/kalman_forecaster.py
+++ b/darts/models/forecasting/kalman_forecaster.py
@@ -17,13 +17,15 @@ from nfoursid.kalman import Kalman
 
 from darts.logging import get_logger
 from darts.models.filtering.kalman_filter import KalmanFilter
-from darts.models.forecasting.forecasting_model import DualCovariatesForecastingModel
+from darts.models.forecasting.forecasting_model import (
+    FutureCovariatesLocalForecastingModel,
+)
 from darts.timeseries import TimeSeries
 
 logger = get_logger(__name__)
 
 
-class KalmanForecaster(DualCovariatesForecastingModel):
+class KalmanForecaster(FutureCovariatesLocalForecastingModel):
     def __init__(self, dim_x: int = 1, kf: Optional[Kalman] = None):
         """Kalman filter Forecaster
 

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -12,14 +12,16 @@ import pandas as pd
 import prophet
 
 from darts.logging import execute_and_suppress_output, get_logger, raise_if
-from darts.models.forecasting.forecasting_model import DualCovariatesForecastingModel
+from darts.models.forecasting.forecasting_model import (
+    FutureCovariatesLocalForecastingModel,
+)
 from darts.timeseries import TimeSeries
 
 logger = get_logger(__name__)
 logger.level = logging.WARNING  # set to warning to suppress prophet logs
 
 
-class Prophet(DualCovariatesForecastingModel):
+class Prophet(FutureCovariatesLocalForecastingModel):
     def __init__(
         self,
         add_seasonalities: Optional[Union[dict, List[dict]]] = None,

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -8,10 +8,7 @@ from typing import List, Optional, Sequence, Tuple, Union
 
 from darts.logging import get_logger, raise_if, raise_if_not
 from darts.models.forecasting.ensemble_model import EnsembleModel
-from darts.models.forecasting.forecasting_model import (
-    ForecastingModel,
-    GlobalForecastingModel,
-)
+from darts.models.forecasting.forecasting_model import ForecastingModel
 from darts.models.forecasting.linear_regression_model import LinearRegressionModel
 from darts.models.forecasting.regression_model import RegressionModel
 from darts.timeseries import TimeSeries
@@ -22,7 +19,7 @@ logger = get_logger(__name__)
 class RegressionEnsembleModel(EnsembleModel):
     def __init__(
         self,
-        forecasting_models: Union[List[ForecastingModel], List[GlobalForecastingModel]],
+        forecasting_models: List[ForecastingModel],
         regression_train_n_points: int,
         regression_model=None,
     ):

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -8,7 +8,10 @@ from typing import List, Optional, Sequence, Tuple, Union
 
 from darts.logging import get_logger, raise_if, raise_if_not
 from darts.models.forecasting.ensemble_model import EnsembleModel
-from darts.models.forecasting.forecasting_model import ForecastingModel
+from darts.models.forecasting.forecasting_model import (
+    GlobalForecastingModel,
+    LocalForecastingModel,
+)
 from darts.models.forecasting.linear_regression_model import LinearRegressionModel
 from darts.models.forecasting.regression_model import RegressionModel
 from darts.timeseries import TimeSeries
@@ -19,7 +22,9 @@ logger = get_logger(__name__)
 class RegressionEnsembleModel(EnsembleModel):
     def __init__(
         self,
-        forecasting_models: List[ForecastingModel],
+        forecasting_models: Union[
+            List[LocalForecastingModel], List[GlobalForecastingModel]
+        ],
         regression_train_n_points: int,
         regression_model=None,
     ):

--- a/darts/models/forecasting/sf_auto_arima.py
+++ b/darts/models/forecasting/sf_auto_arima.py
@@ -9,10 +9,12 @@ import numpy as np
 from statsforecast.models import AutoARIMA as SFAutoARIMA
 
 from darts import TimeSeries
-from darts.models.forecasting.forecasting_model import DualCovariatesForecastingModel
+from darts.models.forecasting.forecasting_model import (
+    FutureCovariatesLocalForecastingModel,
+)
 
 
-class StatsForecastAutoARIMA(DualCovariatesForecastingModel):
+class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
     def __init__(self, *autoarima_args, **autoarima_kwargs):
         """Auto-ARIMA based on `Statsforecasts package
         <https://github.com/Nixtla/statsforecast>`_.

--- a/darts/models/forecasting/sf_ets.py
+++ b/darts/models/forecasting/sf_ets.py
@@ -8,10 +8,12 @@ from typing import Optional
 from statsforecast.models import ETS
 
 from darts import TimeSeries
-from darts.models.forecasting.forecasting_model import DualCovariatesForecastingModel
+from darts.models.forecasting.forecasting_model import (
+    FutureCovariatesLocalForecastingModel,
+)
 
 
-class StatsForecastETS(DualCovariatesForecastingModel):
+class StatsForecastETS(FutureCovariatesLocalForecastingModel):
     def __init__(self, *ets_args, **ets_kwargs):
         """ETS based on `Statsforecasts package
         <https://github.com/Nixtla/statsforecast>`_.

--- a/darts/models/forecasting/tbats.py
+++ b/darts/models/forecasting/tbats.py
@@ -29,7 +29,7 @@ from tbats import BATS as tbats_BATS
 from tbats import TBATS as tbats_TBATS
 
 from darts.logging import get_logger
-from darts.models.forecasting.forecasting_model import ForecastingModel
+from darts.models.forecasting.forecasting_model import LocalForecastingModel
 from darts.timeseries import TimeSeries
 
 logger = get_logger(__name__)
@@ -111,7 +111,7 @@ def _compute_samples(model, predictions, n_samples):
     return samples
 
 
-class _BaseBatsTbatsModel(ForecastingModel, ABC):
+class _BaseBatsTbatsModel(LocalForecastingModel, ABC):
     def __init__(
         self,
         use_box_cox: Optional[bool] = None,

--- a/darts/models/forecasting/theta.py
+++ b/darts/models/forecasting/theta.py
@@ -10,7 +10,7 @@ import numpy as np
 import statsmodels.tsa.holtwinters as hw
 
 from darts.logging import get_logger, raise_if_not, raise_log
-from darts.models.forecasting.forecasting_model import ForecastingModel
+from darts.models.forecasting.forecasting_model import LocalForecastingModel
 from darts.timeseries import TimeSeries
 from darts.utils.statistics import (
     check_seasonality,
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 ALPHA_START = 0.2
 
 
-class Theta(ForecastingModel):
+class Theta(LocalForecastingModel):
     # .. todo: Implement OTM: Optimized Theta Method (https://arxiv.org/pdf/1503.03529.pdf)
     # .. todo: Try with something different than SES? They do that in the paper.
     def __init__(
@@ -180,7 +180,7 @@ class Theta(ForecastingModel):
             return 3
 
 
-class FourTheta(ForecastingModel):
+class FourTheta(LocalForecastingModel):
     def __init__(
         self,
         theta: int = 2,
@@ -408,7 +408,7 @@ class FourTheta(ForecastingModel):
         using the fitted values on the training series `ts`.
 
 
-        Uses 'ForecastingModel.gridsearch' with 'use_fitted_values=True' and 'metric=metrics.mae`.
+        Uses 'LocalForecastingModel.gridsearch' with 'use_fitted_values=True' and 'metric=metrics.mae`.
 
         Parameters
         ----------

--- a/darts/models/forecasting/varima.py
+++ b/darts/models/forecasting/varima.py
@@ -17,14 +17,14 @@ from statsmodels.tsa.api import VARMAX as staVARMA
 
 from darts.logging import get_logger, raise_if
 from darts.models.forecasting.forecasting_model import (
-    TransferableDualCovariatesForecastingModel,
+    TransferableFutureCovariatesLocalForecastingModel,
 )
 from darts.timeseries import TimeSeries
 
 logger = get_logger(__name__)
 
 
-class VARIMA(TransferableDualCovariatesForecastingModel):
+class VARIMA(TransferableFutureCovariatesLocalForecastingModel):
     def __init__(self, p: int = 1, d: int = 0, q: int = 0, trend: Optional[str] = None):
         """VARIMA
 
@@ -70,8 +70,8 @@ class VARIMA(TransferableDualCovariatesForecastingModel):
         return series
 
     def fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
-        # for VARIMA we need to process target `series` before calling TransferableDualCovariatesForecastingModel'
-        # fit() method
+        # for VARIMA we need to process target `series` before calling
+        # TransferableFutureCovariatesLocalForecastingModel's fit() method
         self._last_values = (
             series.last_values()
         )  # needed for back-transformation when d=1

--- a/darts/tests/models/forecasting/test_local_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_local_forecasting_models.py
@@ -25,6 +25,7 @@ from darts.models import (
     NaiveSeasonal,
     Prophet,
     RandomForest,
+    RegressionModel,
     StatsForecastAutoARIMA,
     StatsForecastETS,
     Theta,
@@ -170,7 +171,8 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
 
     def test_models_runnability(self):
         for model, _ in models:
-            self.asstTrue(isinstance(model, LocalForecastingModel))
+            if not isinstance(model, RegressionModel):
+                self.assertTrue(isinstance(model, LocalForecastingModel))
             prediction = model.fit(self.ts_gaussian).predict(self.forecasting_horizon)
             self.assertTrue(len(prediction) == self.forecasting_horizon)
 

--- a/darts/tests/models/forecasting/test_local_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_local_forecasting_models.py
@@ -30,7 +30,8 @@ from darts.models import (
     Theta,
 )
 from darts.models.forecasting.forecasting_model import (
-    TransferableDualCovariatesForecastingModel,
+    LocalForecastingModel,
+    TransferableFutureCovariatesLocalForecastingModel,
 )
 from darts.tests.base_test_class import DartsBaseTestClass
 from darts.timeseries import TimeSeries
@@ -169,6 +170,7 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
 
     def test_models_runnability(self):
         for model, _ in models:
+            self.asstTrue(isinstance(model, LocalForecastingModel))
             prediction = model.fit(self.ts_gaussian).predict(self.forecasting_horizon)
             self.assertTrue(len(prediction) == self.forecasting_horizon)
 
@@ -293,7 +295,7 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
         self.assertEqual(pred.start_time(), pd.Timestamp("20130121"))
         self.assertEqual(pred.end_time(), pd.Timestamp("20130125"))
 
-    def test_statsmodels_dual_models(self):
+    def test_statsmodels_future_models(self):
 
         # same tests, but VARIMA requires to work on a multivariate target series
         UNIVARIATE = "univariate"
@@ -399,7 +401,9 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
             self.assertTrue(np.array_equal(pred1.values(), pred3.values()))
 
             # check backtesting with retrain=False
-            model: TransferableDualCovariatesForecastingModel = model_cls(**kwargs)
+            model: TransferableFutureCovariatesLocalForecastingModel = model_cls(
+                **kwargs
+            )
             model.backtest(series1, future_covariates=exog1, retrain=False)
 
     @patch("typing.Callable")
@@ -420,16 +424,16 @@ class LocalForecastingModelsTestCase(DartsBaseTestClass):
             "lags_past_covariates": [-1, -2, -3],
         }
         params = [  # tuple of (model, retrain-able, multivariate, retrain parameter, model type)
-            (ExponentialSmoothing(), False, False, "hello", "ForecastingModel"),
-            (ExponentialSmoothing(), False, False, True, "ForecastingModel"),
-            (ExponentialSmoothing(), False, False, -2, "ForecastingModel"),
-            (ExponentialSmoothing(), False, False, 2, "ForecastingModel"),
+            (ExponentialSmoothing(), False, False, "hello", "LocalForecastingModel"),
+            (ExponentialSmoothing(), False, False, True, "LocalForecastingModel"),
+            (ExponentialSmoothing(), False, False, -2, "LocalForecastingModel"),
+            (ExponentialSmoothing(), False, False, 2, "LocalForecastingModel"),
             (
                 ExponentialSmoothing(),
                 False,
                 False,
                 patch_retrain_func,
-                "ForecastingModel",
+                "LocalForecastingModel",
             ),
             (
                 LinearRegressionModel(**lr_univ_args),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,8 +48,8 @@ extensions = [
 autodoc_default_options = {
     "inherited-members": None,
     "show-inheritance": None,
-    "exclude-members": "ForecastingModel,DualCovariatesForecastingModel,TorchForecastingModel,"
-    + "PastCovariatesTorchModel,FutureCovariatesTorchModel,DualCovariatesTorchModel,"
+    "exclude-members": "ForecastingModel,LocalForecastingModel,FutureCovariatesLocalForecastingModel,"
+    + "TorchForecastingModel,PastCovariatesTorchModel,FutureCovariatesTorchModel,DualCovariatesTorchModel,"
     + "MixedCovariatesTorchModel,SplitCovariatesTorchModel,"
     + "TorchParametricProbabilisticForecastingModel,"
     + "min_train_series_length,uses_future_covariates,uses_past_covariates,"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,9 +49,9 @@ autodoc_default_options = {
     "inherited-members": None,
     "show-inheritance": None,
     "exclude-members": "ForecastingModel,LocalForecastingModel,FutureCovariatesLocalForecastingModel,"
-    + "TorchForecastingModel,PastCovariatesTorchModel,FutureCovariatesTorchModel,DualCovariatesTorchModel,"
-    + "MixedCovariatesTorchModel,SplitCovariatesTorchModel,"
-    + "TorchParametricProbabilisticForecastingModel,"
+    + "TransferableFutureCovariatesLocalForecastingModel,GlobalForecastingModel,TorchForecastingModel,"
+    + "PastCovariatesTorchModel,FutureCovariatesTorchModel,DualCovariatesTorchModel,MixedCovariatesTorchModel,"
+    + "SplitCovariatesTorchModel,TorchParametricProbabilisticForecastingModel,"
     + "min_train_series_length,uses_future_covariates,uses_past_covariates,"
     + "untrained_model,first_prediction_index,future_covariate_series,past_covariate_series,"
     + "initialize_encoders,register_datapipe_as_function,register_function,functions,"

--- a/docs/userguide/forecasting_overview.md
+++ b/docs/userguide/forecasting_overview.md
@@ -118,6 +118,15 @@ In turn, the advantage of having `predict()` providing forecasts for potentially
 
 These models are shown with a "✅" under the `Multiple-series training` column on the [model list](https://github.com/unit8co/darts#forecasting-models).
 
+You can also find out programatically, whether a model supports multiple series.
+```python
+from darts.models import RegressionModel
+from darts.models.forecasting.forecasting_model import GlobalForecastingModel
+
+# when True, multiple time series are supported
+supports_multi_ts = issubclass(RegressionModel, GlobalForecastingModel)
+```
+
 [This article](https://medium.com/unit8-machine-learning-publication/training-forecasting-models-on-multiple-time-series-with-darts-dc4be70b1844) provides more explanations about training models on multiple series.
 
 ## Support for Covariates


### PR DESCRIPTION
### Summary
- introduces a dedicted LocalForecastingModel class: no model inherits directly from ForecastingModel anymore -> we can decouple the logic from now on
- renames the local forecasting model base class like DualCovariatesForecastingModel -> FutureCovariatesLocalForecastingModel: I believe we talked once about the naming confusion for this one, and that it should actually be called FutureCovariates... Please correct me if I'm wrong.
  -  feel free to propose different class names, or whether I should revert some of the renaming
