### PR TITLE
add a docstring entry to diff transformer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       -  id: isort
 

--- a/darts/dataprocessing/transformers/diff.py
+++ b/darts/dataprocessing/transformers/diff.py
@@ -1,3 +1,8 @@
+"""
+Differencing Transformer
+------------------------
+"""
+
 from typing import Any, Iterator, Sequence, Tuple, Union
 
 import numpy as np


### PR DESCRIPTION
We forgot a docstring entry for the Diff transformer, this PR adds it.

I also had to include one of the changes brought in https://github.com/unit8co/darts/pull/1578/files to make my pre-commit work.