### PR TITLE
avoid no checkpoint warning when loading from checkpoint

### DIFF
--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1459,7 +1459,9 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             f"Could not find base model save file `{INIT_MODEL_NAME}` in {model_dir}.",
             logger,
         )
-        model = TorchForecastingModel.load(base_model_path, **kwargs)
+        model: TorchForecastingModel = torch.load(
+            base_model_path, map_location=kwargs.get("map_location")
+        )
 
         # load PyTorch LightningModule from checkpoint
         # if file_name is None, find the path of the best or most recent checkpoint in savepath


### PR DESCRIPTION
### Summary
- currently, when loading a TorchForecastingModel from checkpoint, a warning is raised that weights could not be loaded (because we call `TorchForecastingModel.load()`). We can avoid this by simply calling torch.load(), as also done in `load_weights_from_checkpoint()`

