### PR TITLE
Fix broken link in 00-quickstart.ipynb

### DIFF
--- a/examples/00-quickstart.ipynb
+++ b/examples/00-quickstart.ipynb
@@ -1820,7 +1820,7 @@
     "By default, the `RegressionModel` will do a linear regression. It is very easy to use any desired sklearn-compatible regression model by specifying the `model` parameter, but for convenience Darts also provides a couple of ready-made models out of the box:\n",
     "\n",
     "* [RandomForest](https://unit8co.github.io/darts/generated_api/darts.models.forecasting.random_forest.html) wraps around `sklearn.ensemble.RandomForestRegressor`.\n",
-    "* [LightGBMModel](https://unit8co.github.io/darts/generated_api/darts.models.forecasting.gradient_boosted_model.html) wraps around `lightbm`.\n",
+    "* [LightGBMModel](https://unit8co.github.io/darts/generated_api/darts.models.forecasting.lgbm.html) wraps around `lightbm`.\n",
     "* [LinearRegressionModel](https://unit8co.github.io/darts/generated_api/darts.models.forecasting.linear_regression_model.html) wraps around `sklearn.linear_model.LinearRegression` (accepting the same kwargs).\n",
     "\n",
     "For example, this is what fitting a Bayesian ridge regression to our toy two-series problem looks like:"


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1792

### Summary
<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

This pull request fixes the broken documentation link for the LightGBMModel class. It replaces the old link with the correct one.

### Other Information

This is a minor change that does not affect the functionality of the library.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
