### PR TITLE
fix failing example notebook from MovingAverage rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ series.plot()
   supporting among other things custom callbacks, GPUs/TPUs training and custom trainers.
 
 * **Filtering Models:** Darts offers three filtering models: `KalmanFilter`, `GaussianProcessFilter`,
-  and `MovingAverage`, which allow to filter time series, and in some cases obtain probabilistic
+  and `MovingAverageFilter`, which allow to filter time series, and in some cases obtain probabilistic
   inferences of the underlying states/values.
 
 * **Datasets** The `darts.datasets` submodule contains some popular time series datasets for rapid

--- a/examples/12-Dynamic-Time-Warping-example.ipynb
+++ b/examples/12-Dynamic-Time-Warping-example.ipynb
@@ -40,7 +40,7 @@
     "from darts.datasets import SunspotsDataset\n",
     "from darts.timeseries import TimeSeries\n",
     "from darts.metrics import dtw_metric, mae, mape\n",
-    "from darts.models import MovingAverage\n",
+    "from darts.models import MovingAverageFilter\n",
     "from scipy.signal import argrelextrema\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "ts_smooth = MovingAverage(window=3).filter(ts)\n",
+    "ts_smooth = MovingAverageFilter(window=3).filter(ts)\n",
     "\n",
     "minimums = argrelextrema(ts_smooth.univariate_values(), np.greater)\n",
     "\n",


### PR DESCRIPTION
### Summary
- fixes failing DTW example notebook from renaming MovingAverage to MovingAverageFilter
- corrects README with new MovingAverageFilter name