### PR TITLE
[DOC] Improve the TFM user guide

### DIFF
--- a/docs/userguide/faq.md
+++ b/docs/userguide/faq.md
@@ -2,8 +2,7 @@
 
 - *Is Darts just a wrapper around other libraries?*
 
-  No. When it makes sense, we reuse existing implementations (e.g. from statsforecasts), but we often write our 
-  own implementations (e.g., of neural networks). Furthermore, Darts models often have more features than their original counter-parts. For instance, unlike the original version, our implementation of N-BEATS supports multivariate time series, past covariates, and probabilistic forecasts.
+  No. When it makes sense, we reuse existing implementations (e.g. from statsforecasts), but we often write our own implementations (e.g., of neural networks). Furthermore, Darts models often have more features than their original counter-parts. For instance, unlike the original version, our implementation of N-BEATS supports multivariate time series, past covariates, and probabilistic forecasts.
 
 - *Darts looks like an awesome project, can I contribute?*
 
@@ -23,10 +22,8 @@
 - *I'm getting some NaNs in my forecasts, what should I do?*
 
   Usually this means one of two things:
-  - You have some NaNs in your training data (targets or covariates). This is the most frequent situation, and it will lead most models
-    to always forecast NaNs.
-  - Training the model causes some numerical divergence. If you're working with neural networks, make sure your data is properly scaled, and if the issue
-    persists, try reducing the learning rate.
+  - You have some NaNs in your training `TimeSeries` (targets or covariates). This is the most frequent situation, and it will lead most models to always forecast NaNs. Note that NaNs can be introduced when you convert data from a `pd.DataFrame` into a `TimeSeries` if some dates are missing and the `freq` argument is incorrectly set.
+  - Training the model causes some numerical divergence. If you're working with neural networks, make sure your data is properly scaled, and if the issue persists, try reducing the learning rate.
 
 - *My forecasting models give bad results, can you help?*
 

--- a/docs/userguide/torch_forecasting_models.md
+++ b/docs/userguide/torch_forecasting_models.md
@@ -404,7 +404,12 @@ Please look at the [hyperparameter optimization](https://unit8co.github.io/darts
 
 ### Example of custom callback
 
-Training and validation loss are automatically logged by Darts in a folder called `darts_log` and can be visualised using the [tensorboard library](https://www.tensorflow.org/tensorboard). It's however also possible to have them directly available in a Python object:
+Training and validation loss are automatically logged by Darts in a folder called `darts_logs` and can be visualised using the [tensorboard library](https://www.tensorflow.org/tensorboard) using the following command (after installing the package) in the command line:
+```bash
+tensorboad --log_dir darts_logs
+```
+
+It's however also possible to have them directly available in a Python object:
 ```python
 from pytorch_lightning.callbacks import Callback
 

--- a/docs/userguide/torch_forecasting_models.md
+++ b/docs/userguide/torch_forecasting_models.md
@@ -95,11 +95,11 @@ Under the hood, Darts has 5 types of `{X}CovariatesModel` classes implemented to
 
 | Class                   | past covariates | future past covariates | future covariates | historic future covariates |
 |-------------------------|:---------------:|:----------------------:|:-----------------:|:--------------------------:|
-| `PastCovariatesModel`   | ✅              | ✅                     | ❌                | ❌                         |
-| `FutureCovariatesModel` | ❌              | ❌                     | ✅                | ❌                         |
-| `DualCovariatesModel`   | ❌              | ❌                     | ✅                | ✅                         |
+| `PastCovariatesModel`   | ✅              | ✅                     |                  |                           |
+| `FutureCovariatesModel` |                |                       | ✅                |                           |
+| `DualCovariatesModel`   |                |                       | ✅                | ✅                         |
 | `MixedCovariatesModel`  | ✅              | ✅                     | ✅                | ✅                         |
-| `SplitCovariatesModel`  | ✅              | ✅                     | ✅                | ❌                         |
+| `SplitCovariatesModel`  | ✅              | ✅                     | ✅                |                           |
 
 **Table 1: Darts' "{X}CovariatesModels" covariate support**
 
@@ -107,12 +107,12 @@ Each Torch Forecasting Model inherits from one `{X}CovariatesModel` (covariate c
 
 | TFM                | `Past` | `Future` | `Dual` | `Mixed` | `Split` |
 |--------------------|:------:|:--------:|:------:|:-------:|:-------:|
-| `RNNModel`         | ❌     | ❌       | ✅     | ❌      | ❌      |
-| `BlockRNNModel`    | ✅     | ❌       | ❌     | ❌      | ❌      |
-| `NBEATSModel`      | ✅     | ❌       | ❌     | ❌      | ❌      |
-| `TCNModel`         | ✅     | ❌       | ❌     | ❌      | ❌      |
-| `TransformerModel` | ✅     | ❌       | ❌     | ❌      | ❌      |
-| `TFTModel`         | ❌     | ❌       | ❌     | ✅      | ❌      |
+| `RNNModel`         |       |         | ✅     |        |        |
+| `BlockRNNModel`    | ✅     |         |       |        |        |
+| `NBEATSModel`      | ✅     |         |       |        |        |
+| `TCNModel`         | ✅     |         |       |        |        |
+| `TransformerModel` | ✅     |         |       |        |        |
+| `TFTModel`         |       |         |       | ✅      |        |
 
 **Table 2: Darts' Torch Forecasting Model covariate support**
 
@@ -272,26 +272,6 @@ model.fit(...)
 
 # load the model state that performed best on validation set
 best_model = model.load_from_checkpoint(model_name='my_model', best=True)
-```
-
-The checkpoints can also be saved directly to remote file systems, including cloud storage providers such as S3 on AWS, GCA on Google Cloud and ADL on Azure (see [detailed documentation](https://lightning.ai/docs/pytorch/latest/common/checkpointing_advanced.html)):
-
-```python
-# indicate AWS S3 bucket address
-model = SomeTorchForecastingModel(...,
-                                  model_name='my_model',
-                                  save_checkpoints=True,
-                                  pl_trainer_kwargs={"default_root_dir":"s3://my_bucket/data/"})
-
-model.fit(...)
-
-# resume training using a checkpoint stored in a AWS S3 bucket
-model = SomeTorchForecastingModel(...,
-                                  model_name='my_model',
-                                  save_checkpoints=True,
-                                  pl_trainer_kwargs={"ckpt_path":"s3://my_bucket/data/"})
-
-model.fit(...)
 ```
 
 #### Manual saving / loading


### PR DESCRIPTION
Fixes #1576  and fixes #1245.

### Summary

- Update the Torch Forecasting Models [user guide](https://unit8co.github.io/darts/userguide/torch_forecasting_models.html) to better cover the save/load functionalities, notably for training on GPU and inference on CPU.
- Also include some examples of Callbacks : Early stopping and LossLogger, as well as a link to the callbacks implement by PyTorchLightning.
- Add a hint in the FAQ, to help troubleshooting NaNs in the predictions.

### Other Information
The next release is going to break the compatibility with checkpoints obtained with older version of Darts, we should probably start documenting ways to convert them so that user can systematically migrate to the latest versions
