### PR TITLE
Refactor/lagged data static covs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Improvements to `EnsembleModel`:
   - Model creation parameter `forecasting_models` now supports a mix of `LocalForecastingModel` and `GlobalForecastingModel` (single `TimeSeries` training/inference only, due to the local models). [#1745](https://github.com/unit8co/darts/pull/1745) by [Antoine Madrona](https://github.com/madtoinou).
   - Future and past covariates can now be used even if `forecasting_models` have different covariates support. The covariates passed to `fit()`/`predict()` are used only by models that support it. [#1745](https://github.com/unit8co/darts/pull/1745) by [Antoine Madrona](https://github.com/madtoinou).
+- Improvements to `ShapExplainer`:
+  - Added static covariates support to `ShapeExplainer`. [#1803](https://github.com/unit8co/darts/pull/#1803) by [Anne de Vries](https://github.com/anne-devries) and [Dennis Bader](https://github.com/dennisbader).
 
 **Fixed**
 - Fixed an issue not considering original component names for `TimeSeries.plot()` when providing a label prefix. [#1783](https://github.com/unit8co/darts/pull/1783) by [Simon Sudrich](https://github.com/sudrich).
 - Fixed an issue with `TorchForecastingModel.load_from_checkpoint()` not properly loading the loss function and metrics. [#1749](https://github.com/unit8co/darts/pull/1749) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug when loading the weights of a `TorchForecastingModel` trained with encoders or a Likelihood. [#1744](https://github.com/unit8co/darts/pull/1744) by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed a bug when using selected `target_components` with `ShapExplainer. [#1803](https://github.com/unit8co/darts/pull/#1803) by [Dennis Bader](https://github.com/dennisbader).
 
 ## [0.24.0](https://github.com/unit8co/darts/tree/0.24.0) (2023-04-12)
 ### For users of the library:

--- a/darts/explainability/explainability_result.py
+++ b/darts/explainability/explainability_result.py
@@ -9,7 +9,6 @@ from abc import ABC
 from typing import Any, Dict, Optional, Sequence, Union
 
 import shap
-from numpy import integer
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_if, raise_if_not
@@ -26,8 +25,8 @@ class ExplainabilityResult(ABC):
     def __init__(
         self,
         explained_forecasts: Union[
-            Dict[integer, Dict[str, TimeSeries]],
-            Sequence[Dict[integer, Dict[str, TimeSeries]]],
+            Dict[int, Dict[str, TimeSeries]],
+            Sequence[Dict[int, Dict[str, TimeSeries]]],
         ],
     ):
         self.explained_forecasts = explained_forecasts
@@ -61,9 +60,7 @@ class ExplainabilityResult(ABC):
 
     def _query_explainability_result(
         self,
-        attr: Union[
-            Dict[integer, Dict[str, Any]], Sequence[Dict[integer, Dict[str, Any]]]
-        ],
+        attr: Union[Dict[int, Dict[str, Any]], Sequence[Dict[int, Dict[str, Any]]]],
         horizon: int,
         component: Optional[str] = None,
     ) -> Any:
@@ -141,16 +138,16 @@ class ShapExplainabilityResult(ExplainabilityResult):
     def __init__(
         self,
         explained_forecasts: Union[
-            Dict[integer, Dict[str, TimeSeries]],
-            Sequence[Dict[integer, Dict[str, TimeSeries]]],
+            Dict[int, Dict[str, TimeSeries]],
+            Sequence[Dict[int, Dict[str, TimeSeries]]],
         ],
         feature_values: Union[
-            Dict[integer, Dict[str, TimeSeries]],
-            Sequence[Dict[integer, Dict[str, TimeSeries]]],
+            Dict[int, Dict[str, TimeSeries]],
+            Sequence[Dict[int, Dict[str, TimeSeries]]],
         ],
         shap_explanation_object: Union[
-            Dict[integer, Dict[str, shap.Explanation]],
-            Sequence[Dict[integer, Dict[str, shap.Explanation]]],
+            Dict[int, Dict[str, shap.Explanation]],
+            Sequence[Dict[int, Dict[str, shap.Explanation]]],
         ],
     ):
         super().__init__(explained_forecasts)

--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -25,7 +25,6 @@ from typing import Dict, NewType, Optional, Sequence, Tuple, Union
 import matplotlib.pyplot as plt
 import pandas as pd
 import shap
-from numpy import integer
 from sklearn.multioutput import MultiOutputRegressor
 
 from darts import TimeSeries
@@ -563,7 +562,7 @@ class _RegressionShapExplainers:
         foreground_X,
         horizons: Optional[Sequence[int]] = None,
         target_components: Optional[Sequence[str]] = None,
-    ) -> Dict[integer, Dict[str, shap.Explanation]]:
+    ) -> Dict[int, Dict[str, shap.Explanation]]:
 
         """
         Return a dictionary of dictionaries of shap.Explanation instances:
@@ -577,7 +576,7 @@ class _RegressionShapExplainers:
             Optionally, a list of integers representing which points/steps in the future we want to explain,
             starting from the first prediction step at 1. Currently, only forecasting models are supported which
             provide an `output_chunk_length` parameter. `horizons` must not be larger than `output_chunk_length`.
-        target_names
+        target_components
             Optionally, a list of strings with the target components we want to explain.
 
         """
@@ -589,7 +588,9 @@ class _RegressionShapExplainers:
 
             for h in horizons:
                 tmp_n = {}
-                for t_idx, t in enumerate(target_components):
+                for t_idx, t in enumerate(self.target_components):
+                    if t not in target_components:
+                        continue
                     explainer = self.explainers[h - 1][t_idx](foreground_X)
                     explainer.base_values = explainer.base_values.ravel()
                     explainer.time_index = foreground_X.index
@@ -601,6 +602,8 @@ class _RegressionShapExplainers:
             for h in horizons:
                 tmp_n = {}
                 for t_idx, t in enumerate(target_components):
+                    if t not in target_components:
+                        continue
                     if not self.single_output:
                         tmp_t = shap.Explanation(
                             shap_explanation_tmp.values[

--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -702,6 +702,8 @@ class _RegressionShapExplainers:
             lags_future_covariates=lags_future_covariates_list
             if future_covariates
             else None,
+            uses_static_covariates=self.model.uses_static_covariates,
+            last_static_covariates_shape=self.model._static_covariates_shape,
         )
         # Remove sample axis:
         X = X[:, :, 0]
@@ -720,26 +722,11 @@ class _RegressionShapExplainers:
         if n_samples:
             X = shap.utils.sample(X, n_samples)
 
-        # We keep the creation order of the different lags/features in create_lagged_data
-        lags_names_list = []
-        if lags_list:
-            for lag in lags_list:
-                for t_name in self.target_components:
-                    lags_names_list.append(t_name + "_target_lag" + str(lag))
-        if lags_past_covariates_list:
-            for lag in lags_past_covariates_list:
-                for t_name in self.past_covariates_components:
-                    lags_names_list.append(t_name + "_past_cov_lag" + str(lag))
-        if lags_future_covariates_list:
-            for lag in lags_future_covariates_list:
-                for t_name in self.future_covariates_components:
-                    lags_names_list.append(t_name + "_fut_cov_lag" + str(lag))
-
+        # rename output columns to the matching lagged features names
         X = X.rename(
             columns={
-                name: lags_names_list[idx]
+                name: self.model.lagged_feature_names[idx]
                 for idx, name in enumerate(X.columns.to_list())
             }
         )
-
         return X

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -353,7 +353,12 @@ class RegressionModel(GlobalForecastingModel):
         lags_past_covariates = self.lags.get("past")
         lags_future_covariates = self.lags.get("future")
 
-        features, labels, _ = create_lagged_training_data(
+        (
+            features,
+            labels,
+            _,
+            self._static_covariates_shape,
+        ) = create_lagged_training_data(
             target_series=target_series,
             output_chunk_length=self.output_chunk_length,
             past_covariates=past_covariates,
@@ -361,6 +366,8 @@ class RegressionModel(GlobalForecastingModel):
             lags=lags,
             lags_past_covariates=lags_past_covariates,
             lags_future_covariates=lags_future_covariates,
+            uses_static_covariates=self.uses_static_covariates,
+            last_static_covariates_shape=None,
             max_samples_per_ts=max_samples_per_ts,
             multi_models=self.multi_models,
             check_inputs=False,
@@ -370,14 +377,6 @@ class RegressionModel(GlobalForecastingModel):
         for i, (X_i, y_i) in enumerate(zip(features, labels)):
             features[i] = X_i[:, :, 0]
             labels[i] = y_i[:, :, 0]
-
-        features, static_covariates_shape = add_static_covariates_to_lagged_data(
-            features,
-            target_series,
-            uses_static_covariates=self.uses_static_covariates,
-            last_shape=None,
-        )
-        self._static_covariates_shape = static_covariates_shape
 
         training_samples = np.concatenate(features, axis=0)
         training_labels = np.concatenate(labels, axis=0)

--- a/darts/tests/explainability/test_shap_explainer.py
+++ b/darts/tests/explainability/test_shap_explainer.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pytest
 import shap
 import sklearn
 from dateutil.relativedelta import relativedelta
@@ -89,6 +90,25 @@ class ShapExplainerTestCase(DartsBaseTestClass):
     target_ts = TimeSeries.from_times_and_values(
         days, np.concatenate([x_1.reshape(-1, 1), x_2.reshape(-1, 1)], axis=1)
     ).with_columns_renamed(["0", "1"], ["price", "power"])
+
+    target_ts_with_static_covs = TimeSeries.from_times_and_values(
+        days,
+        x_1.reshape(-1, 1),
+        static_covariates=pd.DataFrame({"type": [0], "state": [1]}),
+    ).with_columns_renamed(["0"], ["price"])
+    target_ts_with_multi_component_static_covs = TimeSeries.from_times_and_values(
+        days,
+        np.concatenate([x_1.reshape(-1, 1), x_2.reshape(-1, 1)], axis=1),
+        static_covariates=pd.DataFrame({"type": [0, 1], "state": [2, 3]}),
+    ).with_columns_renamed(["0", "1"], ["price", "power"])
+    target_ts_multiple_series_with_different_static_covs = [
+        TimeSeries.from_times_and_values(
+            days, x_1.reshape(-1, 1), static_covariates=pd.DataFrame({"type": [0]})
+        ).with_columns_renamed(["0"], ["price"]),
+        TimeSeries.from_times_and_values(
+            days, x_2.reshape(-1, 1), static_covariates=pd.DataFrame({"state": [1]})
+        ).with_columns_renamed(["0"], ["price"]),
+    ]
 
     past_cov_ts = TimeSeries.from_times_and_values(
         days_past_cov,
@@ -670,3 +690,70 @@ class ShapExplainerTestCase(DartsBaseTestClass):
             ),
             shap.Explanation,
         )
+
+    def test_shapley_with_static_cov(self):
+        ts = self.target_ts_with_static_covs
+        model = LightGBMModel(
+            lags=4,
+            output_chunk_length=1,
+        )
+        model.fit(
+            series=ts,
+        )
+        shap_explain = ShapExplainer(model)
+
+        # different static covariates dimensions should raise an error
+        with pytest.raises(ValueError):
+            shap_explain.explain(
+                ts.with_static_covariates(ts.static_covariates["state"])
+            )
+
+        # without static covariates should raise an error
+        with pytest.raises(ValueError):
+            shap_explain.explain(ts.with_static_covariates(None))
+
+        explanation_results = shap_explain.explain(ts)
+        assert len(explanation_results.explained_forecasts[1]["price"].columns) == (
+            -(min(model.lags["target"])) + model.static_covariates.shape[1]
+        )
+
+        model.fit(
+            series=self.target_ts_with_multi_component_static_covs,
+        )
+        shap_explain = ShapExplainer(model)
+        explanation_results = shap_explain.explain()
+        assert len(explanation_results.feature_values[1]) == 2
+        for comp in self.target_ts_with_multi_component_static_covs.components:
+            comps_out = explanation_results.explained_forecasts[1][comp].columns
+            assert len(comps_out) == (
+                -(min(model.lags["target"])) * model.input_dim["target"]
+                + model.input_dim["target"] * model.static_covariates.shape[1]
+            )
+            assert comps_out[-4:].tolist() == [
+                "type_statcov_target_price",
+                "type_statcov_target_power",
+                "state_statcov_target_price",
+                "state_statcov_target_power",
+            ]
+
+    def test_shapley_multiple_series_with_different_static_covs(self):
+        model = LightGBMModel(
+            lags=4,
+            output_chunk_length=1,
+        )
+        model.fit(
+            series=self.target_ts_multiple_series_with_different_static_covs,
+        )
+        shap_explain = ShapExplainer(
+            model,
+            background_series=self.target_ts_multiple_series_with_different_static_covs,
+        )
+        explanation_results = shap_explain.explain()
+
+        self.assertTrue(len(explanation_results.feature_values) == 2)
+
+        # model trained on multiple series will take column names of first series -> even though
+        # static covs have different names, the output will show the same names
+        for explained_forecast in explanation_results.explained_forecasts:
+            comps_out = explained_forecast[1]["price"].columns.tolist()
+            assert comps_out[-1] == "type_statcov_target_price"

--- a/darts/tests/utils/tabularization/test_create_lagged_prediction_data.py
+++ b/darts/tests/utils/tabularization/test_create_lagged_prediction_data.py
@@ -375,6 +375,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
             )
@@ -462,6 +463,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
             )
@@ -534,6 +536,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
             )
@@ -606,6 +609,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
             )
@@ -694,6 +698,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
             )
