### PR TITLE
[Feature] Support a user defined function name in the window transformation output

### DIFF
--- a/darts/dataprocessing/transformers/window_transformer.py
+++ b/darts/dataprocessing/transformers/window_transformer.py
@@ -53,6 +53,14 @@ class WindowTransformer(BaseDataTransformer):
                                transformation should be applied. If not specified, the transformation will be
                                applied on all components.
 
+            :``"function_name"``: Optional. A string specifying the function name referenced as part of
+                                  the transformation output name. For example, given a user-provided function
+                                  transformation on rolling window size of 5 on the component "comp", the
+                                  default transformation output name is "rolling_udf_5_comp" whereby "udf"
+                                  refers to "user defined function". If specified, the ``"function_name"`` will
+                                  replace the default name "udf". Similarly, the ``"function_name"`` will replace
+                                  the name of the pandas builtin transformation function name in the output name.
+
             All other dictionary items provided will be treated as keyword arguments for the windowing mode
             (i.e., ``rolling/ewm/expanding``) or for the specific function
             in that mode (i.e., ``pandas.DataFrame.rolling.mean/std/max/min...`` or

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -148,6 +148,23 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
             ],
         )
 
+        # test customized function name that overwrites the pandas builtin transformation
+        transforms = {
+            "function": "sum",
+            "mode": "rolling",
+            "window": 1,
+            "function_name": "customized_name",
+        }
+        transformed_ts = self.series_univ_det.window_transform(transforms=transforms)
+        self.assertEqual(
+            transformed_ts.components.to_list(),
+            [
+                f"{transforms['mode']}_{transforms['function_name']}_{str(transforms['window'])}_{comp}"
+                for comp in self.series_univ_det.components
+            ],
+        )
+        del transforms["function_name"]
+
         # multivariate deterministic input
         # transform one component
         transforms.update({"components": "0"})
@@ -241,6 +258,39 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         # multivariate probabilistic input
         transformed_ts = self.series_multi_prob.window_transform(transforms=transforms)
         self.assertEqual(transformed_ts.n_samples, 2)
+
+    def test_user_defined_function_behavior(self):
+        def count_above_mean(array):
+            mean = np.mean(array)
+            return np.where(array > mean)[0].size
+
+        transformation = {
+            "function": count_above_mean,
+            "mode": "rolling",
+            "window": 5,
+        }
+        transformed_ts = self.target.window_transform(
+            transformation,
+        )
+        expected_transformed_series = TimeSeries.from_times_and_values(
+            self.times,
+            [0, 1, 1, 2, 2, 2, 2, 2, 2, 2],
+            columns=["rolling_udf_5_0"],
+        )
+        self.assertEqual(transformed_ts, expected_transformed_series)
+
+        # test if a customized function name is provided
+        transformation.update({"function_name": "count_above_mean"})
+        transformed_ts = self.target.window_transform(
+            transformation,
+        )
+        self.assertEqual(
+            transformed_ts.components.to_list(),
+            [
+                f"{transformation['mode']}_{transformation['function_name']}_{str(transformation['window'])}_{comp}"
+                for comp in self.target.components
+            ],
+        )
 
     def test_ts_windowtransf_output_nabehavior(self):
         window_transformations = {
@@ -494,12 +544,18 @@ class WindowTransformerTestCase(unittest.TestCase):
         expected_transformed_series = TimeSeries.from_times_and_values(
             times1,
             [100, 15, 30, 45, 60, 75, 90, 105, 120, 135],
-            columns=["rolling_sum_3_2_0"],
+            columns=["rolling_TotalOperation_3_2_0"],
         )
 
         # adds NaNs
         window_transformations = [
-            {"function": "sum", "mode": "rolling", "window": 3, "min_periods": 2}
+            {
+                "function": "sum",
+                "function_name": "TotalOperation",
+                "mode": "rolling",
+                "window": 3,
+                "min_periods": 2,
+            }
         ]
 
         def times_five(x):

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -544,18 +544,12 @@ class WindowTransformerTestCase(unittest.TestCase):
         expected_transformed_series = TimeSeries.from_times_and_values(
             times1,
             [100, 15, 30, 45, 60, 75, 90, 105, 120, 135],
-            columns=["rolling_TotalOperation_3_2_0"],
+            columns=["rolling_sum_3_2_0"],
         )
 
         # adds NaNs
         window_transformations = [
-            {
-                "function": "sum",
-                "function_name": "TotalOperation",
-                "mode": "rolling",
-                "window": 3,
-                "min_periods": 2,
-            }
+            {"function": "sum", "mode": "rolling", "window": 3, "min_periods": 2}
         ]
 
         def times_five(x):

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3408,6 +3408,7 @@ class TimeSeries:
                 "function",
                 "group",
                 "components",
+                "function_name",
             }
 
             window_mode_expected_args = set(window_mode.__code__.co_varnames)
@@ -3535,8 +3536,13 @@ class TimeSeries:
             )
             min_periods = transformation["min_periods"]
             # set new columns names
+            fn_name = transformation.get("function_name")
+            if fn_name:
+                function_name = fn_name
+            else:
+                function_name = fn if fn != "apply" else "udf"
             name_prefix = (
-                f"{window_mode}_{fn if fn != 'apply' else 'udf'}"
+                f"{window_mode}_{function_name}"
                 f"{'_'+str(transformation['window']) if 'window' in transformation else ''}"
                 f"{'_'+str(min_periods) if min_periods>1 else ''}"
             )

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3255,6 +3255,14 @@ class TimeSeries:
                                transformation should be applied. If not specified, the transformation will be
                                applied on all components.
 
+            :``"function_name"``: Optional. A string specifying the function name referenced as part of
+                                  the transformation output name. For example, given a user-provided function
+                                  transformation on rolling window size of 5 on the component "comp", the
+                                  default transformation output name is "rolling_udf_5_comp" whereby "udf"
+                                  refers to "user defined function". If specified, the ``"function_name"`` will
+                                  replace the default name "udf". Similarly, the ``"function_name"`` will replace
+                                  the name of the pandas builtin transformation function name in the output name.
+
             All other dictionary items provided will be treated as keyword arguments for the windowing mode
             (i.e., ``rolling/ewm/expanding``) or for the specific function
             in that mode (i.e., ``pandas.DataFrame.rolling.mean/std/max/min...`` or


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
### Summary
 As mentioned in the darts' [gitter chat](https://matrix.to/#/!uumevxjBaNJhovFYgj:gitter.im/$5_mjnsoUNwm3NSisIe_Oggp3Q2191nyQmbmKhQp4rqA?via=gitter.im&via=matrix.org&via=matrix.thegolem.cz), this PR supports a user-defined function name as part of the window transformation output name. 
 
 Without this feature, if we provide multiple user-defined functions for the window operations, we have multiple output names such as `rolling_udf_5_target`, `rolling_udf_5_target_1` and etc. This poses the challenge in tracking the derived feature names.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information
 * Also include an additional test case for window transformation that considers a user-defined function  such as `count_above_mean`. 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
