### PR TITLE
Feat/model deeptime

### DIFF
--- a/darts/dataprocessing/transformers/scaler.py
+++ b/darts/dataprocessing/transformers/scaler.py
@@ -73,7 +73,7 @@ class Scaler(InvertibleDataTransformer, FittableDataTransformer):
         >>> print(min(series_transformed.values()))
         [-1.]
         >>> print(max(series_transformed.values()))
-        [2.]
+        [1.]
         """
 
         super().__init__(name=name, n_jobs=n_jobs, verbose=verbose)

--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -29,13 +29,13 @@ from darts.models.forecasting.varima import VARIMA
 
 try:
     from darts.models.forecasting.block_rnn_model import BlockRNNModel
+    from darts.models.forecasting.deeptime import DeepTimeModel
     from darts.models.forecasting.nbeats import NBEATSModel
     from darts.models.forecasting.nhits import NHiTSModel
     from darts.models.forecasting.rnn_model import RNNModel
     from darts.models.forecasting.tcn_model import TCNModel
     from darts.models.forecasting.tft_model import TFTModel
     from darts.models.forecasting.transformer_model import TransformerModel
-
 except ModuleNotFoundError:
     logger.warning(
         "Support for Torch based models not available. "

--- a/darts/models/forecasting/deeptime.py
+++ b/darts/models/forecasting/deeptime.py
@@ -1,0 +1,497 @@
+"""
+DeepTime
+-------
+"""
+
+from typing import List, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from darts.logging import get_logger, raise_if_not
+from darts.models.forecasting.pl_forecasting_module import PLPastCovariatesModule
+from darts.models.forecasting.torch_forecasting_model import PastCovariatesTorchModel
+from darts.utils.torch import MonteCarloDropout
+
+logger = get_logger(__name__)
+
+
+ACTIVATIONS = [
+    "ReLU",
+    "RReLU",
+    "PReLU",
+    "ELU",
+    "Softplus",
+    "Tanh",
+    "SELU",
+    "LeakyReLU",
+    "Sigmoid",
+    "GELU",
+]
+
+
+class GaussianFourierFeatureTransform(nn.Module):
+    """
+    https://github.com/ndahlquist/pytorch-fourier-feature-networks
+    Given an input of size [..., time, dim], returns a tensor of size [..., n_fourier_feats, time].
+    """
+
+    def __init__(self, input_dim: int, n_fourier_feats: int, scales: List[float]):
+        super().__init__()
+        self.input_dim = input_dim
+        self.n_fourier_feats = n_fourier_feats
+        self.scales = scales
+
+        n_scale_feats = n_fourier_feats // (2 * len(scales))
+        B_size = (input_dim, n_scale_feats)
+        # Sample Fourier components
+        B = torch.cat([torch.randn(B_size) * scale for scale in scales], dim=1)
+        self.register_buffer("B", B)
+
+    def forward(self, x: Tensor) -> Tensor:
+        raise_if_not(
+            x.dim() >= 2,
+            f"Expected 2 or more dimensional input (got {x.dim()}D input)",
+            logger,
+        )
+        dim = x.shape[-1]
+        raise_if_not(
+            dim == self.input_dim,
+            f"Expected input to have {self.input_dim} channels (got {dim} channels)",
+            logger,
+        )
+
+        x = torch.einsum("... t n, n d -> ... t d", [x, self.B])
+        x = 2 * np.pi * x
+        return torch.cat([torch.sin(x), torch.cos(x)], dim=-1)
+
+
+class INR(nn.Module):
+    def __init__(
+        self,
+        input_size: int,
+        num_layers: int,
+        hidden_layers_width: int,
+        n_fourier_feats: int,
+        scales: list[float],
+        dropout: float,
+        activation: str,
+    ):
+        """Implicit Neural Representation, mapping values to their coordinates using a Multi-Layer Perceptron.
+
+        Features can be encoded using either a Linear layer or a Gaussian Fourier Transform
+
+        Parameters
+            ----------
+            input_size
+                The dimensionality of the input time series.
+            num_layers
+                The number of fully connected layers.
+            hidden_layers_width
+                Determines the number of neurons that make up each hidden fully connected layer.
+                If a list is passed, it must have a length equal to `num_layers`. If an integer is passed,
+                every layers will have the same width.
+            n_fourier_feats
+                Number of Fourier components to sample to represent to time-serie in the frequency domain
+            scales
+                Scaling factors applied to the normal distribution sampled for Fourier components' magnitude
+            dropout
+                The fraction of neurons that are dropped at each layer.
+            activation
+                The activation function of fully connected network intermediate layers.
+
+            Inputs
+            ------
+            x of shape `(batch_size, input_size)`
+                Tensor containing the features of the input sequence.
+
+            Outputs
+            -------
+            y of shape `(batch_size, output_chunk_length, target_size, nr_params)`
+                Tensor containing the prediction at the last time step of the sequence.
+        """
+        super().__init__()
+
+        self.input_size = input_size
+        self.num_layers = num_layers
+        self.n_fourier_feats = n_fourier_feats
+        self.scales = scales
+        self.dropout = dropout
+
+        raise_if_not(
+            activation in ACTIVATIONS, f"'{activation}' is not in {ACTIVATIONS}"
+        )
+        self.activation = getattr(nn, activation)()
+
+        if isinstance(hidden_layers_width, int):
+            self.hidden_layers_width = [hidden_layers_width] * self.num_layers
+        else:
+            self.hidden_layers_width = hidden_layers_width
+
+        if n_fourier_feats == 0:
+            feats_size = self.hidden_layers_width[0]
+            self.features = nn.Linear(self.input_size, feats_size)
+        else:
+            feats_size = self.n_fourier_feats
+            self.features = GaussianFourierFeatureTransform(
+                self.input_size, feats_size, self.scales
+            )
+
+        # Fully Connected Network
+        # TODO : solve ambiguity between the num of layers and the number of hidden layers
+        last_width = feats_size
+        linear_layer_stack_list = []
+        for layer_width in self.hidden_layers_width:
+            linear_layer_stack_list.append(nn.Linear(last_width, layer_width))
+            linear_layer_stack_list.append(self.activation)
+
+            if self.dropout > 0:
+                linear_layer_stack_list.append(MonteCarloDropout(p=self.dropout))
+
+            linear_layer_stack_list.append(nn.LayerNorm(layer_width))
+
+            last_width = layer_width
+
+        self.layers = nn.Sequential(*linear_layer_stack_list)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.features(x)
+        return self.layers(x)
+
+
+class RidgeRegressor(nn.Module):
+    def __init__(self, lambda_init: float = 0.0):
+        super().__init__()
+        self._lambda = nn.Parameter(torch.as_tensor(lambda_init, dtype=torch.float))
+
+    def forward(self, reprs: Tensor, x: Tensor, reg_coeff: float = None) -> Tensor:
+        if reg_coeff is None:
+            reg_coeff = self.reg_coeff()
+        w, b = self.get_weights(reprs, x, reg_coeff)
+        return w, b
+
+    def get_weights(self, X: Tensor, Y: Tensor, reg_coeff: float) -> Tensor:
+        batch_size, n_samples, n_dim = X.shape
+        ones = torch.ones(batch_size, n_samples, 1, device=X.device)
+        X = torch.concat([X, ones], dim=-1)
+
+        if n_samples >= n_dim:
+            # standard
+            A = torch.bmm(X.mT, X)
+            A.diagonal(dim1=-2, dim2=-1).add_(reg_coeff)
+            B = torch.bmm(X.mT, Y)
+            weights = torch.linalg.solve(A, B)
+        else:
+            # Woodbury
+            A = torch.bmm(X, X.mT)
+            A.diagonal(dim1=-2, dim2=-1).add_(reg_coeff)
+            weights = torch.bmm(X.mT, torch.linalg.solve(A, Y))
+
+        return weights[:, :-1], weights[:, -1:]
+
+    def reg_coeff(self) -> Tensor:
+        return F.softplus(self._lambda)
+
+
+class _DeepTimeModule(PLPastCovariatesModule):
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        nr_params: int,
+        inr_num_layers: int,
+        inr_layers_width: Union[int, List[int]],
+        n_fourier_feats: int,
+        scales: list[float],
+        dropout: float,
+        activation: str,
+        **kwargs,
+    ):
+        """PyTorch module implementing the DeepTIMe architecture.
+
+        Parameters
+        ----------
+        input_chunk_length
+            The length of the input sequence (lookback) fed to the model.
+        output_chunk_length
+            The length of the forecast (horizon) of the model.
+        inr_num_layers
+            The number of fully connected layers in the INR module.
+        inr_layers_width
+            Determines the number of neurons that make up each hidden fully connected layer of the INR module.
+            If a list is passed, it must have a length equal to `num_layers`. If an integer is passed,
+            every layers will have the same width.
+        n_fourier_feats
+            Number of Fourier components to sample to represent to time-serie in the frequency domain
+        scales
+            Scaling factors applied to the normal distribution sampled for Fourier components' magnitude
+        dropout
+            The dropout probability to be used in fully connected layers (default=0). This is compatible with
+            Monte Carlo dropout at inference time for model uncertainty estimation (enabled with
+            ``mc_dropout=True`` at prediction time).
+        activation
+            The activation function of encoder/decoder intermediate layer (default='ReLU').
+            Supported activations: ['ReLU','RReLU', 'PReLU', 'Softplus', 'Tanh', 'SELU', 'LeakyReLU',  'Sigmoid']
+        **kwargs
+            Optional arguments to initialize the pytorch_lightning.Module, pytorch_lightning.Trainer, and
+            Darts' :class:`TorchForecastingModel`.
+        """
+        super().__init__(**kwargs)
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        # TODO: develop support for nr_params functionality
+        self.nr_params = nr_params
+        self.inr_num_layers = inr_num_layers
+        self.inr_layers_width = inr_layers_width
+        self.n_fourier_feats = n_fourier_feats
+        self.scales = scales
+
+        self.dropout = dropout
+        self.activation = activation
+
+        # single INR for both univariate and multivariate
+        self.inr = INR(
+            input_size=self.input_chunk_length,
+            num_layers=self.inr_num_layers,
+            hidden_layers_width=self.inr_layers_width,
+            n_fourier_feats=self.n_fourier_feats,
+            scales=self.scales,
+            dropout=self.dropout,
+            activation=self.activation,
+        )
+
+        # lambda_ constructor argument should be connected to torch lightning
+        self.adaptive_weights = RidgeRegressor()
+
+    def forward(self, x_in: Tensor) -> Tensor:
+        x, _ = x_in  # x_in: (past_target|past_covariate, static_covariates)
+
+        batch_size, _, in_dim = x.shape  # x: (batch, in_len, in_dim)
+        coords = self.get_coords(self.input_chunk_length, self.output_chunk_length).to(
+            x.device
+        )
+
+        """
+        I don't understand why this code is there... Why would the time have last dim greater than 0?!
+        if y_time.shape[-1] != 0:
+            time = torch.cat([x_time, y_time], dim=1)
+            coords = repeat(coords, '1 t 1 -> b t 1', b=time.shape[0])
+            coords = torch.cat([coords, time], dim=-1)
+            time_reprs = self.inr(coords)
+        """
+
+        # multivariate
+        if self.output_dim > 1:
+            time = torch.zeros(
+                size=(
+                    batch_size,
+                    self.input_chunk_length + self.output_chunk_length,
+                    self.output_dim,
+                )
+            ).to(x.device)
+            coords = coords.repeat(batch_size, 1, 1)
+            coords = torch.cat([coords, time], dim=-1)
+            time_reprs = self.inr(coords)
+        # univariate
+        else:
+            time_reprs = self.inr(coords)
+            time_reprs = time_reprs.repeat(batch_size, 1, 1)
+
+        lookback_reprs = time_reprs[:, : -self.output_chunk_length]
+        horizon_reprs = time_reprs[:, -self.output_chunk_length :]
+        # learn weights from the lookback
+        w, b = self.adaptive_weights(lookback_reprs, x)
+        # apply weights to the horizon
+        y = torch.einsum("... d o, ... t d -> ... t o", [w, horizon_reprs]) + b
+
+        y = y.view(
+            y.shape[0], self.output_chunk_length, self.input_dim, self.nr_params
+        )[:, :, : self.output_dim, :]
+        return y
+
+    def get_coords(self, lookback_len: int, horizon_len: int) -> Tensor:
+        """Return time axis encoded as float values between 0 and 1"""
+        coords = torch.linspace(0, 1, lookback_len + horizon_len)
+        # would it be clearer with the unsqueeze operator?
+        return torch.reshape(coords, (1, lookback_len + horizon_len, 1))
+
+
+class DeepTimeModel(PastCovariatesTorchModel):
+    def __init__(
+        self,
+        input_chunk_length: int,
+        output_chunk_length: int,
+        inr_num_layers: int = 5,
+        inr_layers_width: Union[int, List[int]] = 256,
+        n_fourier_feats: int = 4096,
+        scales: list[float] = [0.01, 0.1, 1, 5, 10, 20, 50, 100],
+        dropout: float = 0.1,
+        activation: str = "ReLU",
+        **kwargs,
+    ):
+        """Deep time-index model with meta-learning (DeepTIMe).
+
+        This is an implementation of the DeepTime architecture, as outlined in [1]_. The default arguments
+        correspond to the hyper-parameters described in the published article.
+
+        This model supports past covariates (known for `input_chunk_length` points before prediction time).
+
+        Parameters
+        ----------
+        input_chunk_length
+            The length of the input sequence (lookback) fed to the model.
+        output_chunk_length
+            The length of the forecast (horizon) of the model.
+        inr_num_layers
+            The number of fully connected layers in the INR module.
+        inr_layers_width
+            Determines the number of neurons that make up each hidden fully connected layer of the INR module.
+            If a list is passed, it must have a length equal to `num_layers`. If an integer is passed,
+            every layers will have the same width.
+        n_fourier_feats
+            Number of Fourier components to sample to represent to time-serie in the frequency domain
+        scales
+            Scaling factors applied to the normal distribution sampled for Fourier components' magnitude
+        dropout
+            The dropout probability to be used in fully connected layers (default=0). This is compatible with
+            Monte Carlo dropout at inference time for model uncertainty estimation (enabled with
+            ``mc_dropout=True`` at prediction time).
+        activation
+            The activation function of encoder/decoder intermediate layer (default='ReLU').
+            Supported activations: ['ReLU','RReLU', 'PReLU', 'Softplus', 'Tanh', 'SELU', 'LeakyReLU',  'Sigmoid']
+        **kwargs
+            Optional arguments to initialize the pytorch_lightning.Module, pytorch_lightning.Trainer, and
+            Darts' :class:`TorchForecastingModel`.
+
+        loss_fn
+            PyTorch loss function used for training.
+            This parameter will be ignored for probabilistic models if the ``likelihood`` parameter is specified.
+            Default: ``torch.nn.MSELoss()``.
+        torch_metrics
+            A torch metric or a ``MetricCollection`` used for evaluation. A full list of available metrics can be found
+            at https://torchmetrics.readthedocs.io/en/latest/. Default: ``None``.
+        optimizer_cls
+            The PyTorch optimizer class to be used. Default: ``torch.optim.Adam``.
+        optimizer_kwargs
+            Optionally, some keyword arguments for the PyTorch optimizer (e.g., ``{'lr': 1e-3}``
+            for specifying a learning rate). Otherwise the default values of the selected ``optimizer_cls``
+            will be used. Default: ``None``.
+        lr_scheduler_cls
+            Optionally, the PyTorch learning rate scheduler class to be used. Specifying ``None`` corresponds
+            to using a constant learning rate. Default: ``None``.
+        lr_scheduler_kwargs
+            Optionally, some keyword arguments for the PyTorch learning rate scheduler. Default: ``None``.
+        batch_size
+            Number of time series (input and output sequences) used in each training pass. Default: ``32``.
+        n_epochs
+            Number of epochs over which to train the model. Default: ``100``.
+        model_name
+            Name of the model. Used for creating checkpoints and saving tensorboard data. If not specified,
+            defaults to the following string ``"YYYY-mm-dd_HH:MM:SS_torch_model_run_PID"``, where the initial part
+            of the name is formatted with the local date and time, while PID is the processed ID (preventing models
+            spawned at the same time by different processes to share the same model_name). E.g.,
+            ``"2021-06-14_09:53:32_torch_model_run_44607"``.
+        work_dir
+            Path of the working directory, where to save checkpoints and Tensorboard summaries.
+            Default: current working directory.
+        log_tensorboard
+            If set, use Tensorboard to log the different parameters. The logs will be located in:
+            ``"{work_dir}/darts_logs/{model_name}/logs/"``. Default: ``False``.
+        nr_epochs_val_period
+            Number of epochs to wait before evaluating the validation loss (if a validation
+            ``TimeSeries`` is passed to the :func:`fit()` method). Default: ``1``.
+        force_reset
+            If set to ``True``, any previously-existing model with the same name will be reset (all checkpoints will
+            be discarded). Default: ``False``.
+        save_checkpoints
+            Whether or not to automatically save the untrained model and checkpoints from training.
+            To load the model from checkpoint, call :func:`MyModelClass.load_from_checkpoint()`, where
+            :class:`MyModelClass` is the :class:`TorchForecastingModel` class that was used (such as :class:`TFTModel`,
+            :class:`NBEATSModel`, etc.). If set to ``False``, the model can still be manually saved using
+            :func:`save_model()` and loaded using :func:`load_model()`. Default: ``False``.
+        add_encoders
+            A large number of past and future covariates can be automatically generated with `add_encoders`.
+            This can be done by adding multiple pre-defined index encoders and/or custom user-made functions that
+            will be used as index encoders. Additionally, a transformer such as Darts' :class:`Scaler` can be added to
+            transform the generated covariates. This happens all under one hood and only needs to be specified at
+            model creation.
+            Read :meth:`SequentialEncoder <darts.dataprocessing.encoders.SequentialEncoder>` to find out more about
+            ``add_encoders``. Default: ``None``. An example showing some of ``add_encoders`` features:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                add_encoders={
+                    'cyclic': {'future': ['month']},
+                    'datetime_attribute': {'future': ['hour', 'dayofweek']},
+                    'position': {'past': ['relative'], 'future': ['relative']},
+                    'custom': {'past': [lambda idx: (idx.year - 1950) / 50]},
+                    'transformer': Scaler()
+                }
+            ..
+        random_state
+            Control the randomness of the weights initialization. Check this
+            `link <https://scikit-learn.org/stable/glossary.html#term-random_state>`_ for more details.
+            Default: ``None``.
+
+        References
+        ----------
+        .. [1] https://arxiv.org/abs/2207.06046
+        """
+        super().__init__(**self._extract_torch_model_params(**self.model_params))
+
+        # extract pytorch lightning module kwargs
+        self.pl_module_params = self._extract_pl_module_params(**self.model_params)
+
+        raise_if_not(
+            isinstance(inr_layers_width, int)
+            or len(inr_layers_width) == inr_num_layers,
+            "Please pass an integer or a list of integers with length `inr_num_layers`"
+            "as value for the `inr_layers_width` argument.",
+            logger,
+        )
+
+        raise_if_not(
+            n_fourier_feats % (2 * len(scales)) == 0,
+            f"n_fourier_feats: {n_fourier_feats} must be divisible by 2 * len(scales) = {2 * len(scales)}",
+            logger,
+        )
+
+        self.inr_num_layers = inr_num_layers
+        self.inr_layers_width = inr_layers_width
+        self.n_fourier_feats = n_fourier_feats
+        self.scales = scales
+
+        self.dropout = dropout
+        self.activation = activation
+
+    # TODO: might actually be True?
+    @staticmethod
+    def _supports_static_covariates() -> bool:
+        return False
+
+    def _create_model(self, train_sample: Tuple[torch.Tensor]) -> torch.nn.Module:
+        input_dim = train_sample[0].shape[1] + (
+            train_sample[1].shape[1] if train_sample[1] is not None else 0
+        )
+        output_dim = train_sample[-1].shape[1]
+        nr_params = 1 if self.likelihood is None else self.likelihood.num_parameters
+
+        # TODO: support nr_params functionnality
+        model = _DeepTimeModule(
+            input_dim=input_dim,
+            output_dim=output_dim,
+            nr_params=nr_params,
+            input_chunk_length=self.input_chunk_length,
+            output_chunk_length=self.output_chunk_length,
+            inr_num_layers=self.inr_num_layers,
+            inr_layers_width=self.inr_layers_width,
+            n_fourier_feats=self.n_fourier_feats,
+            scales=self.scales,
+            dropout=self.dropout,
+            activation=self.activation,
+        )
+        return model

--- a/darts/tests/models/forecasting/test_deeptime.py
+++ b/darts/tests/models/forecasting/test_deeptime.py
@@ -31,7 +31,7 @@ if TORCH_AVAILABLE:
             with self.assertRaises(ValueError):
                 # if a list is passed to the `layer_widths` argument, it must have a length equal to `num_stacks`
                 DeepTimeModel(
-                    input_chunk_length=2,
+                    input_chunk_length=1,
                     output_chunk_length=1,
                     inr_num_layers=3,
                     inr_layers_width=[1],
@@ -43,7 +43,7 @@ if TORCH_AVAILABLE:
 
             # Test basic fit and predict
             model = DeepTimeModel(
-                input_chunk_length=2,
+                input_chunk_length=1,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -58,7 +58,7 @@ if TORCH_AVAILABLE:
 
             # Test whether model trained on one series is better than one trained on another
             model2 = DeepTimeModel(
-                input_chunk_length=2,
+                input_chunk_length=1,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -132,7 +132,7 @@ if TORCH_AVAILABLE:
                 # wrong number of scales and n_fourier feats
                 # n_fourier_feats must be divisiable by 2*len(scales)
                 DeepTimeModel(
-                    input_chunk_length=2,
+                    input_chunk_length=1,
                     output_chunk_length=1,
                     n_epochs=10,
                     inr_num_layers=2,
@@ -148,7 +148,7 @@ if TORCH_AVAILABLE:
 
             # Test basic fit and predict
             model = DeepTimeModel(
-                input_chunk_length=2,
+                input_chunk_length=1,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -165,7 +165,7 @@ if TORCH_AVAILABLE:
             ts = tg.constant_timeseries(length=50, value=10)
 
             model = DeepTimeModel(
-                input_chunk_length=2,
+                input_chunk_length=1,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -180,7 +180,7 @@ if TORCH_AVAILABLE:
 
             with self.assertRaises(ValueError):
                 model = DeepTimeModel(
-                    input_chunk_length=2,
+                    input_chunk_length=1,
                     output_chunk_length=1,
                     n_epochs=10,
                     inr_num_layers=2,

--- a/darts/tests/models/forecasting/test_deeptime.py
+++ b/darts/tests/models/forecasting/test_deeptime.py
@@ -50,7 +50,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=False,
+                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(large_ts[:98])
@@ -65,7 +65,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=False,
+                legacy_optimiser=True,
                 random_state=42,
             )
             model2.fit(small_ts[:98])
@@ -87,10 +87,10 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=5,
-                inr_layers_width=32,
+                inr_layers_width=64,
                 n_fourier_feats=256,  # must have enough fourier components to capture low freq
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=False,
+                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(series_multivariate)
@@ -114,7 +114,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=False,
+                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(series_multivariate, past_covariates=series_covariates)
@@ -138,7 +138,7 @@ if TORCH_AVAILABLE:
                     inr_layers_width=20,
                     n_fourier_feats=17,
                     scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                    legacy_optimiser=False,
+                    legacy_optimiser=True,
                     random_state=42,
                 )
 
@@ -154,7 +154,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=False,
+                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(ts)
@@ -171,7 +171,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=False,
+                legacy_optimiser=True,
                 activation="LeakyReLU",
                 random_state=42,
             )
@@ -186,7 +186,7 @@ if TORCH_AVAILABLE:
                     inr_layers_width=20,
                     n_fourier_feats=64,
                     scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                    legacy_optimiser=False,
+                    legacy_optimiser=True,
                     activation="invalid",
                     random_state=42,
                 )

--- a/darts/tests/models/forecasting/test_deeptime.py
+++ b/darts/tests/models/forecasting/test_deeptime.py
@@ -50,6 +50,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                legacy_optimiser=False,
                 random_state=42,
             )
             model.fit(large_ts[:98])
@@ -64,6 +65,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                legacy_optimiser=False,
                 random_state=42,
             )
             model2.fit(small_ts[:98])
@@ -88,6 +90,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=32,
                 n_fourier_feats=256,  # must have enough fourier components to capture low freq
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                legacy_optimiser=False,
                 random_state=42,
             )
             model.fit(series_multivariate)
@@ -111,6 +114,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                legacy_optimiser=False,
                 random_state=42,
             )
             model.fit(series_multivariate, past_covariates=series_covariates)
@@ -134,6 +138,7 @@ if TORCH_AVAILABLE:
                     inr_layers_width=20,
                     n_fourier_feats=17,
                     scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                    legacy_optimiser=False,
                     random_state=42,
                 )
 
@@ -149,6 +154,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                legacy_optimiser=False,
                 random_state=42,
             )
             model.fit(ts)
@@ -165,6 +171,7 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                legacy_optimiser=False,
                 activation="LeakyReLU",
                 random_state=42,
             )
@@ -179,6 +186,7 @@ if TORCH_AVAILABLE:
                     inr_layers_width=20,
                     n_fourier_feats=64,
                     scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                    legacy_optimiser=False,
                     activation="invalid",
                     random_state=42,
                 )

--- a/darts/tests/models/forecasting/test_deeptime.py
+++ b/darts/tests/models/forecasting/test_deeptime.py
@@ -31,7 +31,7 @@ if TORCH_AVAILABLE:
             with self.assertRaises(ValueError):
                 # if a list is passed to the `layer_widths` argument, it must have a length equal to `num_stacks`
                 DeepTimeModel(
-                    input_chunk_length=1,
+                    input_chunk_length=2,
                     output_chunk_length=1,
                     inr_num_layers=3,
                     inr_layers_width=[1],
@@ -43,7 +43,7 @@ if TORCH_AVAILABLE:
 
             # Test basic fit and predict
             model = DeepTimeModel(
-                input_chunk_length=1,
+                input_chunk_length=2,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -58,7 +58,7 @@ if TORCH_AVAILABLE:
 
             # Test whether model trained on one series is better than one trained on another
             model2 = DeepTimeModel(
-                input_chunk_length=1,
+                input_chunk_length=2,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -98,6 +98,7 @@ if TORCH_AVAILABLE:
 
             # the theoretical result should be [[1.01, 1.02], [0.505, 0.51]].
             # We just test if the given result is not too far on average.
+            print(res)
             self.assertTrue(
                 abs(np.average(res - np.array([[1.01, 1.02], [0.505, 0.51]])) < 0.03)
             )
@@ -131,7 +132,7 @@ if TORCH_AVAILABLE:
                 # wrong number of scales and n_fourier feats
                 # n_fourier_feats must be divisiable by 2*len(scales)
                 DeepTimeModel(
-                    input_chunk_length=1,
+                    input_chunk_length=2,
                     output_chunk_length=1,
                     n_epochs=10,
                     inr_num_layers=2,
@@ -147,7 +148,7 @@ if TORCH_AVAILABLE:
 
             # Test basic fit and predict
             model = DeepTimeModel(
-                input_chunk_length=1,
+                input_chunk_length=2,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -164,7 +165,7 @@ if TORCH_AVAILABLE:
             ts = tg.constant_timeseries(length=50, value=10)
 
             model = DeepTimeModel(
-                input_chunk_length=1,
+                input_chunk_length=2,
                 output_chunk_length=1,
                 n_epochs=10,
                 inr_num_layers=2,
@@ -179,7 +180,7 @@ if TORCH_AVAILABLE:
 
             with self.assertRaises(ValueError):
                 model = DeepTimeModel(
-                    input_chunk_length=1,
+                    input_chunk_length=2,
                     output_chunk_length=1,
                     n_epochs=10,
                     inr_num_layers=2,

--- a/darts/tests/models/forecasting/test_deeptime.py
+++ b/darts/tests/models/forecasting/test_deeptime.py
@@ -1,0 +1,185 @@
+import shutil
+import tempfile
+
+import numpy as np
+
+from darts.logging import get_logger
+from darts.tests.base_test_class import DartsBaseTestClass
+from darts.utils import timeseries_generation as tg
+
+logger = get_logger(__name__)
+
+try:
+    from darts.models.forecasting.deeptime import DeepTimeModel
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    logger.warning("Torch not available. TCN tests will be skipped.")
+    TORCH_AVAILABLE = False
+
+
+if TORCH_AVAILABLE:
+
+    class DeepTimeModelTestCase(DartsBaseTestClass):
+        def setUp(self):
+            self.temp_work_dir = tempfile.mkdtemp(prefix="darts")
+
+        def tearDown(self):
+            shutil.rmtree(self.temp_work_dir)
+
+        def test_creation(self):
+            with self.assertRaises(ValueError):
+                # if a list is passed to the `layer_widths` argument, it must have a length equal to `num_stacks`
+                DeepTimeModel(
+                    input_chunk_length=1,
+                    output_chunk_length=1,
+                    inr_num_layers=3,
+                    inr_layers_width=[1],
+                )
+
+        def test_fit(self):
+            large_ts = tg.constant_timeseries(length=100, value=1000)
+            small_ts = tg.constant_timeseries(length=100, value=10)
+
+            # Test basic fit and predict
+            model = DeepTimeModel(
+                input_chunk_length=1,
+                output_chunk_length=1,
+                n_epochs=10,
+                inr_num_layers=2,
+                inr_layers_width=20,
+                n_fourier_feats=64,
+                scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                random_state=42,
+            )
+            model.fit(large_ts[:98])
+            pred = model.predict(n=2).values()[0]
+
+            # Test whether model trained on one series is better than one trained on another
+            model2 = DeepTimeModel(
+                input_chunk_length=1,
+                output_chunk_length=1,
+                n_epochs=10,
+                inr_num_layers=2,
+                inr_layers_width=20,
+                n_fourier_feats=64,
+                scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                random_state=42,
+            )
+            model2.fit(small_ts[:98])
+            pred2 = model2.predict(n=2).values()[0]
+            self.assertTrue(abs(pred2 - 10) < abs(pred - 10))
+
+            # test short predict
+            pred3 = model2.predict(n=1)
+            self.assertEqual(len(pred3), 1)
+
+        def test_multivariate(self):
+            # testing a 2-variate linear ts, first one from 0 to 1, second one from 0 to 0.5, length 100
+            series_multivariate = tg.linear_timeseries(length=100).stack(
+                tg.linear_timeseries(length=100, start_value=0, end_value=0.5)
+            )
+
+            model = DeepTimeModel(
+                input_chunk_length=3,
+                output_chunk_length=1,
+                n_epochs=10,
+                inr_num_layers=5,
+                inr_layers_width=32,
+                n_fourier_feats=256,  # must have enough fourier components to capture low freq
+                scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                random_state=42,
+            )
+            model.fit(series_multivariate)
+            res = model.predict(n=2).values()
+
+            # the theoretical result should be [[1.01, 1.02], [0.505, 0.51]].
+            # We just test if the given result is not too far on average.
+            self.assertTrue(
+                abs(np.average(res - np.array([[1.01, 1.02], [0.505, 0.51]])) < 0.03)
+            )
+
+            # Test Covariates
+            series_covariates = tg.linear_timeseries(length=100).stack(
+                tg.linear_timeseries(length=100, start_value=0, end_value=0.1)
+            )
+            model = DeepTimeModel(
+                input_chunk_length=3,
+                output_chunk_length=4,
+                n_epochs=10,
+                inr_num_layers=2,
+                inr_layers_width=20,
+                n_fourier_feats=64,
+                scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                random_state=42,
+            )
+            model.fit(series_multivariate, past_covariates=series_covariates)
+
+            res = model.predict(
+                n=3, series=series_multivariate, past_covariates=series_covariates
+            ).values()
+
+            self.assertEqual(len(res), 3)
+            self.assertTrue(abs(np.average(res)) < 5)
+
+        def test_deeptime_n_fourier_feats(self):
+            with self.assertRaises(ValueError):
+                # wrong number of scales and n_fourier feats
+                # n_fourier_feats must be divisiable by 2*len(scales)
+                DeepTimeModel(
+                    input_chunk_length=1,
+                    output_chunk_length=1,
+                    n_epochs=10,
+                    inr_num_layers=2,
+                    inr_layers_width=20,
+                    n_fourier_feats=17,
+                    scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                    random_state=42,
+                )
+
+        def test_logtensorboard(self):
+            ts = tg.constant_timeseries(length=50, value=10)
+
+            # Test basic fit and predict
+            model = DeepTimeModel(
+                input_chunk_length=1,
+                output_chunk_length=1,
+                n_epochs=10,
+                inr_num_layers=2,
+                inr_layers_width=20,
+                n_fourier_feats=64,
+                scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                random_state=42,
+            )
+            model.fit(ts)
+            model.predict(n=2)
+
+        def test_activation_fns(self):
+            ts = tg.constant_timeseries(length=50, value=10)
+
+            model = DeepTimeModel(
+                input_chunk_length=1,
+                output_chunk_length=1,
+                n_epochs=10,
+                inr_num_layers=2,
+                inr_layers_width=20,
+                n_fourier_feats=64,
+                scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                activation="LeakyReLU",
+                random_state=42,
+            )
+            model.fit(ts)
+
+            with self.assertRaises(ValueError):
+                model = DeepTimeModel(
+                    input_chunk_length=1,
+                    output_chunk_length=1,
+                    n_epochs=10,
+                    inr_num_layers=2,
+                    inr_layers_width=20,
+                    n_fourier_feats=64,
+                    scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
+                    activation="invalid",
+                    random_state=42,
+                )
+                model.fit(ts)

--- a/darts/tests/models/forecasting/test_deeptime.py
+++ b/darts/tests/models/forecasting/test_deeptime.py
@@ -50,7 +50,6 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(large_ts[:98])
@@ -65,7 +64,6 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=True,
                 random_state=42,
             )
             model2.fit(small_ts[:98])
@@ -90,7 +88,6 @@ if TORCH_AVAILABLE:
                 inr_layers_width=64,
                 n_fourier_feats=256,  # must have enough fourier components to capture low freq
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(series_multivariate)
@@ -115,7 +112,6 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(series_multivariate, past_covariates=series_covariates)
@@ -139,7 +135,6 @@ if TORCH_AVAILABLE:
                     inr_layers_width=20,
                     n_fourier_feats=17,
                     scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                    legacy_optimiser=True,
                     random_state=42,
                 )
 
@@ -155,7 +150,6 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=True,
                 random_state=42,
             )
             model.fit(ts)
@@ -172,7 +166,6 @@ if TORCH_AVAILABLE:
                 inr_layers_width=20,
                 n_fourier_feats=64,
                 scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                legacy_optimiser=True,
                 activation="LeakyReLU",
                 random_state=42,
             )
@@ -187,7 +180,6 @@ if TORCH_AVAILABLE:
                     inr_layers_width=20,
                     n_fourier_feats=64,
                     scales=[0.01, 0.1, 1, 5, 10, 20, 50, 100],
-                    legacy_optimiser=True,
                     activation="invalid",
                     random_state=42,
                 )

--- a/darts/utils/data/training_dataset.py
+++ b/darts/utils/data/training_dataset.py
@@ -202,7 +202,7 @@ class TrainingDataset(ABC, Dataset):
 class PastCovariatesTrainingDataset(TrainingDataset, ABC):
     def __init__(self):
         """
