### PR TITLE
Fix deprecation warning

### DIFF
--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -611,7 +611,7 @@ class UberTLCDataset(DatasetLoaderCSV):
 
                 output_dict[locationID] = count_series
             output_df = pd.DataFrame(output_dict)
-            output_df.to_csv(dataset_path, line_terminator="\n")
+            output_df.to_csv(dataset_path, lineterminator="\n")
 
         super().__init__(
             metadata=DatasetLoaderMetadata(

--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -611,7 +611,7 @@ class UberTLCDataset(DatasetLoaderCSV):
 
                 output_dict[locationID] = count_series
             output_df = pd.DataFrame(output_dict)
-            output_df.to_csv(dataset_path, lineterminator="\n")
+            output_df.to_csv(dataset_path)
 
         super().__init__(
             metadata=DatasetLoaderMetadata(


### PR DESCRIPTION
Fixes None.

### Summary

The argument has been [renamed](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html).