### PR TITLE
fix getitem with rangeindex start != 0 and freq != 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed an issue with `TorchForecastingModel.load_from_checkpoint()` not properly loading the loss function and metrics. [#1749](https://github.com/unit8co/darts/pull/1749) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug when loading the weights of a `TorchForecastingModel` trained with encoders or a Likelihood. [#1744](https://github.com/unit8co/darts/pull/1744) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug when using selected `target_components` with `ShapExplainer. [#1803](https://github.com/unit8co/darts/pull/#1803) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed `TimeSeries.__getitem__()` for series with a RangeIndex with start != 0 and freq != 1. [#1868](https://github.com/unit8co/darts/pull/#1868) by [Dennis Bader](https://github.com/dennisbader).
 
 ## [0.24.0](https://github.com/unit8co/darts/tree/0.24.0) (2023-04-12)
 ### For users of the library:

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4916,7 +4916,9 @@ class TimeSeries:
                 xa_ = xa_.assign_coords(
                     {
                         self._time_dim: pd.RangeIndex(
-                            start=key, stop=key + self.freq, step=self.freq
+                            start=time_idx[0],
+                            stop=time_idx[0] + self.freq,
+                            step=self.freq,
                         )
                     }
                 )


### PR DESCRIPTION
### Summary
- fixes TimeSeries `__getitem__` with series that have a RangeIndex with start != 0 and freq != 1.
- adds unit test for getitem of integer indexed series