### PR TITLE
fix: replacing lambda with named function to make model pickable

### DIFF
--- a/darts/models/forecasting/fft.py
+++ b/darts/models/forecasting/fft.py
@@ -269,17 +269,17 @@ class FFT(LocalForecastingModel):
             + ")"
         )
 
-    def _exp_trend(self, x):
+    def _exp_trend(self, x) -> Callable:
         """Helper function, used to make FFT model pickable."""
         return np.exp(self.trend_coefficients[1]) * np.exp(
             self.trend_coefficients[0] * x
         )
 
-    def _poly_trend(self, trend_coefficients):
+    def _poly_trend(self, trend_coefficients) -> Callable:
         """Helper function, for consistency with the other trends"""
         return np.poly1d(trend_coefficients)
 
-    def _null_trend(self, x):
+    def _null_trend(self, x) -> Callable:
         """Helper function, used to make FFT model pickable."""
         return 0
 

--- a/darts/models/forecasting/fft.py
+++ b/darts/models/forecasting/fft.py
@@ -238,7 +238,7 @@ class FFT(LocalForecastingModel):
             pd.Timestamp attributes that are relevant for the seasonality automatically.
         trend
             If set, indicates what kind of detrending will be applied before performing DFT.
-            Possible values: 'poly' or 'exp', for polynomial trend, or exponential trend, respectively.
+            Possible values: 'poly', 'exp' or None, for polynomial trend, exponential trend or no trend, respectively.
         trend_poly_degree
             The degree of the polynomial that will be used for detrending, if `trend='poly'`.
 
@@ -269,6 +269,10 @@ class FFT(LocalForecastingModel):
             + ")"
         )
 
+    def _constant_null(self, x):
+        """Helper function, used to make FFT model pickable."""
+        return 0
+
     def fit(self, series: TimeSeries):
         series = fill_missing_values(series)
         super().fit(series)
@@ -289,7 +293,8 @@ class FFT(LocalForecastingModel):
                 trend_coefficients[0] * x
             )
         else:
-            self.trend_function = lambda x: 0
+            # `lambda x : 0 ` is not pickable
+            self.trend_function = self._constant_null
 
         # subtract trend
         detrended_values = series.univariate_values() - self.trend_function(

--- a/darts/models/forecasting/fft.py
+++ b/darts/models/forecasting/fft.py
@@ -3,7 +3,7 @@ Fast Fourier Transform
 ----------------------
 """
 
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Fixes #1587.

### Summary

`save()` was not working on FTT model if the `trend` argument was neither "poly" or "exp" because the function `lambda x : 0` is not pickable. Just created a class method to have a named function that can be pickled and updated the docstring.

### Other Information

I'll make sure all the other models `save()` method are working before converting this draft PR into a real one.