### PR TITLE
add typing-extensions as dependency

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -17,5 +17,6 @@ statsforecast>=1.4
 statsmodels>=0.13.0
 tbats>=1.1.0
 tqdm>=4.60.0
+typing-extensions
 xarray>=0.17.0
 xgboost>=1.6.0


### PR DESCRIPTION
This PR is an attempt to fix the python=3.10 issues with typing-extensions