### PR TITLE
fix failing unit tests with catboost==1.2.0

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
-catboost>=1.0.6
+catboost>=1.0.6,<1.2.0
 holidays>=0.11.1,<0.25.0
 joblib>=0.16.0
 lightgbm>=3.2.0


### PR DESCRIPTION
Fixes failing unit tests with new catboost v1.2.0