### PR TITLE
Fix/ensemble predict with series

### DIFF
--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -59,7 +59,6 @@ class EnsembleModel(GlobalForecastingModel):
 
         super().__init__()
         self.models = models
-        self.is_single_series = None
 
     def fit(
         self,
@@ -83,16 +82,16 @@ class EnsembleModel(GlobalForecastingModel):
             logger,
         )
 
-        self.is_single_series = isinstance(series, TimeSeries)
+        is_single_series = isinstance(series, TimeSeries)
 
         # check that if timeseries is single series, than covariates are as well and vice versa
         error = False
 
         if past_covariates is not None:
-            error = self.is_single_series != isinstance(past_covariates, TimeSeries)
+            error = is_single_series != isinstance(past_covariates, TimeSeries)
 
         if future_covariates is not None:
-            error = self.is_single_series != isinstance(future_covariates, TimeSeries)
+            error = is_single_series != isinstance(future_covariates, TimeSeries)
 
         raise_if(
             error,
@@ -125,6 +124,7 @@ class EnsembleModel(GlobalForecastingModel):
         future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         num_samples: int = 1,
     ):
+        is_single_series = isinstance(series, TimeSeries) or series is None
         predictions = [
             model._predict_wrapper(
                 n=n,
@@ -135,11 +135,11 @@ class EnsembleModel(GlobalForecastingModel):
             )
             for model in self.models
         ]
-
-        if self.is_single_series:
-            return self._stack_ts_seq(predictions)
-        else:
-            return self._stack_ts_multiseq(predictions)
+        return (
+            self._stack_ts_seq(predictions)
+            if is_single_series
+            else self._stack_ts_multiseq(predictions)
+        )
 
     def predict(
         self,

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -165,11 +165,7 @@ class EnsembleModel(GlobalForecastingModel):
             future_covariates=future_covariates,
             num_samples=num_samples,
         )
-
-        if self.is_single_series:
-            return self.ensemble(predictions)
-        else:
-            return self.ensemble(predictions, series)
+        return self.ensemble(predictions, series=series)
 
     @abstractmethod
     def ensemble(

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -15,6 +15,7 @@ from darts.models.forecasting.forecasting_model import (
 from darts.models.forecasting.linear_regression_model import LinearRegressionModel
 from darts.models.forecasting.regression_model import RegressionModel
 from darts.timeseries import TimeSeries
+from darts.utils.utils import seq2series, series2seq
 
 logger = get_logger(__name__)
 
@@ -156,9 +157,10 @@ class RegressionEnsembleModel(EnsembleModel):
         predictions: Union[TimeSeries, Sequence[TimeSeries]],
         series: Optional[Sequence[TimeSeries]] = None,
     ) -> Union[TimeSeries, Sequence[TimeSeries]]:
-        if self.is_single_series:
-            predictions = [predictions]
-            series = [series]
+
+        is_single_series = isinstance(series, TimeSeries) or series is None
+        predictions = series2seq(predictions)
+        series = series2seq(series) if series is not None else [None]
 
         ensembled = [
             self.regression_model.predict(
@@ -166,5 +168,4 @@ class RegressionEnsembleModel(EnsembleModel):
             )
             for serie, prediction in zip(series, predictions)
         ]
-
-        return ensembled[0] if self.is_single_series else ensembled
+        return seq2series(ensembled) if is_single_series else ensembled

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -91,7 +91,8 @@ class RegressionEnsembleModel(EnsembleModel):
         )
 
         # spare train_n_points points to serve as regression target
-        if self.is_single_series:
+        is_single_series = isinstance(series, TimeSeries)
+        if is_single_series:
             train_n_points_too_big = len(self.training_series) <= self.train_n_points
         else:
             train_n_points_too_big = any(
@@ -105,7 +106,7 @@ class RegressionEnsembleModel(EnsembleModel):
             logger,
         )
 
-        if self.is_single_series:
+        if is_single_series:
             forecast_training = self.training_series[: -self.train_n_points]
             regression_target = self.training_series[-self.train_n_points :]
         else:

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -7,6 +7,7 @@ from darts import TimeSeries
 from darts.logging import get_logger
 from darts.models import (
     ExponentialSmoothing,
+    LinearRegressionModel,
     NaiveDrift,
     NaiveEnsembleModel,
     NaiveSeasonal,
@@ -147,6 +148,72 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
         )
         with self.assertRaises(ValueError):
             naive.fit(self.series1, self.series2)
