### PR TITLE
Bug fix - correct for multiple lengths of series in input sequence when adding static covariates to regression models

### DIFF
--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -337,7 +337,13 @@ class RegressionModel(GlobalForecastingModel):
         )
 
         training_samples = _add_static_covariates(
-            self.model, target_series, training_samples
+            self,
+            training_samples,
+            target_series,
+            *self.extreme_lags,
+            past_covariates=past_covariates,
+            future_covariates=future_covariates,
+            max_samples_per_ts=max_samples_per_ts,
         )
 
         return training_samples, training_labels
@@ -675,7 +681,15 @@ class RegressionModel(GlobalForecastingModel):
 
             # concatenate retrieved lags
             X = np.concatenate(np_X, axis=1)
-            X = _add_static_covariates(self.model, series, X)
+            X = _add_static_covariates(
+                self,
+                X,
+                series,
+                *self.extreme_lags,
+                past_covariates=past_covariates,
+                future_covariates=future_covariates,
+                max_samples_per_ts=1,
+            )
 
             # X has shape (n_series * n_samples, n_regression_features)
             prediction = self._predict_and_sample(X, num_samples, **kwargs)

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -655,17 +655,15 @@ class RegressionModelsTestCase(DartsBaseTestClass):
         target_series = series2seq(target_series)
         past_covs = series2seq(past_covs)
         future_covs = series2seq(future_covs)
-
         scovs_set = []
-        scovs_set = scovs_set.extend(
-            s.static_covariates.columns.values if s.has_static_covariates else [""]
-            for s in target_series
-        )
+        for s in target_series:
+            if s.has_static_covariates:
+                scovs_set.extend(s.static_covariates.columns.to_list())
 
         all_target_width = target_series[0].n_components
         scovs_width = (
-            len(set(scovs_set)) if scovs_set is not None else 0 * all_target_width
-        )
+            len(set(scovs_set)) if scovs_set is not None else 0
+        ) * all_target_width
         all_past_width = past_covs[0].n_components if past_covs is not None else 0
         all_future_width = future_covs[0].n_components if future_covs is not None else 0
 

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -656,14 +656,16 @@ class RegressionModelsTestCase(DartsBaseTestClass):
         past_covs = series2seq(past_covs)
         future_covs = series2seq(future_covs)
 
-        max_scovs_width = max(
-            s.static_covariates_values(copy=False).reshape(1, -1).shape[1]
-            if s.has_static_covariates
-            else 0
+        scovs_set = []
+        scovs_set = scovs_set.extend(
+            s.static_covariates.columns.values if s.has_static_covariates else [""]
             for s in target_series
         )
 
         all_target_width = target_series[0].n_components
+        scovs_width = (
+            len(set(scovs_set)) if scovs_set is not None else 0 * all_target_width
+        )
         all_past_width = past_covs[0].n_components if past_covs is not None else 0
         all_future_width = future_covs[0].n_components if future_covs is not None else 0
 
@@ -718,7 +720,7 @@ class RegressionModelsTestCase(DartsBaseTestClass):
             for idx in range(len(target_series))
         ]
 
-        target_feature_width = all_target_width * len(target_lag) + max_scovs_width
+        target_feature_width = all_target_width * len(target_lag) + scovs_width
         past_cov_feature_width = (
             (all_past_width * len(past_covs_lag)) if past_covs is not None else 0
         )
@@ -738,13 +740,13 @@ class RegressionModelsTestCase(DartsBaseTestClass):
 
         static_covs1 = pd.DataFrame(
             data={
-                "cont": [0.1, 0.2, 0.3],
-                "cat": ["a", "b", "c"],  # should lead to 9 one-hot encoded columns
+                "cont1": [0.1, 0.2, 0.3],
+                "cat1": ["a", "b", "c"],  # should lead to 9 one-hot encoded columns
             }
-        ).astype(dtype={"cat": "category"})
+        ).astype(dtype={"cat1": "category"})
 
-        static_covs2 = pd.DataFrame(data={"cont": [10, 20, 30]})
-        static_covs3 = pd.DataFrame(data={"cont": [100, 200, 300]})
+        static_covs2 = pd.DataFrame(data={"cont2": [10, 20, 30]})
+        static_covs3 = pd.DataFrame(data={"cont3": [1, 2, 3]})
 
         # default transformer_num = MinMaxScaler()
         scaler = StaticCovariatesTransformer(transformer_cat=OneHotEncoder())

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -37,7 +37,7 @@ import re
 from collections import defaultdict
 from copy import deepcopy
 from inspect import signature
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -47,6 +47,11 @@ from pandas.tseries.frequencies import to_offset
 from scipy.stats import kurtosis, skew
 
 from .logging import get_logger, raise_if, raise_if_not, raise_log
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 logger = get_logger(__name__)
 

