### PR TITLE
Fix/start value for historical_forecasts in examples

### DIFF
--- a/examples/01-multi-time-series-and-covariates.ipynb
+++ b/examples/01-multi-time-series-and-covariates.ipynb
@@ -758,13 +758,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "\n",
     "\n",
     "### Backtesting with Covariates\n",
-    "We can also backtest the models using covariates. Say for instance we are interested in evaluating the running accuracy with a horizon of 12 months, starting at 75% of the air series:"
+    "We can also backtest the models using covariates. Say for instance we are interested in evaluating the running accuracy with a horizon of 12 months, starting at 60% of the air series:"
    ]
   },
   {

--- a/examples/01-multi-time-series-and-covariates.ipynb
+++ b/examples/01-multi-time-series-and-covariates.ipynb
@@ -849,6 +849,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -859,7 +860,7 @@
     "\n",
     "By contrast, `RNNModel` uses future covariates (it will complain if you try specifying `past_covariates`). This means that prediction with this model requires the covariates (at least) `n` time steps into the future after prediction time.\n",
     "\n",
-    "Past and future covariates (as well as the way they are consummed by the different models) an important but non-trivial topic, and we plan to dedicate a future notebook (or article) to explain this further.\n",
+    "Past and future covariates (as well as the way they are consumed by the different models) are an important but non-trivial topic, and we plan to dedicate a future notebook (or article) to explain this further.\n",
     "\n",
     "## Training and Forecasting Multivariate TimeSeries\n",
     "\n",

--- a/examples/01-multi-time-series-and-covariates.ipynb
+++ b/examples/01-multi-time-series-and-covariates.ipynb
@@ -758,7 +758,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -849,7 +848,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
- Update start value from 0.6 to 0.75 to match the text above the cell.
- Fixing typos

The text above the cell reads: 

> We can also backtest the models using covariates. Say for instance we are interested in evaluating the running accuracy with a horizon of 12 months, starting at 75% of the air series

This commit resolves the issue where the start value was incorrectly set to 0.6 instead of the intended 0.75. 


