### PR TITLE
Fix/Make reconcilliation order independent

### DIFF
--- a/darts/dataprocessing/transformers/reconciliation.py
+++ b/darts/dataprocessing/transformers/reconciliation.py
@@ -134,9 +134,9 @@ class TopDownReconciliator(FittableDataTransformer):
 
         # compute proportions for each base component
         proportions = sum_base / sum_total
-
+        top_level_index = list(series.components).index(series.top_level_component)
         G = np.zeros((m, n))
-        G[:, list(series.components).index(series.top_level_component)] = proportions
+        G[:, top_level_index] = proportions
 
         return G
 

--- a/darts/dataprocessing/transformers/reconciliation.py
+++ b/darts/dataprocessing/transformers/reconciliation.py
@@ -83,8 +83,14 @@ class BottomUpReconciliator(BaseDataTransformer):
 
     @staticmethod
     def get_projection_matrix(series):
-        n, m = series.n_components, len(series.bottom_level_components)
-        return np.concatenate([np.zeros((m, n - m)), np.eye(m)], axis=1)
+        leaves_seq = list(series.bottom_level_components)
+        n, m = series.n_components, len(leaves_seq)
+        leaves_indexes = {l: i for i, l in enumerate(leaves_seq)}
+        G = np.zeros((m, n))
+        for i, c in enumerate(series.components):
+            if c in leaves_indexes:
+                G[leaves_indexes[c], i] = 1.0
+        return G
 
     @staticmethod
     def ts_transform(series: TimeSeries, *args, **kwargs) -> TimeSeries:
@@ -130,7 +136,7 @@ class TopDownReconciliator(FittableDataTransformer):
         proportions = sum_base / sum_total
 
         G = np.zeros((m, n))
-        G[:, 0] = proportions
+        G[:, list(series.components).index(series.top_level_component)] = proportions
 
         return G
 

--- a/darts/tests/dataprocessing/transformers/test_reconciliation.py
+++ b/darts/tests/dataprocessing/transformers/test_reconciliation.py
@@ -206,9 +206,8 @@ class ReconciliationTestCase(unittest.TestCase):
         ts_2 = ts_2.with_hierarchy(hierarchy)
         assert_ts_are_equal(ts_1, ts_2)
 
-        S1 = _get_summation_matrix(ts_1)
-        S2 = _get_summation_matrix(ts_2)
-        np.testing.assert_array_equal(S1, S2)
+        P1 = BottomUpReconciliator().get_projection_matrix(ts_1)
+        P2 = BottomUpReconciliator().get_projection_matrix(ts_2)
 
         ts_1_reconc = TopDownReconciliator().fit_transform(ts_1)
         ts_2_reconc = TopDownReconciliator().fit_transform(ts_2)

--- a/darts/tests/dataprocessing/transformers/test_reconciliation.py
+++ b/darts/tests/dataprocessing/transformers/test_reconciliation.py
@@ -206,9 +206,6 @@ class ReconciliationTestCase(unittest.TestCase):
         ts_2 = ts_2.with_hierarchy(hierarchy)
         assert_ts_are_equal(ts_1, ts_2)
 
-        P1 = BottomUpReconciliator().get_projection_matrix(ts_1)
-        P2 = BottomUpReconciliator().get_projection_matrix(ts_2)
-
         ts_1_reconc = TopDownReconciliator().fit_transform(ts_1)
         ts_2_reconc = TopDownReconciliator().fit_transform(ts_2)
 


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1582.

### Summary
Fixes `get_projection_matrix` in `BottomUpReconciliator` and `TopDownReconcilliator` such that the result takes the order of components of the `TimeSeries` into account.
Adds a test to assert the results of `BottomUpReconciliator`, `TopDownReconciliator` and `MinTReconciliator` do not depend on component order

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
