### PR TITLE
Fix: Syntax Highlighting in Notebook-Generated Sphinx Pages

### DIFF
--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,5 +1,6 @@
 bump2version==1.0.1
 docutils==0.17.1
+ipython==8.8.0
 ipykernel==5.3.4
 ipywidgets==7.5.1
 jinja2==3.0.3


### PR DESCRIPTION
Fixes #1468.

### Summary

It appears that  a bug associated with `ipython==8.7.0` caused syntax highlighting in the notebook-generated example pages to break - see https://github.com/spatialaudio/nbsphinx/issues/687. Explicitly specifying `ipython==8.8.0` in `requirements/release.txt` seems to solve this problem (at least when I compile the docs locally with `Python 3.10.6`).