### PR TITLE
Feat/improved data-transformers

### DIFF
--- a/darts/dataprocessing/transformers/fittable_data_transformer.py
+++ b/darts/dataprocessing/transformers/fittable_data_transformer.py
@@ -218,7 +218,7 @@ class FittableDataTransformer(BaseDataTransformer):
         raise_if(
             len(data) != len(self._fitted_params),
             f"There is a mismatch between the number of TimeSeries used during training"
-            f" ({len(self._fitted_params)}) and transformation ({len(data)}).",
+            f" ({len(self._fitted_params)}) and to transform ({len(data)}).",
             logger,
         )
 

--- a/darts/dataprocessing/transformers/fittable_data_transformer.py
+++ b/darts/dataprocessing/transformers/fittable_data_transformer.py
@@ -53,7 +53,7 @@ class FittableDataTransformer(BaseDataTransformer):
         super().__init__(name=name, n_jobs=n_jobs, verbose=verbose)
 
         self._fit_called = False
-        self.fitted_params = None  # stores the fitted parameters/objects
+        self._fitted_params = None  # stores the fitted parameters/objects
 
     @staticmethod
     @abstractmethod

--- a/darts/dataprocessing/transformers/fittable_data_transformer.py
+++ b/darts/dataprocessing/transformers/fittable_data_transformer.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from typing import Iterator, List, Sequence, Tuple, Union
 
 from darts import TimeSeries
-from darts.logging import get_logger, raise_if
+from darts.logging import get_logger
 from darts.utils import _build_tqdm_iterator, _parallel_apply
 
 from .base_data_transformer import BaseDataTransformer
@@ -205,21 +205,3 @@ class FittableDataTransformer(BaseDataTransformer):
         return self.fit(series, component_mask=component_mask).transform(
             series, *args, **kwargs
         )
-
-    def transform(
-        self, series: Union[TimeSeries, Sequence[TimeSeries]], *args, **kwargs
-    ) -> Union[TimeSeries, List[TimeSeries]]:
-        # check length of input matches fitted parameters
-        if isinstance(series, TimeSeries):
-            data = [series]
-        else:
-            data = series
-
-        raise_if(
-            len(data) != len(self._fitted_params),
-            f"There is a mismatch between the number of TimeSeries used during training"
-            f" ({len(self._fitted_params)}) and to transform ({len(data)}).",
-            logger,
-        )
-
-        return super().transform(series, *args, **kwargs)

--- a/darts/dataprocessing/transformers/invertible_data_transformer.py
+++ b/darts/dataprocessing/transformers/invertible_data_transformer.py
@@ -21,6 +21,7 @@ class InvertibleDataTransformer(BaseDataTransformer):
         name: str = "InvertibleDataTransformer",
         n_jobs: int = 1,
         verbose: bool = False,
+        input_dim_variant: bool = False,
     ):
 
         """Abstract class for invertible transformers.
@@ -162,14 +163,6 @@ class InvertibleDataTransformer(BaseDataTransformer):
             data = [series]
         else:
             data = series
-
-        if hasattr(self, "_fitted_params"):
-            raise_if_not(
-                len(data) == len(self._fitted_params),
-                f"There is a mismatch between the number of TimeSeries used during training"
-                f" ({len(self._fitted_params)}) and to transform ({len(data)}).",
-                logger,
-            )
 
         input_iterator = _build_tqdm_iterator(
             self._inverse_transform_iterator(data),

--- a/darts/dataprocessing/transformers/invertible_data_transformer.py
+++ b/darts/dataprocessing/transformers/invertible_data_transformer.py
@@ -21,7 +21,6 @@ class InvertibleDataTransformer(BaseDataTransformer):
         name: str = "InvertibleDataTransformer",
         n_jobs: int = 1,
         verbose: bool = False,
-        input_dim_variant: bool = False,
     ):
 
         """Abstract class for invertible transformers.

--- a/darts/dataprocessing/transformers/invertible_data_transformer.py
+++ b/darts/dataprocessing/transformers/invertible_data_transformer.py
@@ -163,6 +163,14 @@ class InvertibleDataTransformer(BaseDataTransformer):
         else:
             data = series
 
