### PR TITLE
fix quantile detector when low/high threshold are the same

### DIFF
--- a/darts/ad/detectors/threshold_detector.py
+++ b/darts/ad/detectors/threshold_detector.py
@@ -91,12 +91,12 @@ class ThresholdDetector(Detector):
         raise_if_not(
             all(
                 [
-                    l < h
+                    l <= h
                     for (l, h) in zip(self.low_threshold, self.high_threshold)
                     if ((l is not None) and (h is not None))
                 ]
             ),
-            "all values in `low_threshold` must be lower than their corresponding value in `high_threshold`.",
+            "all values in `low_threshold` must be lower or equal than their corresponding value in `high_threshold`.",
         )
 
     def _detect_core(self, series: TimeSeries) -> TimeSeries:


### PR DESCRIPTION
Fix the issue raised by [philippspengler](https://github.com/philippspengler):

Describe the bug
The QuantileDetector class raises an error during fitting when the time series has low variation.

To Reproduce

series = TimeSeries.from_series(pd.Series([96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 96.0, 93.0]))
quantile_detector = QuantileDetector(low_quantile=0.05, high_quantile=0.95)
quantile_detector.fit(series)
Expected behavior
Expect the quantile detector to fit without an error.

System (please complete the following information):

Python version: 3.8.5
darts version 0.23.1

Solution:

The problemed occurred when the low and high quantiles corresponded to the same number, and when calling the threshold detector, an error was raised as it expected two different values. The condition was removed. 

