### PR TITLE
Feat/prophet logistic growth (#628)

### DIFF
--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -299,8 +299,12 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
     def set_capacity(
         self,
-        cap: Union[float, Callable[[Sequence[pd.Timestamp]], Sequence[float]]],
-        floor: Union[float, Callable[[Sequence[pd.Timestamp]], Sequence[float]]] = 0,
+        cap: Union[
+            float, Callable[[Union[pd.DatetimeIndex, pd.RangeIndex]], Sequence[float]]
+        ],
+        floor: Union[
+            float, Callable[[Union[pd.DatetimeIndex, pd.RangeIndex]], Sequence[float]]
+        ] = 0,
     ) -> None:
         """Set carrying capacities for predicting with logistic growth.
         These capacities are only used when `Prophet` was instantiated with `growth = 'logistic'`
@@ -309,8 +313,8 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         The `cap` and `floor` parameters may be:
         - a number, for constant carrying capacities
-        - a function taking a Sequence of Timestamps and returning a corresponding a Sequence of numbers,
-          where each number indicates the carrying capacity at this timepoint.
+        - a function taking a DatetimeIndex or RangeIndex and returning a corresponding a Sequence of numbers,
+          where each number indicates the carrying capacity at this index.
 
         Parameters
         ----------

--- a/darts/tests/models/forecasting/test_prophet.py
+++ b/darts/tests/models/forecasting/test_prophet.py
@@ -133,6 +133,28 @@ class ProphetTestCase(DartsBaseTestClass):
         model = Prophet()
         assert model._model_builder == FBProphet, "model should use Facebook Prophet"
 
+    def test_prophet_model_with_logistic_growth(self):
+        model = Prophet(growth="logistic")
+        model.set_capacity(1, 0)
+
+        # Create timeseries with logistic function
+        times = tg.generate_index(
+            pd.Timestamp("20200101"), pd.Timestamp("20210101"), freq="D"
+        )
+        values = np.linspace(-10, 10, len(times))
+        f = np.vectorize(lambda x: 1 / (1 + np.exp(-x)))
+        values = f(values)
+        ts = TimeSeries.from_times_and_values(times, values, freq="D")
+        # split in the middle, so the only way of predicting the plateau correctly
+        # is using the capacity
+        train, val = ts.split_after(0.5)
+
+        model.fit(train)
+        pred = model.predict(len(val))
+
+        for val_i, pred_i in zip(val.univariate_values(), pred.univariate_values()):
+            self.assertAlmostEqual(val_i, pred_i, delta=0.1)
+
     def helper_test_freq_coversion(self, test_cases):
         for freq, period in test_cases.items():
             ts_sine = tg.sine_timeseries(


### PR DESCRIPTION

Fixes #628 .

### Summary

Adds support for logistic growth to `Prophet` and a corresponding unit-test.

This PR adds the function `Prophet.set_capacity` to allow setting `cap` and `floor` parameters needed.
`Prophet.set_capacity` takes two arguments (`cap` and `floor`), which may be either numbers or Callables. 
`floor` defaults to 0, to replicate `FBProphet's` default behaviour. 
Numbers should be used as arguments when modeling a constant carrying capacity, Callables can be supplied when variable carrying capacities are needed. 
A Callable supplied as argument to `Prophet.set_capacity` must accept a `DatetimeIndex` or `RangeIndex` as input, and return a Sequence of numbers with the same length. Each number in this Sequence indicates the carrying capacity at the corresponding index.

During `Prophet.fit` and `Prophet.predict` cap and floor columns with the appropriate values are added to `fit_df` and `predict_df`, respectively.
If `Prophet` was instantiated with `growth = 'logistic`, `Prophet.fit` now raises a `ValueError` if carrying capacities have not been set.
If `Prophet.set_capacity` is called when `growth` is not logistic, a warning is logged and the `cap` and `floor` values set are ignored.
