### PR TITLE
Remove unused return type

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -702,7 +702,7 @@ class TimeSeries:
         fill_missing_dates: Optional[bool] = False,
         freq: Optional[str] = None,
         fillna_value: Optional[float] = None,
-    ) -> Union["TimeSeries", List["TimeSeries"]]:
+    ) -> List["TimeSeries"]:
         """
         Build a list of TimeSeries instances grouped by a selection of columns from a DataFrame.
         One column (or the DataFrame index) has to represent the time,
@@ -746,7 +746,7 @@ class TimeSeries:
 
         Returns
         -------
-        TimeSeries
+        List[TimeSeries]
             A list containing a univariate or multivariate deterministic TimeSeries per group in the DataFrame.
         """
         group_cols = [group_cols] if not isinstance(group_cols, list) else group_cols


### PR DESCRIPTION
Fixes #1484.

### Summary

Replace the `Union` return type of `TimeSeries.from_group_dataframe` with a `List["TimeSeries"]`, since the function is guarantied to return a list.