### PR TITLE
fix model_fit_kwargs by removing none elements

### DIFF
--- a/darts/ad/anomaly_model/forecasting_am.py
+++ b/darts/ad/anomaly_model/forecasting_am.py
@@ -152,6 +152,9 @@ class ForecastingAnomalyModel(AnomalyModel):
         model_fit_kwargs["past_covariates"] = list_past_covariates
         model_fit_kwargs["future_covariates"] = list_future_covariates
 
+        # remove None elements from dictionary
+        model_fit_kwargs = {k: v for k, v in model_fit_kwargs.items() if v}
+
         # fit forecasting model
         if allow_model_training:
             # the model has not been trained yet


### PR DESCRIPTION
Added a line in the forecasting anomaly model .fit() that removes the none element in the model_fit_kwargs dictionary. 

Further detail about the problem:

"For a forecasting anomaly model, we allow the user to input a parameter model_fit_kwargs (a dictionary that contains the fitting parameter to pass to the fit function of the model). In the code, we add to this dictionary the past_covariates and future_covariates. If the user does not provide the covariates, we still create the keys in the dictionary, but they point to an empty element.

The problem is that not all forecasting models accept past and future covariates (for example, ARIMA does not accept past_covariates). For example, suppose a user creates a forecasting anomaly model with a non-fitted ARIMA model (with allow_model_training=True). In that case, an error will occur: “TypeError: fit() got an unexpected keyword argument ‘past_covariates’ “, even though the user didn’t give a past_covariates parameter.

In the previous code version, a line removed empty elements from the dictionary before passing it to the fit function. This solved the problem, but after reviews, we decided to remove this line, but I don’t remember why."
