### PR TITLE
[DOC] Improve the explanation on the window parameter (offset) of WindowTransformer

### DIFF
--- a/darts/dataprocessing/transformers/window_transformer.py
+++ b/darts/dataprocessing/transformers/window_transformer.py
@@ -62,7 +62,8 @@ class WindowTransformer(BaseDataTransformer):
 
             * :``"window"``: Size of the moving window for the "rolling" mode.
                             If an integer, the fixed number of observations used for each window.
-                            If an offset, the time period of each window.
+                            If an offset, the time period of each window with data type :class:`pandas.Timedelta`
+                            representing a fixed duration.
             * :``"min_periods"``: The minimum number of observations in the window required to have a value (otherwise
                 NaN). Darts reuses pandas defaults of 1 for "rolling" and "expanding" modes and of 0 for "ewm" mode.
             * :``"win_type"``: The type of weigthing to apply to the window elements.

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from darts import TimeSeries
 from darts.dataprocessing.pipeline import Pipeline
@@ -442,6 +443,8 @@ class WindowTransformerTestCase(unittest.TestCase):
 
     times = pd.date_range("20130101", "20130110")
     target = TimeSeries.from_times_and_values(times, range(1, 11))
+    times_hourly = pd.date_range(start="20130101", freq="1H", periods=10)
+    target_hourly = TimeSeries.from_times_and_values(times_hourly, range(1, 11))
 
     series_multi_prob = (
         (target + 10)
@@ -481,6 +484,46 @@ class WindowTransformerTestCase(unittest.TestCase):
         self.assertEqual(
             transformed_ts_list[1].n_timesteps, self.series_multi_det.n_timesteps
         )
+
+    def test_window_transformer_offset_parameter(self):
+        """
+        Test that the window parameter can support offset of pandas.Timedelta
+        """
+        base_parameters = {
+            "function": "mean",
+            "components": ["0"],
+            "mode": "rolling",
+        }
+
+        offset_parameters = base_parameters.copy()
+        offset_parameters.update({"window": pd.Timedelta(hours=4)})
+        offset_transformer = WindowTransformer(
+            transforms=offset_parameters,
+        )
+        offset_transformed = offset_transformer.transform(self.target_hourly)
+
+        integer_parameters = base_parameters.copy()
+        integer_parameters.update({"window": 4})
+        integer_transformer = WindowTransformer(
+            transforms=integer_parameters,
+        )
+        integer_transformed = integer_transformer.transform(self.target_hourly)
+        np.testing.assert_equal(
+            integer_transformed.values(), offset_transformed.values()
+        )
+        self.assertEqual(
+            offset_transformed.components[0], "rolling_mean_0 days 04:00:00_0"
+        )
+        self.assertEqual(integer_transformed.components[0], "rolling_mean_4_0")
+
+        invalid_parameters = base_parameters.copy()
+        invalid_parameters.update({"window": pd.DateOffset(hours=4)})
+        invalid_transformer = WindowTransformer(
+            transforms=invalid_parameters,
+        )
+        # if pd.DateOffset, raise ValueError of non-fixed frequency
+        with pytest.raises(ValueError):
+            invalid_transformer.transform(self.target_hourly)
 
     def test_transformers_pipeline(self):
         """

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -521,7 +521,7 @@ class WindowTransformerTestCase(unittest.TestCase):
             transforms=invalid_parameters,
         )
         # if pd.DateOffset, raise ValueError of non-fixed frequency
-        self.assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             invalid_transformer.transform(self.target_hourly)
 
     def test_transformers_pipeline(self):

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -4,7 +4,6 @@ import unittest
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from darts import TimeSeries
 from darts.dataprocessing.pipeline import Pipeline
@@ -522,7 +521,7 @@ class WindowTransformerTestCase(unittest.TestCase):
             transforms=invalid_parameters,
         )
         # if pd.DateOffset, raise ValueError of non-fixed frequency
-        with pytest.raises(ValueError):
+        self.assertRaises(ValueError):
             invalid_transformer.transform(self.target_hourly)
 
     def test_transformers_pipeline(self):

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3261,7 +3261,8 @@ class TimeSeries:
 
             * :``"window"``: Size of the moving window for the "rolling" mode.
                             If an integer, the fixed number of observations used for each window.
-                            If an offset, the time period of each window.
+                            If an offset, the time period of each window with data type :class:`pandas.Timedelta`
+                            representing a fixed duration.
             * :``"min_periods"``: The minimum number of observations in the window required to have a value (otherwise
                 NaN). Darts reuses pandas defaults of 1 for "rolling" and "expanding" modes and of 0 for "ewm" mode.
             * :``"win_type"``: The type of weigthing to apply to the window elements.


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
#1662.

### Summary
 * This improves the documentation such that we explain that the acceptable `window` parameter for an offset is `pandas.Timedelta` data type instead of `pandas.DateOffset`.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information
 * Also add additional test cases for the class `WindowTransformer` to demonstrate the mentioned behaviors.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
