### PR TITLE
Remove IPython as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Darts is still in an early development phase, and we cannot always guarantee bac
 
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
 - Fixed edge case in ShapExplainer for regression models where covariates series > target series [#1310](https://https://github.com/unit8co/darts/pull/1310) by [Rijk van der Meulen](https://github.com/rijkvandermeulen)
+- Removed `IPython` as a dependency. [#1331](https://github.com/unit8co/darts/pull/1331) by [Erik Hasse](https://github.com/erik-hasse)
 
 [Full Changelog](https://github.com/unit8co/darts/compare/0.22.0...master)
 

--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -10,13 +10,17 @@ from typing import Callable, Iterator, List, Optional, Sequence, Tuple, TypeVar,
 
 import numpy as np
 import pandas as pd
-from IPython import get_ipython
 from joblib import Parallel, delayed
 from tqdm import tqdm
 from tqdm.notebook import tqdm as tqdm_notebook
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_if, raise_if_not, raise_log
+
+try:
+    from IPython import get_ipython
+except ModuleNotFoundError:
+    get_ipython = None
 
 logger = get_logger(__name__)
 
@@ -88,6 +92,8 @@ def _build_tqdm_iterator(iterable, verbose, **kwargs):
     """
 
     def _isnotebook():
+        if get_ipython is None:
+            return False
         try:
             shell = get_ipython().__class__.__name__
             if shell == "ZMQInteractiveShell":

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,6 +1,5 @@
 catboost>=1.0.6
 holidays>=0.11.1
-ipython>=5.0.0
 joblib>=0.16.0
 lightgbm>=3.2.0
 matplotlib>=3.3.0


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1286.

### Summary
Removes IPython as a core dependency, which makes darts easier to install and maintain in production environments.

### Other Information

<!--Thank you for contributing to darts! -->