--- a/darts/utils/data/tabularization.py
+++ b/darts/utils/data/tabularization.py
@@ -184,7 +184,8 @@ def _add_static_covariates(
     number of available static_covariates in any of the given series in the sequence.
     If no static covariates are provided for a given series, its corresponding features are padded with 0.
     Accounts for the case where the model is trained with series with static covariates and then used to predict
-    on series without static covariates by padding with 0 the static covariates of the series without static covariates.
+    on series without static covariates by padding with 0 the corresponding features of the series without
+    static covariates.
 
     Parameters
     ----------

--- a/darts/utils/data/tabularization.py
+++ b/darts/utils/data/tabularization.py
@@ -161,7 +161,7 @@ def _create_lagged_data(
     # combine samples from all series
     X = np.concatenate(Xs, axis=0)
     y = np.concatenate(ys, axis=0)
-    print("end of feature prep:", X.shape)
+
     return X, y, Ts
 
 

--- a/darts/utils/data/tabularization.py
+++ b/darts/utils/data/tabularization.py
@@ -169,11 +169,11 @@ def _add_static_covariates(
     model: ForecastingModel,
     features: np.array,
     target_series: Union[TimeSeries, Sequence[TimeSeries]],
-    min_target_lag,
-    output_chunk_length,
-    min_past_cov_lag,
-    min_future_cov_lag,
-    max_future_cov_lag,
+    min_target_lag: int,
+    output_chunk_length: int,
+    min_past_cov_lag: Optional[int] = None,
+    min_future_cov_lag: Optional[int] = None,
+    max_future_cov_lag: Optional[int] = None,
     past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
     future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
     max_samples_per_ts: Optional[int] = None,
@@ -190,10 +190,20 @@ def _add_static_covariates(
     ----------
     model
         The regression model. Should be an instance of darts.models.RegressionModel.
-    series
-        The series to which the static covariates are attached.
     features
-        The features to which the static covariates are added.
+        The features' numpy array to which the static covariates will be added.
+    target_series
+        The target series from which to read the static covariates.
+    min_target_lag
+        The minimum past lag of the target series.
+    output_chunk_length
+        The model's output chunk length.
+    min_past_cov_lag
+        The minimum past lag of the past covariates.
+    min_future_cov_lag
+        The minimum past lag of the future covariates.
+    max_future_cov_lag
+        The maximum future lag of the future covariates.
     max_samples_per_ts
         Optionally, the maximum number of samples to be drawn for training or inference.
         It is set to 1 for inference (i.e., auto-regressively predict one step at a time, hence generate one

--- a/darts/utils/data/tabularization.py
+++ b/darts/utils/data/tabularization.py
@@ -295,7 +295,7 @@ def _add_static_covariates(
             df = scovs_map["df"][i]
 
             if not df.empty:
-                df = df.reindex(col_names, axis=1, fill_value=0.0)
+                df = df.reindex(col_names, axis=1, fill_value=0.0, copy=True)
                 # reshape with order="F" to ensure that the covariates are read column wise
                 scovs = df.values.reshape(1, -1, order="F")
                 static_covs.append(np.tile(scovs, reps=(scovs_map["reps"][i], 1)))

--- a/darts/utils/data/tabularization.py
+++ b/darts/utils/data/tabularization.py
@@ -228,7 +228,7 @@ def _add_static_covariates(
     )
 
     # collect static covariates info
-    scovs_map = {"covs_width": [], "df": [], "values": [], "reps": [], "names": set()}
+    scovs_map = {"covs_exist": False, "df": [], "reps": [], "names": set()}
 
     for idx, ts in enumerate(target_series):
         len_target_features = len(ts) - max_past_lag - (output_chunk_length - 1)
@@ -257,7 +257,7 @@ def _add_static_covariates(
         if ts.static_covariates is not None:
 
             scovs_map["names"].update(set(ts.static_covariates.columns))
-            scovs_map["covs_width"].append(len(ts.static_covariates.columns)*n_comps)
+            scovs_map["covs_exist"] = True
             scovs_map["df"].append(ts.static_covariates)
             scovs_map["reps"].append(
                 max_samples_per_ts
@@ -265,7 +265,6 @@ def _add_static_covariates(
                 else len_shortest_features
             )
         else:
-            scovs_map["covs_width"].append(0)
             scovs_map["df"].append(pd.DataFrame())
             scovs_map["reps"].append(
                 max_samples_per_ts
@@ -273,9 +272,7 @@ def _add_static_covariates(
                 else len_shortest_features
             )
 
-    max_width = max(scovs_map["covs_width"])
-
-    if max_width == 0:
+    if not scovs_map["covs_exist"]:
         if (
             hasattr(model, "n_features_in_")
             and model.n_features_in_ is not None
@@ -303,7 +300,7 @@ def _add_static_covariates(
                 scovs = df.values.reshape(1, -1, order="F")
                 static_covs.append(np.tile(scovs, reps=(scovs_map["reps"][i], 1)))
             else:
-                pad_zeros = np.zeros((1, len(col_names)*n_comps))
+                pad_zeros = np.zeros((1, len(col_names) * n_comps))
                 static_covs.append(np.tile(pad_zeros, reps=(scovs_map["reps"][i], 1)))
         static_covs = np.concatenate(static_covs, axis=0)
 


### PR DESCRIPTION

<!-- Please mention an issue this pull request addresses. -->
Fixes #1460 

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->
In the original version for the code adding static covariates to regression models, it was assumed that the series are of same length.
This PR corrects this assumption and allows to support  cases where the series in the input sequence have different sizes. 

### Other Information
None

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