@@ -705,6 +710,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=False,
             )
@@ -772,6 +778,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
             )
@@ -783,6 +790,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=False,
             )
@@ -827,6 +835,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=past_lags,
                 lags_future_covariates=future_lags,
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             # Number of observations should match number of feature times:
@@ -870,6 +879,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=past_lags,
                 lags_future_covariates=future_lags,
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             # Number of observations should match number of feature times:
@@ -917,6 +927,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=use_moving_windows,
             )
@@ -978,6 +989,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=use_moving_windows,
             )
@@ -997,7 +1009,10 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
         lag = 5
         for use_moving_windows in (False, True):
             X, times = create_lagged_prediction_data(
-                target, lags=[-lag], use_moving_windows=use_moving_windows
+                target,
+                lags=[-lag],
+                use_moving_windows=use_moving_windows,
+                uses_static_covariates=False,
             )
             self.assertTrue(np.allclose(expected_X, X))
             # Should only have one sample, generated for
@@ -1020,7 +1035,10 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
         lag = 5
         for use_moving_windows in (False, True):
             X, times = create_lagged_prediction_data(
-                target, lags=[-lag], use_moving_windows=use_moving_windows
+                target,
+                lags=[-lag],
+                use_moving_windows=use_moving_windows,
+                uses_static_covariates=False,
             )
             self.assertTrue(np.allclose(expected_X, X))
             # Should only have one sample, generated for