-        Abstract class for a PastCovariatesTorchModel training dataset. It contains 3-tuples of
+        Abstract class for a PastCovariatesTorchModel training dataset. It contains 4-tuples of
         `(past_target, past_covariate, static_covariates, future_target)` `np.ndarray`.
         The covariates are optional and can be `None`.
         """
@@ -218,7 +218,7 @@ class PastCovariatesTrainingDataset(TrainingDataset, ABC):
 class FutureCovariatesTrainingDataset(TrainingDataset, ABC):
     def __init__(self):
         """
-        Abstract class for a FutureCovariatesTorchModel training dataset. It contains 3-tuples of
+        Abstract class for a FutureCovariatesTorchModel training dataset. It contains 4-tuples of
         `(past_target, future_covariate, static_covariates, future_target)` `np.ndarray`.
         The covariates are optional and can be `None`.
         """
@@ -234,7 +234,7 @@ class FutureCovariatesTrainingDataset(TrainingDataset, ABC):
 class DualCovariatesTrainingDataset(TrainingDataset, ABC):
     def __init__(self):
         """
-        Abstract class for a DualCovariatesTorchModel training dataset. It contains 4-tuples of
+        Abstract class for a DualCovariatesTorchModel training dataset. It contains 5-tuples of
         `(past_target, historic_future_covariates, future_covariates, static_covariates, future_target)` `np.ndarray`.
         The covariates are optional and can be `None`.
         """
@@ -256,7 +256,7 @@ class DualCovariatesTrainingDataset(TrainingDataset, ABC):
 class MixedCovariatesTrainingDataset(TrainingDataset, ABC):
     def __init__(self):
         """
