### PR TITLE
Fix/literal import

### DIFF
--- a/darts/dataprocessing/transformers/static_covariates_transformer.py
+++ b/darts/dataprocessing/transformers/static_covariates_transformer.py
@@ -5,11 +5,15 @@ Static Covariates Transformer
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
 from sklearn.preprocessing import MinMaxScaler, OrdinalEncoder
-from typing_extensions import Literal
 
 from darts.logging import get_logger, raise_log
 from darts.timeseries import TimeSeries

--- a/darts/dataprocessing/transformers/static_covariates_transformer.py
+++ b/darts/dataprocessing/transformers/static_covariates_transformer.py
@@ -3,12 +3,13 @@ Static Covariates Transformer
 ------
 """
 from collections import OrderedDict
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
 from sklearn.preprocessing import MinMaxScaler, OrdinalEncoder
+from typing_extensions import Literal
 
 from darts.logging import get_logger, raise_log
 from darts.timeseries import TimeSeries


### PR DESCRIPTION
### Summary

Quick-fix, the merge of #1409 breaks the python 3.7 compatibility because of the import of Literal in static_covariate_transformer.py