+
+    def test_predict_with_target(self):
+        series_long = self.series1
+        series_short = series_long[:25]
+
+        # train with a single series
+        ensemble_model = self.get_global_ensembe_model()
+        ensemble_model.fit(series_short, past_covariates=series_long)
+        # predict after end of train series
+        preds = ensemble_model.predict(n=5, past_covariates=series_long)
+        self.assertTrue(isinstance(preds, TimeSeries))
+        # predict a new target series
+        preds = ensemble_model.predict(
+            n=5, series=series_long, past_covariates=series_long
+        )
+        self.assertTrue(isinstance(preds, TimeSeries))
+        # predict multiple target series
+        preds = ensemble_model.predict(
+            n=5, series=[series_long] * 2, past_covariates=[series_long] * 2
+        )
+        self.assertTrue(isinstance(preds, list) and len(preds) == 2)
+        # predict single target series in list
+        preds = ensemble_model.predict(
+            n=5, series=[series_long], past_covariates=[series_long]
+        )
+        self.assertTrue(isinstance(preds, list) and len(preds) == 1)
+
+        # train with multiple series
+        ensemble_model = self.get_global_ensembe_model()
+        ensemble_model.fit([series_short] * 2, past_covariates=[series_long] * 2)
+        with self.assertRaises(ValueError):
+            # predict without passing series should raise an error
+            ensemble_model.predict(n=5, past_covariates=series_long)
+        # predict a new target series
+        preds = ensemble_model.predict(
+            n=5, series=series_long, past_covariates=series_long
+        )
+        self.assertTrue(isinstance(preds, TimeSeries))
+        # predict multiple target series
+        preds = ensemble_model.predict(
+            n=5, series=[series_long] * 2, past_covariates=[series_long] * 2
+        )
+        self.assertTrue(isinstance(preds, list) and len(preds) == 2)
+        # predict single target series in list
+        preds = ensemble_model.predict(
+            n=5, series=[series_long], past_covariates=[series_long]
+        )
+        self.assertTrue(isinstance(preds, list) and len(preds) == 1)
+
+    @staticmethod
+    def get_global_ensembe_model(output_chunk_length=5):
+        lags = [-1, -2, -5]
+        return NaiveEnsembleModel(
+            models=[
+                LinearRegressionModel(
+                    lags=lags,
+                    lags_past_covariates=lags,
+                    output_chunk_length=output_chunk_length,
+                ),
+                LinearRegressionModel(
+                    lags=lags,
+                    lags_past_covariates=lags,
+                    output_chunk_length=output_chunk_length,
+                ),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -104,7 +104,6 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
             regression_train_n_points=10,
         )
 
-    @unittest.skipUnless(TORCH_AVAILABLE, "requires torch")
     def test_accepts_different_regression_models(self):
         regr1 = LinearRegression()
         regr2 = RandomForestRegressor()
@@ -120,7 +119,6 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
             model.fit(series=self.combined)
             model.predict(10)
 
-    @unittest.skipUnless(TORCH_AVAILABLE, "requires torch")
     def test_accepts_one_model(self):
         regr1 = LinearRegression()
         regr2 = RandomForest(lags_future_covariates=[0])
@@ -134,7 +132,6 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
             model.fit(series=self.combined)
             model.predict(10)
 
-    @unittest.skipUnless(TORCH_AVAILABLE, "requires torch")
     def test_train_n_points(self):
         regr = LinearRegressionModel(lags_future_covariates=[0])
 
@@ -249,7 +246,6 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
         )
         self.assertTrue(isinstance(preds, list) and len(preds) == 1)
 
-    @unittest.skipUnless(TORCH_AVAILABLE, "requires torch")
     def helper_test_models_accuracy(
         self, model_instance, n, series, past_covariates, min_rmse
     ):
@@ -268,7 +264,6 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
             f"Model was not able to denoise data. A rmse score of {current_rmse} was recorded.",
         )
 
-    @unittest.skipUnless(TORCH_AVAILABLE, "requires torch")
     def denoising_input(self):
         np.random.seed(self.RANDOM_SEED)
 


### PR DESCRIPTION
Fixes #1340

### Summary
- fixes several issues in RegressionEnsembleModel, when using only a single target series at fitting time, and passing a new/multiple series to predict()
- removes "static" ìs_single_series` attribute from ensemble model, and instead recompute it whenever we get a new `series`.
- removes some unnecessary test skips for old regression models torch dependency