### PR TITLE
1862 more robust way of component naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `RegressionEnsembleModel` and `NaiveEnsembleModel` can generate probabilistic forecasts, probabilistics `forecasting_models` can be sampled to train the `regression_model`, updated the documentation (stacking technique). [#1692](https://github.com/unit8co/darts/pull/#1692) by [Antoine Madrona](https://github.com/madtoinou).
 - Improvements to `ShapExplainer`:
   - Added static covariates support to `ShapeExplainer`. [#1803](https://github.com/unit8co/darts/pull/#1803) by [Anne de Vries](https://github.com/anne-devries) and [Dennis Bader](https://github.com/dennisbader).
+  - Improved components naming of static covariates. [#1863](https://github.com/unit8co/darts/pull/1863) by [Anne de Vries](https://github.com/anne-devries)
 
 **Fixed**
 - Fixed an issue not considering original component names for `TimeSeries.plot()` when providing a label prefix. [#1783](https://github.com/unit8co/darts/pull/1783) by [Simon Sudrich](https://github.com/sudrich).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `RegressionEnsembleModel` and `NaiveEnsembleModel` can generate probabilistic forecasts, probabilistics `forecasting_models` can be sampled to train the `regression_model`, updated the documentation (stacking technique). [#1692](https://github.com/unit8co/darts/pull/#1692) by [Antoine Madrona](https://github.com/madtoinou).
 - Improvements to `ShapExplainer`:
   - Added static covariates support to `ShapeExplainer`. [#1803](https://github.com/unit8co/darts/pull/#1803) by [Anne de Vries](https://github.com/anne-devries) and [Dennis Bader](https://github.com/dennisbader).
-  - Improved components naming of static covariates. [#1863](https://github.com/unit8co/darts/pull/1863) by [Anne de Vries](https://github.com/anne-devries)
+  - Improved static covariates column naming when applying a `sklearn.preprocessing.OneHotEncoder` with `StaticCovariatesTransformer` [#1863](https://github.com/unit8co/darts/pull/1863) by [Anne de Vries](https://github.com/anne-devries)
 
 **Fixed**
 - Fixed an issue not considering original component names for `TimeSeries.plot()` when providing a label prefix. [#1783](https://github.com/unit8co/darts/pull/1783) by [Simon Sudrich](https://github.com/sudrich).

--- a/darts/dataprocessing/transformers/static_covariates_transformer.py
+++ b/darts/dataprocessing/transformers/static_covariates_transformer.py
@@ -301,7 +301,11 @@ class StaticCovariatesTransformer(FittableDataTransformer, InvertibleDataTransfo
                     col_map_cat_i = []
                     for cat in categories:
                         col_map_cat_i.append(cat)
-                        inv_col_map_cat[cat] = [col]
+                        if len(categories) > 1:
+                            cat_col_name = str(col) + "_" + str(cat)
+                            inv_col_map_cat[cat_col_name] = [col]
+                        else:
+                            inv_col_map_cat[cat] = [col]
                     col_map_cat[col] = col_map_cat_i
         # If we don't have any categorical static covariates, don't need to generate mapping:
         else:
@@ -454,6 +458,8 @@ class StaticCovariatesTransformer(FittableDataTransformer, InvertibleDataTransfo
             elif is_cat:  # categorical transformed column
                 # covers one to one feature map (ordinal/label encoding) and one to multi feature (one hot encoding)
                 for col_name in col_map_cat[col]:
+                    if len(col_map_cat[col]) > 1:
+                        col_name = str(col) + "_" + str(col_name)
                     if col_name not in static_cov_columns:
                         data[col_name] = vals_cat[:, idx_cat]
                         static_cov_columns.append(col_name)


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #1862 .

### Summary

changed category mappings such that static covariate components now are of the form `<original_column_name>_<value1>`, `<original_column_name>_<value2>`, instead of `<value1>`, `<value2>`. To account for cases where you have one category that is used by two (or more) static covariates. E.g. temperature could be low/medium/high, and sun_hours could be low/medium/high.