@@ -1053,6 +1071,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[0],
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             self.assertTrue(np.allclose(expected_X, X))
@@ -1088,6 +1107,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[0],
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             self.assertTrue(np.allclose(expected_X, X))
@@ -1119,6 +1139,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[1],
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             self.assertTrue(np.allclose(expected_X, X))
@@ -1154,6 +1175,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[1],
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             self.assertTrue(np.allclose(expected_X, X))
@@ -1185,6 +1207,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
             lags=lags,
             lags_past_covariates=lags_past,
             lags_future_covariates=lags_future,
+            uses_static_covariates=False,
         )
         self.assertTrue(np.allclose(X, expected_X))
         self.assertEqual(len(times), 2)
@@ -1198,6 +1221,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
             lags=lags,
             lags_past_covariates=lags_past,
             lags_future_covariates=lags_future,
+            uses_static_covariates=False,
             concatenate=False,
         )
         self.assertEqual(len(X), 2)
@@ -1230,6 +1254,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
             lags=lags,
             lags_past_covariates=lags_past,
             lags_future_covariates=lags_future,
+            uses_static_covariates=False,
         )
         self.assertTrue(np.allclose(X, expected_X))
         self.assertTrue(times[0].equals(expected_times))
@@ -1252,6 +1277,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                     lags=lags,
                     past_covariates=series_2,
                     lags_past_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1264,6 +1290,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                     lags=lags,
                     past_covariates=series_2,
                     lags_past_covariates=lags,
