### PR TITLE
Fix NLinear for use with past covariates

### DIFF
--- a/darts/models/forecasting/nlinear.py
+++ b/darts/models/forecasting/nlinear.py
@@ -147,7 +147,7 @@ class _NLinearModule(PLMixedCovariatesModule):
             )
 
             if self.normalize:
-                x = x + seq_last  # Note: works only when nr_params == 1
+                x = x + seq_last[:, :, : self.output_dim]  # Note: works only when nr_params == 1
 
             if self.future_cov_dim != 0:
                 # x_future might be shorter than output_chunk_length when n < output_chunk_length


### PR DESCRIPTION
Previously, they caused a shape mismatch.

No issue exists for this yet.

### Summary

Only some part of `seq_last` may be re-added, in particular only the part that refers to the target. Apparently, this is the first part (see the beginning of the `self.shared_weights == True` case).

### Other Information

None.
