### PR TITLE
[Fix] missing prophet/catboost/lightgbm library should not prevent use of others models

### DIFF
--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -11,18 +11,13 @@ logger = get_logger(__name__)
 from darts.models.forecasting.arima import ARIMA
 from darts.models.forecasting.auto_arima import AutoARIMA
 from darts.models.forecasting.baselines import NaiveDrift, NaiveMean, NaiveSeasonal
-from darts.models.forecasting.catboost_model import CatBoostModel
-from darts.models.forecasting.croston import Croston
 from darts.models.forecasting.exponential_smoothing import ExponentialSmoothing
 from darts.models.forecasting.fft import FFT
 from darts.models.forecasting.kalman_forecaster import KalmanForecaster
 from darts.models.forecasting.linear_regression_model import LinearRegressionModel
-from darts.models.forecasting.prophet_model import Prophet
 from darts.models.forecasting.random_forest import RandomForest
 from darts.models.forecasting.regression_ensemble_model import RegressionEnsembleModel
 from darts.models.forecasting.regression_model import RegressionModel
-from darts.models.forecasting.sf_auto_arima import StatsForecastAutoARIMA
-from darts.models.forecasting.sf_ets import StatsForecastETS
 from darts.models.forecasting.tbats import BATS, TBATS
 from darts.models.forecasting.theta import FourTheta, Theta
 from darts.models.forecasting.varima import VARIMA
@@ -47,11 +42,74 @@ try:
     from darts.models.forecasting.gradient_boosted_model import LightGBMModel
 except ModuleNotFoundError:
     logger.warning(
-        "Support for LightGBM not available."
+        "Support for LightGBM not available. "
         "To enable LightGBM support in Darts, follow the detailed "
         "install instructions for LightGBM in the README: "
-        "https://github.com/unit8co/darts/blob/master/README.md"
+        "https://github.com/unit8co/darts/blob/master/INSTALL.md"
     )
+    # TODO: simpler option would be to write LightGBMModel=None
+    # Prevent a second ImportError that would interrupt the import
+    class NotImportedLightGBM:
+        usable = False
+
+    LightGBMModel = NotImportedLightGBM()
+
+try:
+    from darts.models.forecasting.prophet_model import Prophet
+except ImportError:
+    logger.warning(
+        "The prophet module could not be imported. "
+        "To enable support for Prophet model, follow "
+        "the instruction in the README: "
+        "https://github.com/unit8co/darts/blob/master/INSTALL.md"
+    )
+
+    class NotImportedProphet:
+        usable = False
+
+    Prophet = NotImportedProphet()
+
+try:
+    from darts.models.forecasting.catboost_model import CatBoostModel
+except ModuleNotFoundError:
+    logger.warning(
+        "The catboost module could not be imported. "
+        "To enable support for CatBoostModel model, "
+        "follow the instruction in the README: "
+        "https://github.com/unit8co/darts/blob/master/INSTALL.md"
+    )
+
+    class NotImportedCatBoostModel:
+        usable = False
+
+    CatBoostModel = NotImportedCatBoostModel()
+
+try:
+    from darts.models.forecasting.croston import Croston
+    from darts.models.forecasting.sf_auto_arima import StatsForecastAutoARIMA
+    from darts.models.forecasting.sf_ets import StatsForecastETS
+except ImportError:
+    logger.warning(
+        "The statsforecast module could not be imported. "
+        "To enable support for the StatsForecastAutoARIMA, "
+        "StatsForecastETS and Croston models, please consider "
+        "installing it."
+    )
+
+    class NotImportedStatsForecastAutoARIMA:
+        usable = False
+
+    StatsForecastAutoARIMA = NotImportedStatsForecastAutoARIMA()
+
+    class NotImportedStatsForecastETS:
+        usable = False
+
+    StatsForecastETS = NotImportedStatsForecastETS()
+
+    class NotImportedCroston:
+        usable = False
+
+    Croston = NotImportedCroston()
 
 from darts.models.filtering.gaussian_process_filter import GaussianProcessFilter
 from darts.models.filtering.kalman_filter import KalmanFilter

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -28,7 +28,6 @@ from collections import OrderedDict
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
-from catboost import CatBoostRegressor
 from sklearn.linear_model import LinearRegression
 
 from darts.logging import get_logger, raise_if, raise_if_not, raise_log
@@ -39,6 +38,16 @@ from darts.utils.multioutput import MultiOutputRegressor
 from darts.utils.utils import _check_quantiles, seq2series, series2seq
 
 logger = get_logger(__name__)
+
+try:
+    from catboost import CatBoostRegressor
+except ModuleNotFoundError:
+    logger.warning(
+        "The catboost module could not be imported. "
+        "To enable support for CatBoostRegressor, "
+        "follow the instruction in the README: "
+        "https://github.com/unit8co/darts/blob/master/INSTALL.md"
+    )
 
 
 class RegressionModel(GlobalForecastingModel):


### PR DESCRIPTION
Fixes ##1272 and #1217.

### Summary

Exception handling in `models/__init__.py` to display warning message when trying to import models depending on uninstalled external libraries. The logger will display a warning message, linking to the INSTALL.md file when relevant.

### Other Information

- The unavailable models are replaced by dummy class with explicit name so that the user should realize that the import failed even if the warnings are ignored.
- I had to add similar logic in regression_model.py can eventually depend on the `CatBoostRegressor`.
- The exception handling was not extended to the tests so that they remain a reliable way to verify that the local install is correct.
