### PR TITLE
Fixed multiple Optuna errors in example

### DIFF
--- a/docs/userguide/hyperparameter_optimization.md
+++ b/docs/userguide/hyperparameter_optimization.md
@@ -63,9 +63,7 @@ def objective(trial):
     # detect if a GPU is available
     if torch.cuda.is_available():
         pl_trainer_kwargs = {
-            "accelerator": "gpu",
-            "gpus": -1,
-            "auto_select_gpus": True,
+            "accelerator": "auto",
             "callbacks": callbacks,
         }
         num_workers = 4

--- a/docs/userguide/hyperparameter_optimization.md
+++ b/docs/userguide/hyperparameter_optimization.md
@@ -62,14 +62,14 @@ def objective(trial):
 
     # detect if a GPU is available
     if torch.cuda.is_available():
-        pl_trainer_kwargs = {
-            "accelerator": "auto",
-            "callbacks": callbacks,
-        }
         num_workers = 4
     else:
-        pl_trainer_kwargs = {"callbacks": callbacks}
         num_workers = 0
+        
+    pl_trainer_kwargs = {
+        "accelerator": "auto",
+        "callbacks": callbacks,
+    }
 
     # optionally also add the (scaled) year value as a past covariate
     if include_year:

--- a/docs/userguide/hyperparameter_optimization.md
+++ b/docs/userguide/hyperparameter_optimization.md
@@ -133,9 +133,10 @@ def print_callback(study, trial):
     print(f"Best value: {study.best_value}, Best params: {study.best_trial.params}")
 
 
-# optimize hyperparameters by minimizing the sMAPE on the validation set 
-study = optuna.create_study(direction="minimize")
-study.optimize(objective, n_trials=100, callbacks=[print_callback])
+# optimize hyperparameters by minimizing the sMAPE on the validation set
+if __name__ == "__main__":
+    study = optuna.create_study(direction="minimize")
+    study.optimize(objective, n_trials=100, callbacks=[print_callback])
 ```
 
 ## Hyperparameter optimization with Ray Tune


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
No issue found yet.

### Summary

Fixes two TypeErrors and one RunTimeError in the Optuna example. This will save new users time troubleshooting the errors. The errors were caused by outdated arguments in `pl_trainer_kwargs` and because Windows needs `if __name__ ==  '__main__':` to run the code properly. 

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->