### PR TITLE
Fix/Failing test - make TimeSeries.with_hierarchy type hint python 3.7 compatible

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2857,7 +2857,7 @@ class TimeSeries:
             )
         )
 
-    def with_hierarchy(self, hierarchy: Dict[str, Union[str, list[str]]]):
+    def with_hierarchy(self, hierarchy: Dict[str, Union[str, List[str]]]):
         """
         Adds a hierarchy to the TimeSeries.
 


### PR DESCRIPTION
Fixes the type hint introduced in #1592 to make it compatible with python 3.7.
Should fix the failing test on master
