### PR TITLE
Refactor/data_transformers

### DIFF
--- a/darts/dataprocessing/transformers/missing_values_filler.py
+++ b/darts/dataprocessing/transformers/missing_values_filler.py
@@ -3,7 +3,7 @@ Missing Values Filler
 ---------------------
 """
 
-from typing import List, Sequence, Union
+from typing import Any, Mapping, Union
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_if, raise_if_not
@@ -78,17 +78,11 @@ class MissingValuesFiller(BaseDataTransformer):
             logger,
         )
 
-        super().__init__(name=name, n_jobs=n_jobs, verbose=verbose)
         self._fill = fill
+        super().__init__(name=name, n_jobs=n_jobs, verbose=verbose)
 
     @staticmethod
     def ts_transform(
-        series: TimeSeries, fill: Union[str, float], **kwargs
+        series: TimeSeries, params: Mapping[str, Any], **kwargs
     ) -> TimeSeries:
-        return fill_missing_values(series, fill, **kwargs)
-
-    def transform(
-        self, series: Union[TimeSeries, Sequence[TimeSeries]], *args, **kwargs
-    ) -> Union[TimeSeries, List[TimeSeries]]:
-        # adding the fill param
-        return super().transform(series, self._fill, *args, **kwargs)
+        return fill_missing_values(series, params["fixed"]["_fill"], **kwargs)

--- a/darts/dataprocessing/transformers/scaler.py
+++ b/darts/dataprocessing/transformers/scaler.py
@@ -100,15 +100,10 @@ class Scaler(InvertibleDataTransformer, FittableDataTransformer):
     ) -> TimeSeries:
 
         transformer = params["fitted"]
-        component_mask = kwargs.get("component_mask", None)
 
-        tr_out = transformer.transform(
-            Scaler._reshape_in(series, component_mask=component_mask)
-        )
+        tr_out = transformer.transform(Scaler.stack_samples(series))
 
-        transformed_vals = Scaler._reshape_out(
-            series, tr_out, component_mask=component_mask
-        )
+        transformed_vals = Scaler.unstack_samples(tr_out, series=series)
 
         return series.with_values(transformed_vals)
 
@@ -117,14 +112,9 @@ class Scaler(InvertibleDataTransformer, FittableDataTransformer):
         series: TimeSeries, params: Mapping[str, Any], *args, **kwargs
     ) -> TimeSeries:
         transformer = params["fitted"]
-        component_mask = kwargs.get("component_mask", None)
 
-        tr_out = transformer.inverse_transform(
-            Scaler._reshape_in(series, component_mask=component_mask)
-        )
-        inv_transformed_vals = Scaler._reshape_out(
-            series, tr_out, component_mask=component_mask
-        )
+        tr_out = transformer.inverse_transform(Scaler.stack_samples(series))
+        inv_transformed_vals = Scaler.unstack_samples(tr_out, series=series)
 
         return series.with_values(inv_transformed_vals)
 
@@ -132,9 +122,6 @@ class Scaler(InvertibleDataTransformer, FittableDataTransformer):
     def ts_fit(series: TimeSeries, params: Mapping[str, Any], *args, **kwargs) -> Any:
         transformer = deepcopy(params["fixed"]["transformer"])
         # fit_parameter will receive the transformer object instance
-        component_mask = kwargs.get("component_mask", None)
 
-        scaler = transformer.fit(
-            Scaler._reshape_in(series, component_mask=component_mask)
-        )
+        scaler = transformer.fit(Scaler.stack_samples(series))
         return scaler

--- a/darts/dataprocessing/transformers/static_covariates_transformer.py
+++ b/darts/dataprocessing/transformers/static_covariates_transformer.py
@@ -102,7 +102,11 @@ class StaticCovariatesTransformer(InvertibleDataTransformer, FittableDataTransfo
         comp2               1.0  2.0
         comp3               0.5  1.0
         """
-        super().__init__(name=name, n_jobs=n_jobs, verbose=verbose)
+        # Don't automatically apply `component_mask` since special masking behaviour
+        # is implemented here:
+        super().__init__(
+            name=name, n_jobs=n_jobs, verbose=verbose, mask_components=False
+        )
         self.transformer_num = (
             MinMaxScaler() if transformer_num is None else transformer_num
         )

