### PR TITLE
fix: restore Python 3.7 back-compatibility 

### DIFF
--- a/darts/ad/scorers/kmeans_scorer.py
+++ b/darts/ad/scorers/kmeans_scorer.py
@@ -112,7 +112,7 @@ class KMeansScorer(FittableAnomalyScorer):
         self.kmeans_kwargs["n_clusters"] = k
         # stop warning about default value of "n_init" changing from 10 to "auto" in sklearn 1.4
         if "n_init" not in self.kmeans_kwargs:
-            self.kmeans_kwargs["n_init"] = "auto"
+            self.kmeans_kwargs["n_init"] = 10
 
         super().__init__(
             univariate_scorer=(not component_wise), window=window, diff_fn=diff_fn

--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -611,7 +611,7 @@ class UberTLCDataset(DatasetLoaderCSV):
 
                 output_dict[locationID] = count_series
             output_df = pd.DataFrame(output_dict)
-            output_df.to_csv(dataset_path, lineterminator="\n")
+            output_df.to_csv(dataset_path, line_terminator="\n")
 
         super().__init__(
             metadata=DatasetLoaderMetadata(


### PR DESCRIPTION
Fixes Python 3.7 back-compatibility issue introduced by #1502.

### Summary

- revert lineterminator to line_terminator for `read_csv`
- overwrite the default value of `n_init` with 10 instead of "auto" (sklearn 1.4 changes) to eliminate warning in 3.9 but retain compatibility with 3.7

### Other Information

Sorry for breaking python 3.7.
