### PR TITLE
Use component names for plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Improved**
 - Added support for `PathLike` to the `save()` and `load()` functions of `ForecastingModel`. [#1754](https://github.com/unit8co/darts/pull/1754) by [Simon Sudrich](https://github.com/sudrich).
 
+**Fixed**
+- Fixed an issue not considering original component names for `TimeSeries.plot()` when providing a label prefix. [#1783](https://github.com/unit8co/darts/pull/1783) by [Simon Sudrich](https://github.com/sudrich).
+
 ## [0.24.0](https://github.com/unit8co/darts/tree/0.24.0) (2023-04-12)
 ### For users of the library:
 

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -195,7 +195,6 @@ class TimeSeries:
             # We have to check manually if the index is complete for non-empty series. Another way could
             # be to rely on `inferred_freq` being present, but this fails for series of length < 3.
             if len(self._time_index) > 0:
-
                 is_index_complete = (
                     len(
                         pd.date_range(
@@ -2147,7 +2146,6 @@ class TimeSeries:
     def _split_at(
         self, split_point: Union[pd.Timestamp, float, int], after: bool = True
     ) -> Tuple["TimeSeries", "TimeSeries"]:
-
         # Get index with not after in order to avoid moving twice if split_point is not in self
         point_index = self.get_index_at_point(split_point, not after)
         return (
@@ -3046,7 +3044,6 @@ class TimeSeries:
         )
 
     def resample(self, freq: str, method: str = "pad", **kwargs) -> Self:
-
         """
         Build a reindexed ``TimeSeries`` with a given frequency.
         Provided method is used to fill holes in reindexed TimeSeries, by default 'pad'.
@@ -3499,7 +3496,6 @@ class TimeSeries:
 
         # run through all transformations in transforms
         for transformation in transforms:
-
             if "components" in transformation:
                 if isinstance(transformation["components"], str):
                     transformation["components"] = [transformation["components"]]
@@ -3723,8 +3719,10 @@ class TimeSeries:
         default_formatting
             Whether or not to use the darts default scheme.
         label
-            A prefix that will appear in front of each component of the TimeSeries or a list of string of
-            length the number of components in the plotted TimeSeries (default "").
+            Can either be a string or list of strings. If it's a single string and the series has only has a single
+            component, it is used as the label of the series in the plot. If it's a single string and the series has
+            more components, it is used as a prefix that will appear in front of each component. If it's a list of
+            strings, it is used as the label of each component. (default: "")
         args
             some positional arguments for the `plot()` method
         kwargs
@@ -3800,6 +3798,8 @@ class TimeSeries:
             else:
                 if label == "":
                     label_to_use = comp_name
+                elif len(self.components) == 1:
+                    label_to_use = label
                 else:
                     label_to_use = f"{label}_{comp_name}"
             kwargs["label"] = label_to_use
@@ -4694,7 +4694,6 @@ class TimeSeries:
             )
 
     def __gt__(self, other) -> xr.DataArray:
-
         if isinstance(other, (int, float, np.integer, np.ndarray, xr.DataArray)):
             return _xarray_with_attrs(
                 self._xa > other, self.static_covariates, self.hierarchy

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3798,11 +3798,10 @@ class TimeSeries:
             if custom_labels:
                 label_to_use = label[i]
             else:
-                label_to_use = (
-                    (label + ("_" + str(i) if len(self.components) > 1 else ""))
-                    if label != ""
-                    else "" + str(comp_name)
-                )
+                if label == "":
+                    label_to_use = comp_name
+                else:
+                    label_to_use = f"{label}_{comp_name}"
             kwargs["label"] = label_to_use
 
             if central_series.shape[0] > 1:

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3719,10 +3719,10 @@ class TimeSeries:
         default_formatting
             Whether or not to use the darts default scheme.
         label
-            Can either be a string or list of strings. If it's a single string and the series has only has a single
-            component, it is used as the label of the series in the plot. If it's a single string and the series has
-            more components, it is used as a prefix that will appear in front of each component. If it's a list of
-            strings, it is used as the label of each component. (default: "")
+            Can either be a string or list of strings. If a string and the series only has a single component, it is
+            used as the label for that component. If a string and the series has multiple components, it is used as
+            a prefix for each component name. If a list of strings with length equal to the number of components in
+            the series, the labels will be mapped to the components in order.
         args
             some positional arguments for the `plot()` method
         kwargs


### PR DESCRIPTION
### Summary

This PR changes `TimeSeries.plot()` to be in line with its documentation.

**Example:**

Imagine invoking `plot(label="prediction")` on a `TimeSeries` with the labels `[A, B, C]`.

Before the change, the labels are using an enumeration of the components: `[prediction_0, prediction_1, prediction_2]`.
With the change, the labels are using the component names: `[prediction_A, prediction_B, prediction_C]`.

### Other Information

The change also allows adding a prefix for a series with a single component. This was not possible for some reason.

**Example:**

Imagine invoking `plot(label="prediction")` on a `TimeSeries` with the labels `[A]`.

Before the change, the label would just be ignored: `[A]`.
With the change, the label is taken into account: `[prediction_A]`.

This behaviour is still possible to recreate by calling `plot()` or `plot(label="")`.
