### PR TITLE
fixes lgb warning when not using any categorical features

### DIFF
--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -27,7 +27,7 @@ When static covariates are present, they are appended to the lagged features. Wh
 if their static covariates do not have the same size, the shorter ones are padded with 0 valued features.
 """
 from collections import OrderedDict
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from sklearn.linear_model import LinearRegression
@@ -1157,12 +1157,12 @@ class RegressionModelWithCategoricalCovariates(RegressionModel):
         )
 
     @property
-    def _categorical_fit_param_name(self) -> str:
+    def _categorical_fit_param(self) -> Tuple[str, Any]:
         """
-        Returns the name of the parameter of the model's `fit` method that specifies the categorical features.
+        Returns the name, and default value of the categorical features parameter from model's `fit` method .
         Can be overridden in subclasses.
         """
-        return "categorical_feature"
+        return "categorical_feature", "auto"
 
     def _validate_categorical_covariates(
         self,
@@ -1321,7 +1321,10 @@ class RegressionModelWithCategoricalCovariates(RegressionModel):
             future_covariates,
         )
 
-        kwargs[self._categorical_fit_param_name] = cat_col_indices
+        cat_param_name, cat_param_default = self._categorical_fit_param
+        kwargs[cat_param_name] = (
+            cat_col_indices if cat_col_indices else cat_param_default
+        )
         super()._fit_model(
             target_series=target_series,
             past_covariates=past_covariates,

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -2338,8 +2338,12 @@ class RegressionModelsTestCase(DartsBaseTestClass):
 
         # Check that mocked super.fit() method was called with correct categorical_feature argument
         args, kwargs = lgb_fit_patch.call_args
+        (
+            cat_praam_name,
+            cat_param_default,
+        ) = self.lgbm_w_categorical_covariates._categorical_fit_param
         self.assertEqual(
-            kwargs[self.lgbm_w_categorical_covariates._categorical_fit_param_name],
+            kwargs[cat_praam_name],
             [2, 3, 5],
         )
 

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -2339,11 +2339,11 @@ class RegressionModelsTestCase(DartsBaseTestClass):
         # Check that mocked super.fit() method was called with correct categorical_feature argument
         args, kwargs = lgb_fit_patch.call_args
         (
-            cat_praam_name,
+            cat_param_name,
             cat_param_default,
         ) = self.lgbm_w_categorical_covariates._categorical_fit_param
         self.assertEqual(
-            kwargs[cat_praam_name],
+            kwargs[cat_param_name],
             [2, 3, 5],
         )
 

--- a/darts/utils/multioutput.py
+++ b/darts/utils/multioutput.py
@@ -1,9 +1,8 @@
-from joblib import Parallel
 from sklearn.base import is_classifier
 from sklearn.multioutput import MultiOutputRegressor as sk_MultiOutputRegressor
 from sklearn.multioutput import _fit_estimator
-from sklearn.utils.fixes import delayed
 from sklearn.utils.multiclass import check_classification_targets
+from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import _check_fit_params, has_fit_parameter
 
 


### PR DESCRIPTION
### Summary

- removes warning when no categorical features are used with new categorical support for LightGBM models (introduced by #1585)
- fixes deprecation warning for joblib Parallel with sklearn.utils.fixes.delayed