### PR TITLE
Feat/probabilistic ensemble

### DIFF
--- a/darts/models/forecasting/baselines.py
+++ b/darts/models/forecasting/baselines.py
@@ -204,6 +204,7 @@ class NaiveEnsembleModel(EnsembleModel):
         self,
         predictions: Union[TimeSeries, Sequence[TimeSeries]],
         series: Optional[Sequence[TimeSeries]] = None,
+        num_samples: int = 1,
     ) -> Union[TimeSeries, Sequence[TimeSeries]]:
         def take_average(prediction: TimeSeries) -> TimeSeries:
             series = prediction.pd_dataframe(copy=False).sum(axis=1) / len(self.models)

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -167,13 +167,14 @@ class EnsembleModel(GlobalForecastingModel):
             future_covariates=future_covariates,
             num_samples=num_samples,
         )
-        return self.ensemble(predictions, series=series)
+        return self.ensemble(predictions, series=series, num_samples=num_samples)
 
     @abstractmethod
     def ensemble(
         self,
         predictions: Union[TimeSeries, Sequence[TimeSeries]],
         series: Optional[Sequence[TimeSeries]] = None,
+        num_samples: int = 1,
     ) -> Union[TimeSeries, Sequence[TimeSeries]]:
         """
         Defines how to ensemble the individual models' predictions to produce a single prediction.

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -157,6 +157,7 @@ class RegressionEnsembleModel(EnsembleModel):
         self,
         predictions: Union[TimeSeries, Sequence[TimeSeries]],
         series: Optional[Sequence[TimeSeries]] = None,
+        num_samples: int = 1,
     ) -> Union[TimeSeries, Sequence[TimeSeries]]:
 
         is_single_series = isinstance(series, TimeSeries) or series is None
@@ -165,7 +166,12 @@ class RegressionEnsembleModel(EnsembleModel):
 
         ensembled = [
             self.regression_model.predict(
-                n=len(prediction), series=serie, future_covariates=prediction
+                n=len(prediction),
+                series=serie,
+                future_covariates=prediction,
+                num_samples=num_samples
+                if self.regression_model._is_probabilistic()
+                else 1,
             )
             for serie, prediction in zip(series, predictions)
         ]


### PR DESCRIPTION
Fixes #1682.

### Summary
The `num_sample` argument is properly passed to `regression_model.predict()` in `RegressionEnsembleModel.ensemble()`.

In order to obtain probabilistic predictions, all the models of the `RegressionEnsembleModel` need to be probabilistic, including its `regression_model`.

It's however still possible to obtain deterministic predictions if the `regression_model` is not probabilistic but the others are or by using `num_sample=1`.

### Other Information
The definition of a probabilistic `EnsembleModel` should be better defined; at the moment, it requires that all its model are probabilistic however for a `RegressionEnsembleModel`, we might also want the regression model itself to be probabilistic? Or on the opposite, ss a probabilistic `regression_model` enough to make a `RegressionEnsembleModel` probabilistic even if all the other models are deterministic?
