### PR TITLE
Fix/ptl version 200

### DIFF
--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 
 # Check whether we are running pytorch-lightning >= 1.6.0 or not:
 tokens = pl.__version__.split(".")
-pl_160_or_above = int(tokens[0]) >= 1 and int(tokens[1]) >= 6
+pl_160_or_above = int(tokens[0]) > 1 or int(tokens[0]) == 1 and int(tokens[1]) >= 6
 
 
 class PLForecastingModule(pl.LightningModule, ABC):

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -20,6 +20,7 @@ This file contains several abstract classes:
 import datetime
 import inspect
 import os
+import re
 import shutil
 import sys
 from abc import ABC, abstractmethod
@@ -84,6 +85,10 @@ INIT_MODEL_NAME = "_model.pth.tar"
 TFM_ATTRS_NO_PICKLE = {"model": None, "trainer": None}
 
 logger = get_logger(__name__)
+
+# Check whether we are running pytorch-lightning >= 2.0.0 or not:
+tokens = pl.__version__.split(".")
+pl_200_or_above = int(tokens[0]) >= 2
 
 
 def _get_checkpoint_folder(work_dir, model_name):
@@ -427,25 +432,49 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         dtype = self.train_sample[0].dtype
         if np.issubdtype(dtype, np.float32):
             logger.info("Time series values are 32-bits; casting model to float32.")
-            precision = 32
+            precision = "32" if not pl_200_or_above else "32-true"
         elif np.issubdtype(dtype, np.float64):
             logger.info("Time series values are 64-bits; casting model to float64.")
-            precision = 64
+            precision = "64" if not pl_200_or_above else "64-true"
+        else:
+            raise_log(
+                ValueError(
+                    f"Invalid time series data type `{dtype}`. Cast your data to `np.float32` "
+                    f"or `np.float64`, e.g. with `TimeSeries.astype(np.float32)`."
+                ),
+                logger,
+            )
+        precision_int = int(re.findall(r"\d+", str(precision))[0])
 
         precision_user = (
             self.trainer_params.get("precision", None)
             if trainer is None
             else trainer.precision
         )
+        if precision_user is not None:
+            # currently, we only support float 64 and 32
+            valid_precisions = (
+                ["64", "32"] if not pl_200_or_above else ["64-true", "32-true"]
+            )
+            if str(precision_user) not in valid_precisions:
+                raise_log(
+                    ValueError(
+                        f"Invalid user-defined trainer_kwarg `precision={precision_user}`. "
+                        f"Use one of ({valid_precisions})"
+                    ),
+                    logger,
+                )
+            precision_user_int = int(re.findall(r"\d+", str(precision_user))[0])
+        else:
+            precision_user_int = None
 
         raise_if(
-            precision_user is not None and int(precision_user) != precision,
-            f"User-defined trainer_kwarg `precision={precision_user}` does not match dtype: `{dtype}` of the "
+            precision_user is not None and precision_user_int != precision_int,
+            f"User-defined trainer_kwarg `precision='{precision_user}'` does not match dtype: `{dtype}` of the "
             f"underlying TimeSeries. Set `precision` to `{precision}` or cast your data to `{precision_user}"
-            f"` with `TimeSeries.astype(np.float{precision_user})`.",
+            f"` with `TimeSeries.astype(np.float{precision_user_int})`.",
             logger,
         )
-
         self.trainer_params["precision"] = precision
 
         # we need to save the initialized TorchForecastingModel as PyTorch-Lightning only saves module checkpoints

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -127,7 +127,7 @@ if TORCH_AVAILABLE:
             {
                 "input_chunk_length": 10,
                 "output_chunk_length": 5,
-                "n_epochs": 5,
+                "n_epochs": 10,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
             },
@@ -168,6 +168,7 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
 
     def test_probabilistic_forecast_accuracy(self):
         for model_cls, model_kwargs, err in models_cls_kwargs_errs:
+            print(model_cls)
             self.helper_test_probabilistic_forecast_accuracy(
                 model_cls, model_kwargs, err, self.constant_ts, self.constant_noisy_ts
             )

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -168,7 +168,6 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
 
     def test_probabilistic_forecast_accuracy(self):
         for model_cls, model_kwargs, err in models_cls_kwargs_errs:
-            print(model_cls)
             self.helper_test_probabilistic_forecast_accuracy(
                 model_cls, model_kwargs, err, self.constant_ts, self.constant_noisy_ts
             )


### PR DESCRIPTION
### Summary
fixes the issues with the new PyTorch-Lightning=2.0.0 release:
- fixes minor issue when checking for ptl>=1.6.0
- fixes precision issues from their new naming convention (see [here](https://lightning.ai/docs/pytorch/stable/generated/CHANGELOG.html#changed)
- fixes a failing probablistic NBEATSModel test

### Other Information

- had to increase the number of training epochs for the failing probabilistic NBEATSModel test. Not sure why the results are not the same anymore, probably from some changes on pytorch-lightning / pytorch side