+                    uses_static_covariates=False,
                 )
             self.assertEqual(
                 "Specified series do not share any common times for which features can be created.",
@@ -1289,6 +1316,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                         target_series=series,
                         lags_future_covariates=[-1],
                         past_covariates=series,
+                        uses_static_covariates=False,
                         use_moving_windows=use_moving_windows,
                     )
             self.assertEqual(
@@ -1306,7 +1334,9 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
         for use_moving_windows in (False, True):
             with self.assertRaises(ValueError) as e:
                 create_lagged_prediction_data(
-                    target_series=target, use_moving_windows=use_moving_windows
+                    target_series=target,
+                    use_moving_windows=use_moving_windows,
+                    uses_static_covariates=False,
                 )
             self.assertEqual(
                 "Must specify at least one of: `lags`, `lags_past_covariates`, `lags_future_covariates`.",
@@ -1326,6 +1356,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 create_lagged_prediction_data(
                     target_series=series,
                     lags=[-20, -1],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1340,6 +1371,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 create_lagged_prediction_data(
                     past_covariates=series,
                     lags_past_covariates=[-20, -1],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1369,6 +1401,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 create_lagged_prediction_data(
                     target_series=series,
                     lags=[0],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1382,6 +1415,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                 create_lagged_prediction_data(
                     past_covariates=series,
                     lags_past_covariates=[0],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1394,6 +1428,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
             create_lagged_prediction_data(
                 future_covariates=series,
                 lags_future_covariates=[-1, 0, 1],
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
 
@@ -1412,6 +1447,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                     target_series=series,
                     lags=lags,
                     future_covariates=series,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 1)
@@ -1429,6 +1465,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                     target_series=series,
                     lags=lags,
                     lags_future_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 1)
@@ -1449,6 +1486,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                     lags=lags,
                     past_covariates=series,
                     lags_future_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 2)
@@ -1475,6 +1513,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                     target_series=series,
                     past_covariates=series,
                     lags_past_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 1)
@@ -1493,6 +1532,7 @@ class CreateLaggedPredictionDataTestCase(DartsBaseTestClass):
                     lags=lags,
                     past_covariates=series,
                     lags_past_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 1)

--- a/darts/tests/utils/tabularization/test_create_lagged_training_data.py
+++ b/darts/tests/utils/tabularization/test_create_lagged_training_data.py
@@ -452,7 +452,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             lags_is_none = [x is None for x in all_lags]
             if all(lags_is_none):
                 continue
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -460,6 +460,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
@@ -558,7 +559,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             lags_is_none = [x is None for x in all_lags]
             if all(lags_is_none):
                 continue
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -566,6 +567,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=True,
@@ -649,7 +651,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             lags_is_none = [x is None for x in all_lags]
             if all(lags_is_none):
                 continue
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -657,6 +659,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=False,
@@ -755,7 +758,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             lags_is_none = [x is None for x in all_lags]
             if all(lags_is_none):
                 continue
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -763,6 +766,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=False,
@@ -846,7 +850,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             if all(lags_is_none):
                 continue
             # Using moving window method:
-            X_mw, y_mw, times_mw = create_lagged_training_data(
+            X_mw, y_mw, times_mw, _ = create_lagged_training_data(
                 target_series=target,
                 output_chunk_length=output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -854,12 +858,13 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 multi_models=multi_models,
                 use_moving_windows=True,
             )
             # Using time intersection method:
-            X_ti, y_ti, times_ti = create_lagged_training_data(
+            X_ti, y_ti, times_ti, _ = create_lagged_training_data(
                 target_series=target,
                 output_chunk_length=output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -867,6 +872,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 multi_models=multi_models,
                 use_moving_windows=False,
@@ -938,7 +944,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             if all(lags_is_none):
                 continue
             # Using moving window method:
-            X_mw, y_mw, times_mw = create_lagged_training_data(
+            X_mw, y_mw, times_mw, _ = create_lagged_training_data(
                 target_series=target,
                 output_chunk_length=output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -946,12 +952,13 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 multi_models=multi_models,
                 use_moving_windows=True,
             )
             # Using time intersection method:
-            X_ti, y_ti, times_ti = create_lagged_training_data(
+            X_ti, y_ti, times_ti, _ = create_lagged_training_data(
                 target_series=target,
                 output_chunk_length=output_chunk_length,
                 past_covariates=past if lags_past else None,
@@ -959,6 +966,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 multi_models=multi_models,
                 use_moving_windows=False,
@@ -1001,7 +1009,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             [expected_X_target, expected_X_past, expected_X_future], axis=1
         )
         for use_moving_windows in (False, True):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target_series=series,
                 output_chunk_length=output_chunk_length,
                 past_covariates=series,
@@ -1009,6 +1017,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=past_lags,
                 lags_future_covariates=future_lags,
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             # Number of observations should match number of feature times:
@@ -1051,7 +1060,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             [expected_X_target, expected_X_past, expected_X_future], axis=1
         )
         for use_moving_windows in (False, True):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target_series=series,
                 output_chunk_length=output_chunk_length,
                 past_covariates=series,
@@ -1059,6 +1068,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=past_lags,
                 lags_future_covariates=future_lags,
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
             # Number of observations should match number of feature times:
@@ -1106,7 +1116,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Check correctness for both 'moving window' method
         # and 'time intersection' method:
         for use_moving_windows in (False, True):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length=1,
                 past_covariates=past,
@@ -1114,6 +1124,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=use_moving_windows,
             )
@@ -1171,7 +1182,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Check correctness for both 'moving window' method
         # and 'time intersection' method:
         for use_moving_windows in (False, True):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length=1,
                 past_covariates=past,
@@ -1179,6 +1190,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 lags=lags,
                 lags_past_covariates=lags_past,
                 lags_future_covariates=lags_future,
+                uses_static_covariates=False,
                 max_samples_per_ts=max_samples_per_ts,
                 use_moving_windows=use_moving_windows,
             )
@@ -1202,10 +1214,11 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Test correctness for 'moving window' and for 'time intersection' methods, as well
         # as for different `multi_models` values:
         for (use_moving_windows, multi_models) in product([False, True], [False, True]):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length,
                 lags=lags,
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 use_moving_windows=use_moving_windows,
             )
@@ -1233,10 +1246,11 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Test correctness for 'moving window' and for 'time intersection' methods, as well
         # as for different `multi_models` values:
         for (use_moving_windows, multi_models) in product([False, True], [False, True]):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length,
                 lags=lags,
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 use_moving_windows=use_moving_windows,
             )
@@ -1269,12 +1283,13 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Check correctness for 'moving windows' and 'time intersection' methods, as
         # well as for different `multi_models` values:
         for (use_moving_windows, multi_models) in product([False, True], [False, True]):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length=1,
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[0],
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 use_moving_windows=use_moving_windows,
             )
@@ -1308,12 +1323,13 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Check correctness for 'moving windows' and 'time intersection' methods, as
         # well as for different `multi_models` values:
         for (use_moving_windows, multi_models) in product([False, True], [False, True]):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length=1,
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[0],
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 use_moving_windows=use_moving_windows,
             )
