### PR TITLE
bump minimum python version from 3.7 to 3.8

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,8 +17,8 @@ Steps to reproduce the behavior, preferably code snippet.
 A clear and concise description of what you expected to happen.
 
 **System (please complete the following information):**
- - Python version: [e.g. 3.7]
- - darts version [e.g. 0.14.0]
+ - Python version: [e.g. 3.8]
+ - darts version [e.g. 0.24.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ['3.7', '3.10']
+        python-version: ['3.8', '3.10']
         flavour: ['core', 'torch', 'all']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug when loading the weights of a `TorchForecastingModel` trained with encoders or a Likelihood. [#1744](https://github.com/unit8co/darts/pull/1744) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug when using selected `target_components` with `ShapExplainer. [#1803](https://github.com/unit8co/darts/pull/#1803) by [Dennis Bader](https://github.com/dennisbader).
 
+**Removed**
+- Removed support for Python 3.7 [#1864](https://github.com/unit8co/darts/pull/#1864) by [Dennis Bader](https://github.com/dennisbader).
+
 ## [0.24.0](https://github.com/unit8co/darts/tree/0.24.0) (2023-04-12)
 ### For users of the library:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 Below, we detail how to install Darts using either `conda` or `pip`.
 
 ## From conda-forge
-Currently only the x86_64 architecture with Python 3.7-3.10
+Currently only the x86_64 architecture with Python 3.8-3.10
 is fully supported with conda; consider using PyPI if you are running into troubles.
 
 To create a conda environment for Python 3.9

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 [![PyPI version](https://badge.fury.io/py/u8darts.svg)](https://badge.fury.io/py/darts)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/u8darts-all.svg)](https://anaconda.org/conda-forge/u8darts-all)
-![Supported versions](https://img.shields.io/badge/python-3.7+-blue.svg)
+![Supported versions](https://img.shields.io/badge/python-3.8+-blue.svg)
 ![Docker Image Version (latest by date)](https://img.shields.io/docker/v/unit8/darts?label=docker&sort=date)
 ![GitHub Release Date](https://img.shields.io/github/release-date/unit8co/darts)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/unit8co/darts/release.yml?branch=master)
@@ -50,7 +50,7 @@ fledged anomaly detection models.
 
 ## Quick Install
 
-We recommend to first setup a clean Python environment for your project with Python 3.7+ using your favorite tool
+We recommend to first setup a clean Python environment for your project with Python 3.8+ using your favorite tool
 ([conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html "conda-env"),
 [venv](https://docs.python.org/3/library/venv.html), [virtualenv](https://virtualenv.pypa.io/en/latest/) with
 or without [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)).

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -1,6 +1,6 @@
 # conda-specific dependencies for the dev environment
 name: darts-dev
 dependencies:
-  - python>=3.7
+  - python>=3.8
   - conda-build
   - conda-verify

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -1,5 +1,4 @@
 import itertools
-import sys
 import unittest
 
 import numpy as np
@@ -103,16 +102,14 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
             }  # window list
             self.series_univ_det.window_transform(transforms=window_transformations)
 
-        # skip this test for Python <= 3.7
-        if sys.version_info >= (3, 8):
-            with self.assertRaises(ValueError):
-                window_transformations = {
-                    "function": "mean",
-                    "window": 3,
-                    "mode": "rolling",
-                    "step": -2,
-                }  # Negative step
-                self.series_univ_det.window_transform(transforms=window_transformations)
+        with self.assertRaises(ValueError):
+            window_transformations = {
+                "function": "mean",
+                "window": 3,
+                "mode": "rolling",
+                "step": -2,
+            }  # Negative step
+            self.series_univ_det.window_transform(transforms=window_transformations)
 
         with self.assertRaises(ValueError):
             window_transformations = {
@@ -397,13 +394,6 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
             transformation, include_current=False
         )
         self.assertEqual(transformed_ts, expected_transformed_series)
-
-        # pandas on Python <= 3.7 raises this error:
-        # AttributeError: 'ExponentialMovingWindow' object has no attribute 'sum'
-
-        # skip these tests in Python <= 3.7:
-        if sys.version_info < (3, 8):
-            return
 
         transformation = [
             {"function": "sum", "mode": "rolling", "window": 1, "closed": "left"},

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -772,7 +772,6 @@ class RegressionModelsTestCase(DartsBaseTestClass):
             assert not model.uses_static_covariates
             assert model._static_covariates_shape is None
             preds = model.predict(n=2, series=series)
-            # there seem to be some dtype issues with python=3.7
             np.testing.assert_almost_equal(
                 preds.static_covariates.values,
                 series.static_covariates.values,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "darts": ["py.typed"],
     },
     zip_safe=False,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
@@ -55,7 +55,6 @@ setup(
         "Operating System :: Unix",
         "Operating System :: MacOS",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup_u8darts.py
+++ b/setup_u8darts.py
@@ -44,7 +44,7 @@ setup(
         "darts": ["py.typed"],
     },
     zip_safe=False,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
@@ -56,7 +56,6 @@ setup(
         "Operating System :: Unix",
         "Operating System :: MacOS",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
### Summary
- drops python 3.7 support due to [End Of Life](https://endoflife.date/python)