### PR TITLE
enfore multivariate series for VARIMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ on bringing more models and features.
 Model | Univariate | Multivariate | Probabilistic | Multiple series (global) | Past-observed covariates | Future-known covariates | Static covariates | Reference
 --- | --- | --- | --- | --- | --- | --- | --- | ---
 `ARIMA` | ✅ | | ✅ | | | ✅ | |
-`VARIMA` | ✅ | ✅ | | | | ✅ | |
+`VARIMA` | | ✅ | | | | ✅ | |
 `AutoARIMA` | ✅ | | | | | ✅ | |
 `StatsForecastAutoARIMA` (faster AutoARIMA) | ✅ | | ✅ | | | ✅ | | [Nixtla's statsforecast](https://github.com/Nixtla/statsforecast)
 `ExponentialSmoothing` | ✅ | | ✅ | | | | |

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -1616,7 +1616,17 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
     def _assert_univariate(self, series: TimeSeries):
         if not series.is_univariate:
             raise_log(
-                ValueError("This model only supports univariate TimeSeries instances")
+                ValueError(
+                    f"Model `{self.__class__.__name__}` only supports univariate TimeSeries instances"
+                )
+            )
+
+    def _assert_multivariate(self, series: TimeSeries):
+        if series.is_univariate:
+            raise_log(
+                ValueError(
+                    f"Model `{self.__class__.__name__}` only supports multivariate TimeSeries instances"
+                )
             )
 
 

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -1625,7 +1625,8 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
             raise_log(
                 ValueError(
                     f"Model `{self.__class__.__name__}` only supports univariate TimeSeries instances"
-                )
+                ),
+                logger=logger,
             )
 
     def _assert_multivariate(self, series: TimeSeries):
@@ -1633,7 +1634,8 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
             raise_log(
                 ValueError(
                     f"Model `{self.__class__.__name__}` only supports multivariate TimeSeries instances"
-                )
+                ),
+                logger=logger,
             )
 
 

--- a/darts/models/forecasting/varima.py
+++ b/darts/models/forecasting/varima.py
@@ -114,6 +114,8 @@ class VARIMA(TransferableFutureCovariatesLocalForecastingModel):
     ) -> None:
         super()._fit(series, future_covariates)
 
+        self._assert_multivariate(series)
+
         # storing to restore the statsmodels model results object
         self.training_historic_future_covariates = future_covariates
 


### PR DESCRIPTION
Fixes #1641

### Summary
- enforces multivariate input series for VARIMA
- removes univariate support from VARIMA in docs