### PR TITLE
fix NoneType error for encoder train index generation

### DIFF
--- a/darts/dataprocessing/encoders/encoder_base.py
+++ b/darts/dataprocessing/encoders/encoder_base.py
@@ -334,7 +334,7 @@ class FutureCovariatesIndexGenerator(CovariatesIndexGenerator):
         #     target index; always True for all models except RegressionModels.
         # case 3
         #     covariate lags were given and (shift_start <= 0 or shift_end <= 0): historic part of future covariates.
-        #     if shift_end < there will only be the historic part of future covariates.
+        #     if shift_end < 0 there will only be the historic part of future covariates.
         #     If shift_start <= 0 and abs(shift_start - 1) > input_chunk_length: we need to add indices before the
         #     beginning of the target series; can only be True for RegressionModels.
         # case 4
@@ -818,8 +818,12 @@ def _generate_train_idx(target, steps_ahead_start, steps_ahead_end) -> Supported
     )
 
     # if `steps_ahead_start >= 0` or `steps_ahead_end <= 0` we must extract a slice of the target series index
-    center_start = None if steps_ahead_start < 0 else steps_ahead_start
-    center_end = None if steps_ahead_end > 0 else steps_ahead_end
+    center_start = steps_ahead_start if steps_ahead_start >= 0 else None
+    center_end = (
+        steps_ahead_end
+        if steps_ahead_end is not None and steps_ahead_end <= 0
+        else None
+    )
     idx_center = target.time_index[center_start:center_end]
 
     # case 3
@@ -829,7 +833,7 @@ def _generate_train_idx(target, steps_ahead_start, steps_ahead_end) -> Supported
             length=abs(steps_ahead_end),
             freq=target.freq,
         )
-        if steps_ahead_end > 0
+        if steps_ahead_end is not None and steps_ahead_end > 0
         else target.time_index.__class__([])
     )
 

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -675,11 +675,9 @@ class RegressionModelsTestCase(DartsBaseTestClass):
             max_future_cov_lag,
         ) = reg_model.extreme_lags
         max_past_lag = max(
-            [
-                abs(v)
-                for v in [min_target_lag, min_past_cov_lag, min_future_cov_lag]
-                if v is not None
-            ]
+            abs(v)
+            for v in [min_target_lag, min_past_cov_lag, min_future_cov_lag]
+            if v is not None
         )
 
         len_target_features = [
@@ -1751,6 +1749,32 @@ class RegressionModelsTestCase(DartsBaseTestClass):
                     for model in [model_pc_valid0, model_fc_valid0, model_mixed_valid0]:
                         model.fit(ts)
                         assert not model.encoders.encoding_available
+                        _ = model.predict(n=1, series=ts)
+                        _ = model.predict(n=3, series=ts)
+
+                    model_pc_valid0 = model_cls(
+                        lags_past_covariates=[-2],
+                        add_encoders=encoder_examples["past"],
+                        multi_models=mode,
+                        output_chunk_length=ocl,
+                    )
+                    model_fc_valid0 = model_cls(
+                        lags_future_covariates=[-1, 0],
+                        add_encoders=encoder_examples["future"],
+                        multi_models=mode,
+                        output_chunk_length=ocl,
+                    )
+                    model_mixed_valid0 = model_cls(
+                        lags_past_covariates=[-2, -1],
+                        lags_future_covariates=[-3, 3],
+                        add_encoders=encoder_examples["mixed"],
+                        multi_models=mode,
+                        output_chunk_length=ocl,
+                    )
+                    # check that fit/predict works with model internal covariate requirement checks
+                    for model in [model_pc_valid0, model_fc_valid0, model_mixed_valid0]:
+                        model.fit(ts)
+                        assert model.encoders.encoding_available
                         _ = model.predict(n=1, series=ts)
                         _ = model.predict(n=3, series=ts)
 


### PR DESCRIPTION
### Summary
- fixes a bug when using a future covariates encoder with a maximum lag value of 0.