-        Abstract class for a MixedCovariatesTorchModel training dataset. It contains 5-tuples of
+        Abstract class for a MixedCovariatesTorchModel training dataset. It contains 6-tuples of
         `(past_target, past_covariates, historic_future_covariates, future_covariates, static_covariates,
         future_target)` `np.ndarray`.
         The covariates are optional and can be `None`.
@@ -280,7 +280,7 @@ class MixedCovariatesTrainingDataset(TrainingDataset, ABC):
 class SplitCovariatesTrainingDataset(TrainingDataset, ABC):
     def __init__(self):
         """
-        Abstract class for a SplitCovariatesTorchModel training dataset. It contains 4-tuples of
+        Abstract class for a SplitCovariatesTorchModel training dataset. It contains 5-tuples of
         `(past_target, past_covariates, future_covariates, static_covariates, future_target)` `np.ndarray`.
         The covariates are optional and can be `None`.
         """


### PR DESCRIPTION
Fixes #1152.

### Summary

Implement the DeepTIMe model from https://arxiv.org/pdf/2207.06046.pdf, based on the original repository https://github.com/salesforce/DeepTime and the article pseudo-code.

Also implement some basics tests, inspired by the tests for N-Beats.

### Other Information

In the original article, distinct optimizers are defined for the three groups of parameters: Ridge Regression regularization term, the biais/norm of the Implicit Neural Representation (INR) network and the weights of the INR. This was accomplished by overriding the configure_optimizer method and partially breaking the logic behind the lr_scheduler_cls and lr_scheduler_kwargs arguments. To make the model easier to use out of the box, the default arguments correspond to the original article parameters (including for the optimizer).

All the module necessary for this architecture were included in the same file to limit the fragmentation of the code. The Ridge Regression and the INR modules could however be extracted if others models require them.

