### PR TITLE
Fix pandas deprecation warning

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4910,7 +4910,9 @@ class TimeSeries:
 
             # restore a RangeIndex if needed:
             time_idx = xa_.get_index(self._time_dim)
-            if time_idx.is_integer() and not isinstance(time_idx, pd.RangeIndex):
+            if pd.api.types.is_integer_dtype(time_idx) and not isinstance(
+                time_idx, pd.RangeIndex
+            ):
                 xa_ = xa_.assign_coords(
                     {
                         self._time_dim: pd.RangeIndex(


### PR DESCRIPTION
`pd.Index.is_integer` is deprecated from pandas 2.0. 
This PR replaces `pd.Index.is_integer` with `pd.api.types.is_integer_dtype` in timeseries.py, as advised in the pandas [documentation](https://pandas.pydata.org/docs/reference/api/pandas.Index.is_integer.html)
