### PR TITLE
Fix #1049 - add prior_scale and mode arguments to prophet model's add_seasonality

### DIFF
--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -186,6 +186,8 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                 name=seasonality_name,
                 period=attributes["seasonal_periods"] * interval_length,
                 fourier_order=attributes["fourier_order"],
+                prior_scale=attributes["prior_scale"],
+                mode=attributes["mode"],
             )
 
         # add covariates


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1049 .

### Summary

When fitting a prophet model, the add_seasonality function will now properly add the prior_scale and mode to the custom seasonality, in accordance with the behaviour described in the docs.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