@@ -1345,12 +1361,13 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Check correctness for 'moving windows' and 'time intersection' methods, as
         # well as for different `multi_models` values:
         for (use_moving_windows, multi_models) in product([False, True], [False, True]):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length=1,
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[1],
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 use_moving_windows=use_moving_windows,
             )
@@ -1384,12 +1401,13 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         # Check correctness for 'moving windows' and 'time intersection' methods, as
         # well as for different `multi_models` values:
         for (use_moving_windows, multi_models) in product([False, True], [False, True]):
-            X, y, times = create_lagged_training_data(
+            X, y, times, _ = create_lagged_training_data(
                 target,
                 output_chunk_length=1,
                 future_covariates=future,
                 lags=[-1],
                 lags_future_covariates=[1],
+                uses_static_covariates=False,
                 multi_models=multi_models,
                 use_moving_windows=use_moving_windows,
             )
@@ -1423,7 +1441,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         expected_times_1 = target_1.time_index[1:]
         expected_times_2 = target_2.time_index[1:]
         # Check when `concatenate = True`:
-        X, y, times = create_lagged_training_data(
+        X, y, times, _ = create_lagged_training_data(
             (target_1, target_2),
             output_chunk_length=output_chunk_length,
             past_covariates=(past_1, past_2),
@@ -1431,6 +1449,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             lags=lags,
             lags_past_covariates=lags_past,
             lags_future_covariates=lags_future,
+            uses_static_covariates=False,
         )
         self.assertTrue(np.allclose(X, expected_X))
         self.assertTrue(np.allclose(y, expected_y))
@@ -1438,7 +1457,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         self.assertTrue(times[0].equals(expected_times_1))
         self.assertTrue(times[1].equals(expected_times_2))
         # Check when `concatenate = False`:
-        X, y, times = create_lagged_training_data(
+        X, y, times, _ = create_lagged_training_data(
             (target_1, target_2),
             output_chunk_length=output_chunk_length,
             past_covariates=(past_1, past_2),
@@ -1446,6 +1465,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             lags=lags,
             lags_past_covariates=lags_past,
             lags_future_covariates=lags_future,
+            uses_static_covariates=False,
             concatenate=False,
         )
         self.assertEqual(len(X), 2)
@@ -1477,7 +1497,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
         )
         expected_y = target.all_values(copy=False)[1:, :, :]
         expected_times = target.time_index[1:]
-        X, y, times = create_lagged_training_data(
+        X, y, times, _ = create_lagged_training_data(
             target,
             output_chunk_length=output_chunk_length,
             past_covariates=past,
@@ -1485,6 +1505,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
             lags=lags,
             lags_past_covariates=lags_past,
             lags_future_covariates=lags_future,
+            uses_static_covariates=False,
         )
         self.assertTrue(np.allclose(X, expected_X))
         self.assertTrue(np.allclose(y, expected_y))
@@ -1509,6 +1530,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     lags=lags,
                     past_covariates=series_2,
                     lags_past_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1536,6 +1558,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                         target_series=series_1,
                         output_chunk_length=1,
                         lags_past_covariates=lags,
+                        uses_static_covariates=False,
                         use_moving_windows=use_moving_windows,
                     )
             self.assertEqual(
@@ -1554,6 +1577,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                         output_chunk_length=1,
                         lags_future_covariates=lags,
                         past_covariates=series_2,
+                        uses_static_covariates=False,
                         use_moving_windows=use_moving_windows,
                     )
             self.assertEqual(
@@ -1576,6 +1600,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     target_series=target,
                     output_chunk_length=0,
                     lags=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1587,6 +1612,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     target_series=target,
                     output_chunk_length=1.1,
                     lags=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1606,6 +1632,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 create_lagged_training_data(
                     target_series=target,
                     output_chunk_length=1,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1632,6 +1659,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     target_series=series,
                     output_chunk_length=5,
                     lags=[-20, -10],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1649,6 +1677,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     output_chunk_length=1,
                     past_covariates=series,
                     lags_past_covariates=[-5, -3],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1680,6 +1709,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     target_series=series,
                     output_chunk_length=1,
                     lags=[0],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1695,6 +1725,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     output_chunk_length=1,
                     past_covariates=series,
                     lags_past_covariates=[0],
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
             self.assertEqual(
@@ -1709,6 +1740,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                 output_chunk_length=1,
                 future_covariates=series,
                 lags_future_covariates=[-1, 0, 1],
+                uses_static_covariates=False,
                 use_moving_windows=use_moving_windows,
             )
 
@@ -1734,6 +1766,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     output_chunk_length=1,
                     lags=lags,
                     future_covariates=series,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 1)
@@ -1752,6 +1785,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     output_chunk_length=1,
                     lags=lags,
                     lags_future_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 1)
@@ -1772,6 +1806,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     output_chunk_length=1,
                     past_covariates=series,
                     lags_future_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 2)
@@ -1799,6 +1834,7 @@ class CreateLaggedTrainingDataTestCase(DartsBaseTestClass):
                     output_chunk_length=1,
                     past_covariates=series,
                     lags_past_covariates=lags,
+                    uses_static_covariates=False,
                     use_moving_windows=use_moving_windows,
                 )
                 self.assertEqual(len(w), 0)

--- a/darts/utils/data/tabularization.py
+++ b/darts/utils/data/tabularization.py
@@ -663,7 +663,7 @@ def add_static_covariates_to_lagged_data(
             features[idx] = np.hstack(
                 [
                     features[idx],
-                    np.broadcast_to(static_covs, shape_out),
+                    np.broadcast_to(static_covs, shape_out[:2]).reshape(shape_out),
                 ]
             )
 


### PR DESCRIPTION
### Summary
- moved static covariates handling into create_lagged_data for RegressionModels
- Added support for static covariates to `ShapExplainer` (continues the work of @anne-devries in #1732, as the PR is stale at the moment) 
- Fixed a bug when using selected `target_components` with `ShapExplainer`.
