### PR TITLE
Fix/ Allow empty TimeSeries

### DIFF
--- a/darts/tests/test_logging.py
+++ b/darts/tests/test_logging.py
@@ -63,7 +63,7 @@ class LoggingTestCase(unittest.TestCase):
             (
                 "darts.timeseries",
                 "ERROR",
-                "ValueError: The time series array must not be empty.",
+                "ValueError: TimeSeries require DataArray of dimensionality 3 (('time', 'component', 'sample')).",
             )
         )
 

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -292,6 +292,10 @@ class TimeSeries:
         # Store static covariates and hierarchy in attributes (potentially storing None)
         self._xa = _xarray_with_attrs(self._xa, static_covariates, hierarchy)
 
+        # at the end since other exceptions can prevent the creation of the time serie
+        if not xa.size > 0:
+            logger.warning("TimeSeries is empty.")
+
     """
     Factory Methods
     ===============

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -86,7 +86,6 @@ class TimeSeries:
             "TimeSeries.from_times_and_values(), etc...).",
             logger,
         )
-        raise_if_not(xa.size > 0, "The time series array must not be empty.", logger)
         raise_if_not(
             len(xa.shape) == 3,
             f"TimeSeries require DataArray of dimensionality 3 ({DIMS}).",


### PR DESCRIPTION
Fixes #1279.

### Summary
Remove the assert preventing to create an empty `TimeSeries` in the constructor and replaced it by a warning to limit the risk of unexpected behavior for the users. Edited the corresponding test to catch the `ValueError` about missing dimensions in input `xarray.DataArray` instead of its emptiness.

