### PR TITLE
refactors MovingAverage filter 

### DIFF
--- a/darts/models/filtering/moving_average.py
+++ b/darts/models/filtering/moving_average.py
@@ -9,7 +9,7 @@ from darts.timeseries import TimeSeries
 
 class MovingAverage(FilteringModel):
     """
-    A simple moving average filter. Works on deterministic series (made of 1 sample).
+    A simple moving average filter. Works on deterministic and stochastic series.
     """
 
     def __init__(self, window: int, centered: bool = True):
@@ -19,7 +19,7 @@ class MovingAverage(FilteringModel):
         window
             The length of the window over which to average values
         centered
-            Set the labels at the center of the window. If not set, the averaged values are lagging after the
+            Set the labels at the center of the window. If not set, the averaged values are lagging after
             the original values.
         """
         super().__init__()
@@ -31,9 +31,6 @@ class MovingAverage(FilteringModel):
         Computes a moving average of this series' values and returns a new TimeSeries.
         The returned series has the same length and time axis as `series`. (Note that this might create border effects).
 
-        Behind the scenes the moving average is computed using :func:`pandas.DataFrame.rolling()` on the underlying
-        DataFrame.
-
         Parameters
         ----------
         series
@@ -44,14 +41,14 @@ class MovingAverage(FilteringModel):
         TimeSeries
             A time series containing the average values
         """
-        filtered_df = (
-            series.pd_dataframe(copy=False)
-            .rolling(window=self.window, min_periods=1, center=self.centered)
-            .mean()
-        )
+        transformation = {
+            "function": "mean",
+            "mode": "rolling",
+            "window": self.window,
+            "center": self.centered,
+            "min_periods": 1,
+        }
 
-        return TimeSeries.from_dataframe(
-            filtered_df,
-            static_covariates=series.static_covariates,
-            hierarchy=series.hierarchy,
+        return series.window_transform(
+            transforms=transformation, forecasting_safe=False
         )

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3525,6 +3525,8 @@ class TimeSeries:
                 len(new_index), -1, n_samples
             ),
             columns=new_columns,
+            static_covariates=self.static_covariates,
+            hierarchy=self.hierarchy,
         )
 
         return transformed_time_series


### PR DESCRIPTION
- makes MovingAverage filter to use window_transform() for TimeSeries
- adds static covariates and hierarchy to the transformed series (output of window_transform())
