### PR TITLE
Fixed pytorch_lightning warning

### DIFF
--- a/docs/userguide/hyperparameter_optimization.md
+++ b/docs/userguide/hyperparameter_optimization.md
@@ -195,7 +195,7 @@ my_stopper = EarlyStopping(
 # set up ray tune callback
 tune_callback = TuneReportCallback(
     {
-        "loss": "val_Loss",
+        "loss": "val_loss",
         "MAPE": "val_MeanAbsolutePercentageError",
     },
     on="validation_end",


### PR DESCRIPTION
Renamed "val_Loss" to "val_loss" to prevent to following error:  WARNING pytorch_lightning.py:142 -- Metric val_Loss does not exist in `trainer.callback_metrics.

<!-- Please mention an issue this pull request addresses. -->
Fixes no issue found for this.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

This fixes the Pytorch Lightning warning users get when running the code for Ray Tune. It might confuse new users of Darts when running the example, wondering if they did something wrong.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
