### PR TITLE
Fix: `append_values` and `prepend_values` correctly extends `RangeIndex`-typed `TimeSeries`

### DIFF
--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -621,15 +621,53 @@ class TimeSeriesTestCase(DartsBaseTestClass):
 
     def test_append(self):
         TimeSeriesTestCase.helper_test_append(self, self.series1)
+        # Check `append` deals with `RangeIndex` series correctly:
+        series_1 = linear_timeseries(start=1, length=5, freq=2)
+        series_2 = linear_timeseries(start=11, length=2, freq=2)
+        appended = series_1.append(series_2)
+        expected_vals = np.concatenate(
+            [series_1.all_values(), series_2.all_values()], axis=0
+        )
+        expected_idx = pd.RangeIndex(start=1, stop=15, step=2)
+        self.assertTrue(np.allclose(appended.all_values(), expected_vals))
+        self.assertTrue(appended.time_index.equals(expected_idx))
 
     def test_append_values(self):
         TimeSeriesTestCase.helper_test_append_values(self, self.series1)
+        # Check `append_values` deals with `RangeIndex` series correctly:
+        series = linear_timeseries(start=1, length=5, freq=2)
+        appended = series.append_values(np.ones((2, 1, 1)))
+        expected_vals = np.concatenate(
+            [series.all_values(), np.ones((2, 1, 1))], axis=0
+        )
+        expected_idx = pd.RangeIndex(start=1, stop=15, step=2)
+        self.assertTrue(np.allclose(appended.all_values(), expected_vals))
+        self.assertTrue(appended.time_index.equals(expected_idx))
 
     def test_prepend(self):
         TimeSeriesTestCase.helper_test_prepend(self, self.series1)
+        # Check `prepend` deals with `RangeIndex` series correctly:
+        series_1 = linear_timeseries(start=1, length=5, freq=2)
+        series_2 = linear_timeseries(start=11, length=2, freq=2)
+        prepended = series_2.prepend(series_1)
+        expected_vals = np.concatenate(
+            [series_1.all_values(), series_2.all_values()], axis=0
+        )
+        expected_idx = pd.RangeIndex(start=1, stop=15, step=2)
+        self.assertTrue(np.allclose(prepended.all_values(), expected_vals))
+        self.assertTrue(prepended.time_index.equals(expected_idx))
 
     def test_prepend_values(self):
         TimeSeriesTestCase.helper_test_prepend_values(self, self.series1)
+        # Check `prepend_values` deals with `RangeIndex` series correctly:
+        series = linear_timeseries(start=1, length=5, freq=2)
+        prepended = series.prepend_values(np.ones((2, 1, 1)))
+        expected_vals = np.concatenate(
+            [np.ones((2, 1, 1)), series.all_values()], axis=0
+        )
+        expected_idx = pd.RangeIndex(start=-3, stop=11, step=2)
+        self.assertTrue(np.allclose(prepended.all_values(), expected_vals))
+        self.assertTrue(prepended.time_index.equals(expected_idx))
 
     def test_with_values(self):
         vals = np.random.rand(5, 10, 3)

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2604,9 +2604,9 @@ class TimeSeries:
             attrs=self._xa.attrs,
         )
 
-        # new_xa = xr.concat(objs=[self._xa, other_xa], dim=str(self._time_dim))
-        if not self._has_datetime_index:
-            new_xa = new_xa.reset_index(dims_or_levels=new_xa.dims[0])
+        # # new_xa = xr.concat(objs=[self._xa, other_xa], dim=str(self._time_dim))
+        # if not self._has_datetime_index:
+        #     new_xa = new_xa.reset_index(dims_or_levels=new_xa.dims[0])
 
         return self.__class__.from_xarray(
             new_xa, fill_missing_dates=True, freq=self._freq_str
@@ -2626,7 +2626,6 @@ class TimeSeries:
         TimeSeries
             A new TimeSeries with the new values appended
         """
-
         if self._has_datetime_index:
             idx = pd.DatetimeIndex(
                 [self.end_time() + i * self._freq for i in range(1, len(values) + 1)],
@@ -2634,9 +2633,10 @@ class TimeSeries:
             )
         else:
             idx = pd.RangeIndex(
-                len(self), len(self) + self.freq * len(values), step=self.freq
+                start=self.end_time() + self._freq,
+                stop=self.end_time() + (len(values) + 1) * self._freq,
+                step=self._freq,
             )
-
         return self.append(
             self.__class__.from_times_and_values(
                 values=values,

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2604,10 +2604,6 @@ class TimeSeries:
             attrs=self._xa.attrs,
         )
 
-        # # new_xa = xr.concat(objs=[self._xa, other_xa], dim=str(self._time_dim))
-        # if not self._has_datetime_index:
-        #     new_xa = new_xa.reset_index(dims_or_levels=new_xa.dims[0])
-
         return self.__class__.from_xarray(
             new_xa, fill_missing_dates=True, freq=self._freq_str
         )


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1434.

### Summary

Previously, `append_values` and `prepend_values` did not correctly handle extending `RangeIndex`-typed `TimeSeries`. For example, the following code snippet:
```python
from darts.utils.timeseries_generation import linear_timeseries
import numpy as np

series = linear_timeseries(start=1, length=5, freq=2)
print('Before `append_values`:')
print(list(series.time_index))
new_values = np.ones((1,))
print('After `append_values`:')
print(list(series.append_values(new_values).time_index))
```
would print:
```
Before `append_values`:
[1, 3, 5, 7, 9]
After `append_values`:
[0, 1, 2, 3, 4, 5]
```
This has been fixed in this PR so that this code now prints:
```
Before `append_values`:
[1, 3, 5, 7, 9]
After `append_values`:
[1, 3, 5, 7, 9, 11]
```

Similarly, the code snippet:
```python
from darts.utils.timeseries_generation import linear_timeseries
import numpy as np

series = linear_timeseries(start=1, length=5, freq=2)
print('Before `prepend_values`:')
print(list(series.time_index))
new_values = np.ones((1,))
print('After `prepend_values`:')
print(list(series.prepend_values(new_values).time_index))
```
would previously print:
```
Before `append_values`:
[1, 3, 5, 7, 9]
After `append_values`:
[0, 1, 2, 3, 4, 5]
```
Now, this same code snippet prints:
```
Before `prepend_values`:
[1, 3, 5, 7, 9]
After `prepend_values`:
[-1, 1, 3, 5, 7, 9]
```

### Other Information

Tests have also been updated to explicitly check for this behaviour.
