### PR TITLE
Make DatetimeIndex timezone naive for compatibility with xarray/numpy engine

### DIFF
--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1775,7 +1775,7 @@ class TimeSeriesFromDataFrameTestCase(DartsBaseTestClass):
 
     def test_time_col_with_tz(self):
         # numpy and xarray don't support "timezone aware" pd.DatetimeIndex
-        # BUGFIX remove timezone information without convertion
+        # the BUGFIX removes timezone information without conversion
 
         time_range_MS = pd.date_range(
             start="20180501", end="20200301", freq="MS", tz="CET"

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1773,6 +1773,55 @@ class TimeSeriesFromDataFrameTestCase(DartsBaseTestClass):
         self.assertEqual(ts.time_index.dtype, "datetime64[ns]")
         self.assertEqual(ts.time_index.name, "Time")
 
+    def test_time_col_with_tz(self):
+        # numpy and xarray don't support "timezone aware" pd.DatetimeIndex
+        # BUGFIX remove timezone information without convertion
+
+        time_range_MS = pd.date_range(
+            start="20180501", end="20200301", freq="MS", tz="CET"
+        )
+        values = np.random.uniform(low=-10, high=10, size=len(time_range_MS))
+        # pd.DataFrame loses the tz information unless it is contained in its index
+        # (other columns are silently converted to UTC, with tz attribute set to None)
+        df = pd.DataFrame(data=values, index=time_range_MS)
+        ts = TimeSeries.from_dataframe(df=df)
+        self.assertEqual(list(ts.time_index), list(time_range_MS.tz_localize(None)))
+        self.assertEqual(list(ts.time_index.tz_localize("CET")), list(time_range_MS))
+        self.assertEqual(ts.time_index.tz, None)
+
+        serie = pd.Series(data=values, index=time_range_MS)
+        ts = TimeSeries.from_series(pd_series=serie)
+        self.assertEqual(list(ts.time_index), list(time_range_MS.tz_localize(None)))
+        self.assertEqual(list(ts.time_index.tz_localize("CET")), list(time_range_MS))
+        self.assertEqual(ts.time_index.tz, None)
+
+        ts = TimeSeries.from_times_and_values(times=time_range_MS, values=values)
+        self.assertEqual(list(ts.time_index), list(time_range_MS.tz_localize(None)))
+        self.assertEqual(list(ts.time_index.tz_localize("CET")), list(time_range_MS))
+        self.assertEqual(ts.time_index.tz, None)
+
+        time_range_H = pd.date_range(
+            start="20200518", end="20200521", freq="H", tz="CET"
+        )
+        values = np.random.uniform(low=-10, high=10, size=len(time_range_H))
+
+        df = pd.DataFrame(data=values, index=time_range_H)
+        ts = TimeSeries.from_dataframe(df=df)
+        self.assertEqual(list(ts.time_index), list(time_range_H.tz_localize(None)))
+        self.assertEqual(list(ts.time_index.tz_localize("CET")), list(time_range_H))
+        self.assertEqual(ts.time_index.tz, None)
+
+        serie = pd.Series(data=values, index=time_range_H)
+        ts = TimeSeries.from_series(pd_series=serie)
+        self.assertEqual(list(ts.time_index), list(time_range_H.tz_localize(None)))
+        self.assertEqual(list(ts.time_index.tz_localize("CET")), list(time_range_H))
+        self.assertEqual(ts.time_index.tz, None)
+
+        ts = TimeSeries.from_times_and_values(times=time_range_H, values=values)
+        self.assertEqual(list(ts.time_index), list(time_range_H.tz_localize(None)))
+        self.assertEqual(list(ts.time_index.tz_localize("CET")), list(time_range_H))
+        self.assertEqual(ts.time_index.tz, None)
+
     def test_time_col_convert_garbage(self):
         expected = [
             "2312312asdfdw",

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -657,10 +657,13 @@ class TimeSeries:
             # BUGFIX : force time-index to be timezone naive as xarray doesn't support it
             # pandas.DataFrame loses the tz information if it's not its index
             if isinstance(df.index, pd.DatetimeIndex) and df.index.tz is not None:
-                print(
+                logger.warning(
                     "The provided DatetimeIndex was associated with a timezone, which is currently not supported "
-                    "by xarray. To avoid unexpected behaviour, the tz information was removed, don't forget to "
-                    f"call `ts.time_index.tz_localize({df.index.tz})` when exporting the results."
+                    "by xarray. To avoid unexpected behaviour, the tz information was removed. Consider calling "
+                    f"`ts.time_index.tz_localize({df.index.tz})` when exporting the results."
+                    "To plot the series with the right time steps, consider setting the matplotlib.pyplot "
+                    "`rcParams['timezone']` parameter to automatically convert the time axis back to the "
+                    "original timezone."
                 )
                 time_index = df.index.tz_localize(None)
             else:
@@ -841,15 +844,6 @@ class TimeSeries:
         TimeSeries
             A univariate and deterministic TimeSeries constructed from the inputs.
         """
-        # BUGFIX : force time-index to be timezone naive as xarray doesn't support it
-        if isinstance(pd_series, pd.DatetimeIndex) and pd_series.dt.tz is not None:
-            print(
-                "The `times` argument was associated with a timezone, which is currently not supported "
-                "by xarray. To avoid unexpected behaviour, the tz information was removed, don't forget to "
-                f"call `ts.time_index.tz_localize({pd_series.dt.tz})` when exporting the results."
-            )
-            pd_series = pd_series.dt.tz_localize(None)
-
         df = pd.DataFrame(pd_series)
         return cls.from_dataframe(
             df,
@@ -944,10 +938,13 @@ class TimeSeries:
 
         # BUGFIX : force time-index to be timezone naive as xarray doesn't support it
         if isinstance(times, pd.DatetimeIndex) and times.tz is not None:
-            print(
+            logger.warning(
                 "The `times` argument was associated with a timezone, which is currently not supported "
-                "by xarray. To avoid unexpected behaviour, the tz information was removed, don't forget to "
-                f"call `ts.time_index.tz_localize({times.tz})` when exporting the results."
+                "by xarray. To avoid unexpected behaviour, the tz information was removed. Consider calling "
+                f"`ts.time_index.tz_localize({times.tz})` when exporting the results."
+                "To plot the series with the right time steps, consider setting the matplotlib.pyplot "
+                "`rcParams['timezone']` parameter to automatically convert the time axis back to the "
+                "original timezone."
             )
             times = times.tz_localize(None)
 


### PR DESCRIPTION
Fixes #1052 and #648. Xarray relies on numpy engine, which is not timezone aware. Causes issues for plotting and resampling.

### Summary
When constructing a `TimeSeries` from a `pd.DataFrame` or a `pd.Series` with a `DatetimeIndex` containing timezone information, this attribute is dropped without conversion using `tz_localize(None)` (conversion can causes shift in the timestamps, making the index invalid). The timezone information can be recovered by calling `ts.time_index.tz_localize(original_tz)` prior to exporting the data.

### Other Information
The `DatetimeIndex` not used as index are silently converted to UTC by the `pd.DataFrame` constructor without saving the timezone information. Thus, timezone aware dataset should use the time range as index to take advantage of the bugfix and avoid the error raised by the `TimeSeries` constructor due to index invalidity.

In order to have the desired x-axis when plotting the `TimeSeries` (with a timezone unaware `time_index` due to the bugfix), the user can simply leverage the matplotlib.pyplot `rcParams['timezone']` parameter to automatically convert the time axis back to the original timezone.