--- a/darts/dataprocessing/transformers/window_transformer.py
+++ b/darts/dataprocessing/transformers/window_transformer.py
@@ -3,12 +3,11 @@ Window Transformer
 ------------------
 """
 
-from typing import Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Mapping, Optional, Union
 
 from darts.dataprocessing.transformers import BaseDataTransformer
 from darts.logging import get_logger
 from darts.timeseries import TimeSeries
-from darts.utils.utils import series2seq
 
 logger = get_logger(__name__)
 
@@ -126,7 +125,6 @@ class WindowTransformer(BaseDataTransformer):
         verbose
             Whether to print operations progress.
         """
-        super().__init__(name, n_jobs, verbose)
 
         # dictionary checks are implemented in TimeSeries.window_transform()
 
@@ -134,22 +132,8 @@ class WindowTransformer(BaseDataTransformer):
         self.keep_non_transformed = keep_non_transformed
         self.treat_na = treat_na
         self.forecasting_safe = forecasting_safe
-
-    def _transform_iterator(
-        self, series: Union[TimeSeries, Sequence[TimeSeries]]
-    ) -> Iterator[Tuple]:
-
-        series = series2seq(series)
-
-        kwargs_dict = {
-            "transforms": self.transforms,
-            "keep_non_transformed": self.keep_non_transformed,
-            "treat_na": self.treat_na,
-            "forecasting_safe": self.forecasting_safe,
-        }
-        for s in series:
-            yield (s, kwargs_dict)
+        super().__init__(name, n_jobs, verbose)
 
     @staticmethod