+        if hasattr(self, "_fitted_params"):
+            raise_if_not(
+                len(data) == len(self._fitted_params),
+                f"There is a mismatch between the number of TimeSeries used during training"
+                f" ({len(self._fitted_params)}) and to transform ({len(data)}).",
+                logger,
+            )
+
         input_iterator = _build_tqdm_iterator(
             self._inverse_transform_iterator(data),
             verbose=self._verbose,

--- a/darts/dataprocessing/transformers/scaler.py
+++ b/darts/dataprocessing/transformers/scaler.py
@@ -4,11 +4,11 @@ Scaler
 """
 
 from copy import deepcopy
-from typing import Any, Iterator, Sequence, Tuple
+from typing import Any, Iterator, List, Sequence, Tuple, Union
 
 from sklearn.preprocessing import MinMaxScaler
 
-from darts.logging import get_logger, raise_log
+from darts.logging import get_logger, raise_if_not, raise_log
 from darts.timeseries import TimeSeries
 
 from .fittable_data_transformer import FittableDataTransformer
@@ -134,6 +134,41 @@ class Scaler(InvertibleDataTransformer, FittableDataTransformer):
             Scaler._reshape_in(series, component_mask=component_mask)
         )
         return scaler
+
+    def transform(
+        self, series: Union[TimeSeries, Sequence[TimeSeries]], *args, **kwargs
+    ) -> Union[TimeSeries, List[TimeSeries]]:
+        # check length of input matches fitted parameters
+        if isinstance(series, TimeSeries):
+            data = [series]
+        else:
+            data = series
+
+        raise_if_not(
+            len(data) == len(self._fitted_params),
+            f"There is a mismatch between the number of TimeSeries used during training"
+            f" ({len(self._fitted_params)}) and to transform ({len(data)}).",
+            logger,
+        )
+
+        return super().transform(series, *args, **kwargs)
+
+    def inverse_transform(
+        self, series: Union[TimeSeries, Sequence[TimeSeries]], *args, **kwargs
+    ) -> Union[TimeSeries, List[TimeSeries]]:
+        # check length of input matches fitted parameters
+        if isinstance(series, TimeSeries):
+            data = [series]
+        else:
+            data = series
+
+        raise_if_not(
+            len(data) == len(self._fitted_params),
+            f"There is a mismatch between the number of TimeSeries used during training"
+            f" ({len(self._fitted_params)}) and to transform ({len(data)}).",
+            logger,
+        )
+        return super().inverse_transform(series, *args, **kwargs)
 
     def _fit_iterator(
         self, series: Sequence[TimeSeries]

--- a/darts/tests/dataprocessing/transformers/test_data_transformer.py
+++ b/darts/tests/dataprocessing/transformers/test_data_transformer.py
@@ -89,6 +89,12 @@ class DataTransformerTestCase(unittest.TestCase):
         # fitted on 2 series, transform 3 series
         with self.assertRaises(ValueError):
             transformer1.transform([self.series1, self.series1, self.series2])
+        # fitted on 2 series, inverse transform 1 serie
+        with self.assertRaises(ValueError):
+            transformer1.inverse_transform(self.series1)
+        # fitted on 2 series, inverse transform 3 series
+        with self.assertRaises(ValueError):
+            transformer1.inverse_transform([self.series1, self.series1, self.series2])
 
     def test_multivariate_stochastic_series(self):
         scaler = Scaler(MinMaxScaler())

--- a/darts/tests/dataprocessing/transformers/test_data_transformer.py
+++ b/darts/tests/dataprocessing/transformers/test_data_transformer.py
@@ -83,6 +83,13 @@ class DataTransformerTestCase(unittest.TestCase):
                 series_array[index].values().flatten(),
             )
 
+        # fitted on 2 series, transform 1 serie
+        with self.assertRaises(ValueError):
+            transformer1.transform(self.series1)
+        # fitted on 2 series, transform 3 series
+        with self.assertRaises(ValueError):
+            transformer1.transform([self.series1, self.series1, self.series2])
+
     def test_multivariate_stochastic_series(self):
         scaler = Scaler(MinMaxScaler())
         vals = np.random.rand(10, 5, 50)


### PR DESCRIPTION
Fixes #1288,  #1300.

### Summary
- `Scaler` verifies that the dimensions of the input to `transform()` and `inverse_transform()`  match the dimensions of the fitted parameters, raise an exception if the condition is not verified.
- Fixed a small typo in `BaseDataTransformer`, the fitted parameters were not properly stored in the attribute.

### Other Information
Would be happy to also implement the Mappable support in the same PR, I just need to think of a nice way to implement it without breaking the support of Sequence.

**[EDIT]** My first approach was to place the logic in `Fittable`-/`InvertibleDataTransformer` but it was requiring transversal modifications to cover all the types of transformation: I tried to add an attribute `input_dim_invariant` to bypass the input dimension check for the relevant Transformers (notably for `StaticCovariatesTransformer`) but it was too messy so I moved the logic to `Scaler`)