### PR TITLE
added acf_max_lags as argument to plot_residuals and have the param d…

### DIFF
--- a/darts/tests/utils/test_statistics.py
+++ b/darts/tests/utils/test_statistics.py
@@ -205,5 +205,9 @@ class PlotTestCase(DartsBaseTestClass):
     def test_statistics_plot(self):
         plot_residuals_analysis(self.series)
         plt.close()
+        plot_residuals_analysis(self.series, acf_max_lag=10)
+        plt.close()
+        plot_residuals_analysis(self.series[:10])
+        plt.close()
         plot_pacf(self.series)
         plt.close()

--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -852,6 +852,7 @@ def plot_residuals_analysis(
     num_bins: int = 20,
     fill_nan: bool = True,
     default_formatting: bool = True,
+    acf_max_lag: int = 24,
 ) -> None:
     """Plots data relevant to residuals.
 
@@ -871,6 +872,8 @@ def plot_residuals_analysis(
         A boolean value indicating whether NaN values should be filled in the residuals.
     default_formatting
         Whether or not to use the darts default scheme.
+    acf_max_lag
+        The maximum lag to be displayed in the ACF plot. Must be less than residuals length.
     """
 
     residuals._assert_univariate()
@@ -910,8 +913,11 @@ def plot_residuals_analysis(
     ax2.set_xlabel("value")
 
     # plot ACF
+    acf_max_lag = min(acf_max_lag, len(residuals) - 1)
     ax3 = fig.add_subplot(gs[1:, :1])
-    plot_acf(residuals, axis=ax3, default_formatting=default_formatting)
+    plot_acf(
+        residuals, axis=ax3, default_formatting=default_formatting, max_lag=acf_max_lag
+    )
     ax3.set_ylabel("ACF value")
     ax3.set_xlabel("lag")
     ax3.set_title("ACF")


### PR DESCRIPTION
Fixes #1659: plot_residuals_analysis uses plot_acf with default lag of 24 with no option for the user to change this value, making it fail on TS smaller than n=24.

### Summary

2 modifications:
1. add a acf_max_lag argument to plot_residuals_analysis
2. defaults acf_max_lag to len(ts)-1 if TS is smaller than 24


<!--Thank you for contributing to darts! -->
