### PR TITLE
fixes sklearn Parallel issue for sklearn versions < 1.3

### DIFF
--- a/darts/utils/multioutput.py
+++ b/darts/utils/multioutput.py
@@ -2,8 +2,14 @@ from sklearn.base import is_classifier
 from sklearn.multioutput import MultiOutputRegressor as sk_MultiOutputRegressor
 from sklearn.multioutput import _fit_estimator
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import _check_fit_params, has_fit_parameter
+
+try:
+    # delayed was moved from sklearn.utils.fixes to sklearn.utils.parallel in v1.3
+    from sklearn.utils.parallel import Parallel, delayed
+except ImportError:
+    from joblib import Parallel
+    from sklearn.utils.fixes import delayed
 
 
 class MultiOutputRegressor(sk_MultiOutputRegressor):


### PR DESCRIPTION
- fixes failing unittests introduced by #1681. Parallel, delayed were moved from sklearn.utils.fixes to sklearn.utils.parallel in sklearn version 1.3