### PR TITLE
Feat/normalized deviation metric

### DIFF
--- a/darts/metrics/__init__.py
+++ b/darts/metrics/__init__.py
@@ -11,6 +11,7 @@ from .metrics import (
     marre,
     mase,
     mse,
+    nd,
     ope,
     r2_score,
     rho_risk,

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -1226,10 +1226,10 @@ def nd(
     n_jobs: int = 1,
     verbose: bool = False
 ) -> Union[float, np.ndarray]:
-    """Normalized deviation (ND), described in Annexes A of F. Yu et al. \
+    """Normalized Deviation (ND), described in Annexes A of F. Yu et al. \
     “Temporal Regularized Matrix Factorization for High-dimensional Time Series Prediction”
 
-    For one time serie :math:`y` and its forecast :math:`\\hat{y}`, it is computed as
+    Given a time series of actual values :math:`y` and a time series of predicted values :math:`\\hat{y}`
 
     .. math:: \\frac{
                 \\frac{1}{\\left| \\Omega_{test} \\right|}
@@ -1238,7 +1238,7 @@ def nd(
                 \\frac{1}{\\left| \\Omega_{test} \\right|}
                     \\sum_{(i,t) \\in \\Omega_{test}} {\\left| y_{i,t} \\right|}}.
 
-    where :math:`y_{i,t}` is the observation at the t-th time point of the i-th time series and
+    where :math:`y_{i,t}` is the observation at the :math:`t`-th time point of the :math:`i`-th time series and
     :math:`\\Omega_{test}` the set of observations.
 
     If any of the series is stochastic (containing several samples), the median sample value is considered.
@@ -1276,7 +1276,7 @@ def nd(
     Returns
     -------
     float
-        The Normalized devation
+        The Normalized Deviation
     """
 
     y_true, y_pred = _get_values_or_raise(

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -1226,20 +1226,20 @@ def nd(
     n_jobs: int = 1,
     verbose: bool = False
 ) -> Union[float, np.ndarray]:
-    """Normalized deviation (ND), described in Supplemental A of
-
-    https://proceedings.neurips.cc/paper/2016/hash/85422afb467e9456013a2a51d4dff702-Abstract.html.
+    """Normalized deviation (ND), described in Annexes A of F. Yu et al. \
+    “Temporal Regularized Matrix Factorization for High-dimensional Time Series Prediction”
 
     For one time serie :math:`y` and its forecast :math:`\\hat{y}`, it is computed as
 
     .. math:: \\frac{
-                        \\frac{1}{\\left| \\Omega_{test} \\right|}
-                            \\sum_{(i,t) \\in \\Omega_{test}}{\\left| \\hat{y}_{i,t} - y_{i,t} \\right|}
-                    }{
-                        \\frac{1}{\\left| \\Omega_{test} \\right|}
-                            \\sum_{(i,t) \\in \\Omega_{test}}{\\left| y_{i,t} \\right|}.
+                \\frac{1}{\\left| \\Omega_{test} \\right|}
+                    \\sum_{(i,t) \\in \\Omega_{test}} {\\left| \\hat{y}_{i,t} - y_{i,t} \\right|}
+              }{
+                \\frac{1}{\\left| \\Omega_{test} \\right|}
+                    \\sum_{(i,t) \\in \\Omega_{test}} {\\left| y_{i,t} \\right|}}.
 
-    where i is the index of the value in the timeserie and t the index of the variate.
+    where :math:`y_{i,t}` is the observation at the t-th time point of the i-th time series and
+    :math:`\\Omega_{test}` the set of observations.
 
     If any of the series is stochastic (containing several samples), the median sample value is considered.
 
@@ -1268,6 +1268,11 @@ def nd(
     verbose
         Optionally, whether to print operations progress
 
+    Raises
+    ------
+    ValueError
+        If :math:`\\sum_{(i,t) \\in \\Omega_{test}} {\\left| y_{i,t} \\right|} = 0`.
+
     Returns
     -------
     float
@@ -1283,4 +1288,4 @@ def nd(
         "The actual series must be strictly positive to compute the ND.",
         logger,
     )
-    return np.mean(np.abs(y_pred - y_true)) / np.mean(np.abs(y_pred))
+    return np.mean(np.abs(y_pred - y_true)) / np.mean(np.abs(y_true))

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -347,6 +347,11 @@ class MetricsTestCase(DartsBaseTestClass):
         self.assertAlmostEqual(metrics.rho_risk(s1, s12_stochastic, rho=0.0), 0.0)
         self.assertAlmostEqual(metrics.rho_risk(s2, s12_stochastic, rho=1.0), 0.0)
 
+    def test_nd(self):
+        self.helper_test_multivariate_duplication_equality(metrics.nd)
+        self.helper_test_multiple_ts_duplication_equality(metrics.nd)
+        self.helper_test_nan(metrics.nd)
+
     def test_metrics_arguments(self):
         series00 = self.series0.stack(self.series0)
         series11 = self.series1.stack(self.series1)
@@ -409,6 +414,7 @@ class MetricsTestCase(DartsBaseTestClass):
             metrics.marre,
             metrics.mse,
             metrics.rmsle,
+            metrics.nd,
         ]
 
         for metric in test_metric:

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -60,10 +60,16 @@ class MetricsTestCase(DartsBaseTestClass):
             metrics.smape(self.series1, self.series1)
 
         with self.assertRaises(ValueError):
+            metrics.nd(self.series1, self.series1)
+
+        with self.assertRaises(ValueError):
             metrics.mape(self.series12, self.series12)
 
         with self.assertRaises(ValueError):
             metrics.smape(self.series12, self.series12)
+
+        with self.assertRaises(ValueError):
+            metrics.nd(self.series12, self.series12)
 
         with self.assertRaises(ValueError):
             metrics.ope(


### PR DESCRIPTION
Fixes #877 .

### Summary
Implement the normalized deviation metric (ND) based on the description in the Annexe A of [F. Yu et al. "Temporal Regularized Matrix Factorization for High-dimensional Time Series Prediction"](https://papers.nips.cc/paper/2016/hash/85422afb467e9456013a2a51d4dff702-Abstract.html) and added corresponding tests.

### Other Information
Since all the other metrics had exactly the same signature, I used the same one even if some arguments are not used/relevant for ND. 