-    def ts_transform(series: TimeSeries, kwargs_dict) -> TimeSeries:
-        return series.window_transform(**kwargs_dict)
+    def ts_transform(series: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
+        return series.window_transform(**params["fixed"])

--- a/darts/tests/dataprocessing/test_pipeline.py
+++ b/darts/tests/dataprocessing/test_pipeline.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+from typing import Any, Mapping
 
 from darts import TimeSeries
 from darts.dataprocessing import Pipeline
@@ -28,7 +29,7 @@ class PipelineTestCase(unittest.TestCase):
             self.fit_called = False
 
         @staticmethod
-        def ts_transform(data: TimeSeries) -> TimeSeries:
+        def ts_transform(data: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
             return data.append_values(constant_timeseries(value=1, length=3).values())
 
         def transform(self, data, *args, **kwargs) -> TimeSeries:
@@ -48,11 +49,13 @@ class PipelineTestCase(unittest.TestCase):
             pass
 
         @staticmethod
-        def ts_transform(series: TimeSeries) -> TimeSeries:
+        def ts_transform(series: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
             return series.append_values(constant_timeseries(value=2, length=3).values())
 
         @staticmethod
-        def ts_inverse_transform(series: TimeSeries) -> TimeSeries:
+        def ts_inverse_transform(
+            series: TimeSeries, params: Mapping[str, Any]
+        ) -> TimeSeries:
             return series
 
         def fit(self, data):
@@ -77,11 +80,13 @@ class PipelineTestCase(unittest.TestCase):
             super().__init__(name=name)
 
         @staticmethod
-        def ts_transform(series: TimeSeries) -> TimeSeries:
+        def ts_transform(series: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
             return series.map(lambda x: x + 10)
 
         @staticmethod
-        def ts_inverse_transform(series: TimeSeries) -> TimeSeries:
+        def ts_inverse_transform(
+            series: TimeSeries, params: Mapping[str, Any]
+        ) -> TimeSeries:
             return series.map(lambda x: x - 10)
 
     class TimesTwoTransformer(InvertibleDataTransformer):
@@ -89,11 +94,13 @@ class PipelineTestCase(unittest.TestCase):
             super().__init__(name="*2 transformer")
 
         @staticmethod
-        def ts_transform(data: TimeSeries) -> TimeSeries:
+        def ts_transform(data: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
             return data.map(lambda x: x * 2)
 
         @staticmethod
-        def ts_inverse_transform(data: TimeSeries) -> TimeSeries:
+        def ts_inverse_transform(
+            data: TimeSeries, params: Mapping[str, Any]
+        ) -> TimeSeries:
             return data.map(lambda x: x / 2)
 
     def test_transform(self):

--- a/darts/tests/dataprocessing/test_pipeline.py
+++ b/darts/tests/dataprocessing/test_pipeline.py
@@ -45,7 +45,7 @@ class PipelineTestCase(unittest.TestCase):
             self.fit_called = False
 
         @staticmethod
-        def ts_fit(series: TimeSeries):
+        def ts_fit(series: TimeSeries, params: Mapping[str, Any]):
             pass
 
         @staticmethod

--- a/darts/tests/dataprocessing/transformers/test_base_data_transformer.py
+++ b/darts/tests/dataprocessing/transformers/test_base_data_transformer.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+from typing import Any, Mapping
 
 from darts import TimeSeries
 from darts.dataprocessing.transformers import BaseDataTransformer
@@ -19,7 +20,7 @@ class BaseDataTransformerTestCase(unittest.TestCase):
             self.transform_called = False
 
         @staticmethod
-        def ts_transform(series: TimeSeries) -> TimeSeries:
+        def ts_transform(series: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
             return series + 10
 
     def test_input_transformed(self):

--- a/darts/tests/dataprocessing/transformers/test_invertible_fittable_data_transformer.py
+++ b/darts/tests/dataprocessing/transformers/test_invertible_fittable_data_transformer.py
@@ -5,7 +5,12 @@ from typing import Any, Mapping, Sequence, Union
 import numpy as np
 
 from darts import TimeSeries
-from darts.dataprocessing.transformers import BaseDataTransformer
+from darts.dataprocessing.transformers.fittable_data_transformer import (
+    FittableDataTransformer,
+)
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    InvertibleDataTransformer,
+)
 from darts.utils.timeseries_generation import constant_timeseries
 
 
@@ -16,7 +21,7 @@ class BaseDataTransformerTestCase(unittest.TestCase):
     def setUpClass(cls):
         logging.disable(logging.CRITICAL)
 
-    class DataTransformerMock(BaseDataTransformer):
+    class DataTransformerMock(InvertibleDataTransformer, FittableDataTransformer):
         def __init__(
             self,
             scale: float,
@@ -26,7 +31,8 @@ class BaseDataTransformerTestCase(unittest.TestCase):
             parallel_params: Union[bool, Sequence[str]] = False,
         ):
             """
-            Applies the transform `transformed_series = scale * series + translation`.
+            Applies the (invertible) transform `transformed_series = scale * series + translation`.
+            When 'fitting' this transform, the `scale` and `translation` fixed parameters are returned.
 
             Parameters
             ----------
@@ -56,6 +62,24 @@ class BaseDataTransformerTestCase(unittest.TestCase):
             )
 
         @staticmethod
+        def ts_fit(series: TimeSeries, params: Mapping[str, Any], **kwargs):
+            """
+            'Fits' transform by returning `scale` and `translation` fixed params.
+            """
+            # Ensure `component_mask` not passed via `kwargs` if specified `mask_components=True`
+            # when transform created
+            mask_components = params["fixed"]["_mask_components"]
+            if mask_components:
+                assert "component_mask" not in kwargs
+            # Ensure 'fitted' is not in `params`:
+            assert "fitted" not in params
+            scale, translation = (
+                params["fixed"]["_scale"],
+                params["fixed"]["_translation"],
+            )
+            return scale, translation
+
+        @staticmethod
         def ts_transform(
             series: TimeSeries, params: Mapping[str, Any], **kwargs
         ) -> TimeSeries:
@@ -67,10 +91,9 @@ class BaseDataTransformerTestCase(unittest.TestCase):
             all used when computing this transformation.
 
             """
-            fixed_params = params["fixed"]
-            stack_samples = fixed_params["_stack_samples"]
-            mask_components = fixed_params["_mask_components"]
-            scale, translation = fixed_params["_scale"], fixed_params["_translation"]
+            stack_samples = params["fixed"]["_stack_samples"]
+            mask_components = params["fixed"]["_mask_components"]
+            scale, translation = params["fitted"]
 
             # Ensure `component_mask` not passed via `kwargs` if specified `mask_components=True`
             # when transform created
@@ -103,19 +126,69 @@ class BaseDataTransformerTestCase(unittest.TestCase):
 
             return series.with_values(vals)
 
+        @staticmethod
+        def ts_inverse_transform(
+            series: TimeSeries, params: Mapping[str, Any], **kwargs
+        ) -> TimeSeries:
+            """
+            Implements the inverse transform `(series - translation) / scale`.
+
+            If `component_mask` is in `kwargs`, this is manually applied and unapplied. If
+            `_stack_samples = True` in `params['fixed']`, then `stack_samples` and `unstack_samples`
+            all used when computing this transformation.
+
+            """
+            stack_samples = params["fixed"]["_stack_samples"]
+            mask_components = params["fixed"]["_mask_components"]
+            scale, translation = params["fitted"]
+
+            # Ensure `component_mask` not passed via `kwargs` if specified `mask_components=True`
+            # when transform created
+            if mask_components:
+                assert "component_mask" not in kwargs
+
+            # Ensure manual masking only performed when `mask_components = False`
+            # when transform constructed:
+            if not mask_components and ("component_mask" in kwargs):
+                vals = BaseDataTransformerTestCase.DataTransformerMock.apply_component_mask(
+                    series, kwargs["component_mask"], return_ts=False
+                )
+            else:
+                vals = series.all_values()
+
+            if stack_samples:
+                vals = BaseDataTransformerTestCase.DataTransformerMock.stack_samples(
+                    vals
+                )
+            vals = (vals - translation) / scale
+            if stack_samples:
+                vals = BaseDataTransformerTestCase.DataTransformerMock.unstack_samples(
+                    vals, series=series
+                )
+
+            if not mask_components and ("component_mask" in kwargs):
+                vals = BaseDataTransformerTestCase.DataTransformerMock.unapply_component_mask(
+                    series, vals, kwargs["component_mask"]
+                )
+
+            return series.with_values(vals)
+
     def test_input_transformed_single_series(self):
         """
-        Tests for correct transformation of single series.
+        Tests for correct (inverse) transformation of single series.
         """
         test_input = constant_timeseries(value=1, length=10)
 
         mock = self.DataTransformerMock(scale=2, translation=10)
 
-        transformed = mock.transform(test_input)
+        transformed = mock.fit_transform(test_input)
 
         # 2 * 1 + 10 = 12
         expected = constant_timeseries(value=12, length=10)
         self.assertEqual(transformed, expected)
+
+        # Should get input back:
+        self.assertEqual(mock.inverse_transform(transformed), test_input)
 
     def test_input_transformed_multiple_series(self):
         """
@@ -129,21 +202,33 @@ class BaseDataTransformerTestCase(unittest.TestCase):
 
         # Don't have different params for different jobs:
         mock = self.DataTransformerMock(scale=2, translation=10, parallel_params=False)
-        (transformed_1, transformed_2) = mock.transform((test_input_1, test_input_2))
+        (transformed_1, transformed_2) = mock.fit_transform(
+            (test_input_1, test_input_2)
+        )
         # 2 * 1 + 10 = 12
         self.assertEqual(transformed_1, constant_timeseries(value=12, length=10))
         # 2 * 2 + 10 = 14
         self.assertEqual(transformed_2, constant_timeseries(value=14, length=11))
+        # Should get input back:
+        inv_1, inv_2 = mock.inverse_transform((transformed_1, transformed_2))
+        self.assertEqual(inv_1, test_input_1)
+        self.assertEqual(inv_2, test_input_2)
 
         # Have different `scale` param for different jobs:
         mock = self.DataTransformerMock(
             scale=(2, 3), translation=10, parallel_params=["_scale"]
         )
-        (transformed_1, transformed_2) = mock.transform((test_input_1, test_input_2))
+        (transformed_1, transformed_2) = mock.fit_transform(
+            (test_input_1, test_input_2)
+        )
         # 2 * 1 + 10 = 12
         self.assertEqual(transformed_1, constant_timeseries(value=12, length=10))
         # 3 * 2 + 10 = 16
         self.assertEqual(transformed_2, constant_timeseries(value=16, length=11))
+        # Should get input back:
+        inv_1, inv_2 = mock.inverse_transform((transformed_1, transformed_2))
+        self.assertEqual(inv_1, test_input_1)
+        self.assertEqual(inv_2, test_input_2)
 
         # Have different `scale`, `translation`, and `stack_samples` params for different jobs:
         mock = self.DataTransformerMock(
@@ -153,11 +238,17 @@ class BaseDataTransformerTestCase(unittest.TestCase):
             mask_components=(False, False),
             parallel_params=True,
         )
-        (transformed_1, transformed_2) = mock.transform((test_input_1, test_input_2))
+        (transformed_1, transformed_2) = mock.fit_transform(
+            (test_input_1, test_input_2)
+        )
         # 2 * 1 + 10 = 12
         self.assertEqual(transformed_1, constant_timeseries(value=12, length=10))
         # 3 * 2 + 11 = 17
         self.assertEqual(transformed_2, constant_timeseries(value=17, length=11))
+        # Should get input back:
+        inv_1, inv_2 = mock.inverse_transform((transformed_1, transformed_2))
+        self.assertEqual(inv_1, test_input_1)
+        self.assertEqual(inv_2, test_input_2)
 
     def test_input_transformed_multiple_samples(self):
         """
@@ -170,7 +261,7 @@ class BaseDataTransformerTestCase(unittest.TestCase):
         )
 
         mock = self.DataTransformerMock(scale=2, translation=10, stack_samples=True)
-        transformed = mock.transform(test_input)
+        transformed = mock.fit_transform(test_input)
 
         # 2 * 1 + 10 = 12
         expected = constant_timeseries(value=12, length=10)
@@ -179,6 +270,9 @@ class BaseDataTransformerTestCase(unittest.TestCase):
             constant_timeseries(value=14, length=10), axis="sample"
         )
         self.assertEqual(transformed, expected)
+        # Should get input back:
+        inv = mock.inverse_transform(transformed)
+        self.assertEqual(inv, test_input)
 
     def test_input_transformed_masking(self):
         """
@@ -201,10 +295,16 @@ class BaseDataTransformerTestCase(unittest.TestCase):
         mock = self.DataTransformerMock(
             scale=scale, translation=translation, mask_components=True
         )
-        transformed = mock.transform(test_input, component_mask=mask)
+        transformed = mock.fit_transform(test_input, component_mask=mask)
         self.assertEqual(transformed, expected)
+        # Should get input back:
+        inv = mock.inverse_transform(transformed, component_mask=mask)
+        self.assertEqual(inv, test_input)
 
         # Manually apply component mask:
         mock = self.DataTransformerMock(scale=2, translation=10, mask_components=False)
-        transformed = mock.transform(test_input, component_mask=mask)
+        transformed = mock.fit_transform(test_input, component_mask=mask)
         self.assertEqual(transformed, expected)
+        # Should get input back:
+        inv = mock.inverse_transform(transformed, component_mask=mask)
+        self.assertEqual(inv, test_input)

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -393,7 +393,7 @@ class WindowTransformerTestCase(unittest.TestCase):
             transformed_ts_list[1].n_timesteps, self.series_multi_det.n_timesteps
         )
 
-    def test_transformers_pipline(self):
+    def test_transformers_pipeline(self):
         """
         Test that the forecasting window transformer can be used in a pipeline
 

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -350,9 +350,10 @@ class WindowTransformerTestCase(unittest.TestCase):
         associations_list = list(transformer._transform_iterator(self.sequence_det))
         self.assertEqual(len(associations_list), 2)
         self.assertEqual(associations_list[0][0], self.series_univ_det)
-        self.assertEqual(associations_list[0][1], expected_kwargs_dict)
+        # Need to access `'fixed'`` values in `params`:
+        self.assertEqual(associations_list[0][1]["fixed"], expected_kwargs_dict)
         self.assertEqual(associations_list[1][0], self.series_multi_det)
-        self.assertEqual(associations_list[1][1], expected_kwargs_dict)
+        self.assertEqual(associations_list[1][1]["fixed"], expected_kwargs_dict)
 
         # no series_id and components : all series will receive the same transformation on those components
         window_transformations = {"function": "mean", "components": ["0"]}
@@ -363,12 +364,13 @@ class WindowTransformerTestCase(unittest.TestCase):
             "treat_na": None,
             "forecasting_safe": True,
         }
+        # Need to access 'fixed' parameters inside of `params`:
         associations_list = list(transformer._transform_iterator(self.sequence_det))
         self.assertEqual(len(associations_list), 2)
         self.assertEqual(associations_list[0][0], self.series_univ_det)
-        self.assertEqual(associations_list[0][1], expected_kwargs_dict)
+        self.assertEqual(associations_list[0][1]["fixed"], expected_kwargs_dict)
         self.assertEqual(associations_list[1][0], self.series_multi_det)
-        self.assertEqual(associations_list[1][1], expected_kwargs_dict)
+        self.assertEqual(associations_list[1][1]["fixed"], expected_kwargs_dict)
 
     def test_window_transformer_output(self):
         window_transformations = {


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1407.

### Summary

This PR makes two major changes to how data transformers work:
1. Fixed parameters and fitted parameters (if any) are now 'automatically' passed to `ts_transform`, `ts_inverse_transform`, and `ts_fit` by default, without the user having to re-implement `_transform_iterator`, `_inverse_transform_iterator`, or `_fit_iterator`. To accommodate this, each of these `ts_*` methods now accepts a `params` (dictionary) argument, where `params['fixed']` stores the fixed parameters of the transformation (defined to be all those attributes defined in the child-most class *before calling `super().__init__`*) and `params['fitted']` stores the fitted parameters (i.e. what `ts_fit` returned).
2. `component_mask` key word arguments will be automatically applied to timeseries inputs given to `ts_*` and automatically 'unapplied' to timeseries outputs returned by these methods, which means that users don't have to worry about 'manually' dealing with these arguments inside of their implemented `ts_*` methods.  If the user does not wish for `component_masks` to be automatically applied, they may specify `mask_components=False` when calling `super().__init__`; this will cause any `component_mask` key word argument to be passed via `kwargs` to the called method (i.e. current behaviour).

To see how these changes can help simplify the work involved in implementing a new transformation, compare the [current implementation of `BoxCox`](https://github.com/unit8co/darts/blob/master/darts/dataprocessing/transformers/boxcox.py) and with the `BoxCox` implementation in this PR. 

### Other Information

Some other minor changes that come with this PR:
1. I split up the `_reshape_in` method into two new methods (`apply_component_mask` and `stack_samples`), as well as `_reshape_out` into two new methods (`unapply_component_mask` and `unstack_samples`). There are two reasons for this change:
     - `_reshape_in` and `_reshape_out` were responsible for applying two distinctly different changes to the data: masking component columns and stacking the samples of each component along a single axis. From a user interaction and maintainability perspective, I think it's much cleaner to have these two pieces of functionality separated from one another. The names `_reshape_in` and `_reshape_out` are, in my opinion, also a bit vague.
     - In the original implementation of `_reshape_in`/`_reshape_out`, the 'stacking step' was performed using a `for` loop; I've changed this so that only `np.swapaxes` and `np.reshape` operations are used , which theoretically should speed things up a bit.
     - I've made these new methods explicitly public, so that it's explicitly clear to new users looking to write their own transformations that it's "okay" to call these functions. 
2. I've refactored all of the currently implemented transformations so that they conform with these changes, with the exception of `StaticCovariatesTransformer`, which directly overrides the `fit`, `inverse_transform` and `transform` methods anyways. Similarly, I also had to make some minor adjustments to existing tests.
3. I've implemented new tests for the refactored `BaseDataTransformer` , `FittableDataTransformer`, and `InvertableDataTransformer` classes.
4. Some transformations, such as `BoxCox`, allow for different fixed parameter values to be distributed over different parallel jobs. To facillitate this, I've added a `parallel_params` argument to the `*Transformer` classes, which allows the user to specify which parameters should take different values for different parallel jobs. 

There are two drawbacks to what I've done here:
1. Some of these changes are slightly breaking; with that being said, I doubt many users currently have their own private code bases with their own custom-implemented `darts` transformations (although I could be wrong).
2. One 'gotcha' with this proposed interface is  that the user must only call `super().__init__` *after initialising the fixed parameters of their transformation*. For example, the following will allow the user to access `'_my_param'` in `params['fixed']`:
   ```python
   class MyTransform(BaseDataTransformer):
       def __init__(self):
              # Correct: Define fixed parameter *before* calling `super().__init__`
              self._my_param = 1
              super().__init__()
   ```
   whereas the following will **not**:
   ```python
   class MyTransform(BaseDataTransformer):
       def __init__(self):
              # Incorrect: Define fixed parameter *after* calling `super().__init__`
              super().__init__()
              self._my_param = 1
   ```

Any thoughts/comments on these changes are more than welcome.

Cheers,
Matt.