### PR TITLE
Fix/Make DTW alignment plot compatible with RangeIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug when loading the weights of a `TorchForecastingModel` trained with encoders or a Likelihood. [#1744](https://github.com/unit8co/darts/pull/1744) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug when using selected `target_components` with `ShapExplainer. [#1803](https://github.com/unit8co/darts/pull/#1803) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed `TimeSeries.__getitem__()` for series with a RangeIndex with start != 0 and freq != 1. [#1868](https://github.com/unit8co/darts/pull/#1868) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed an issue where `DTWAlignment.plot_alignment` was not plotting the alignment plot of series with a RangeIndex correctly. [#1880](https://github.com/unit8co/darts/pull/1880) by [Ahmet Zamanis](https://github.com/AhmetZamanis) and [Dennis Bader](https://github.com/dennisbader).
 
 **Removed**
 - Removed support for Python 3.7 [#1864](https://github.com/unit8co/darts/pull/#1864) by [Dennis Bader](https://github.com/dennisbader).

--- a/darts/dataprocessing/dtw/_plot.py
+++ b/darts/dataprocessing/dtw/_plot.py
@@ -148,8 +148,8 @@ def plot_alignment(
     path = self.path()
     n = len(path)
 
-    time_dim1 = series1._time_dim
-    time_dim2 = series2._time_dim
+    time_dim1 = series1.time_dim
+    time_dim2 = series2.time_dim
 
     x_coords1 = np.array(xa1[time_dim1], dtype=xa1[time_dim1].dtype)[path[:, 0]]
     x_coords2 = np.array(xa2[time_dim2], dtype=xa2[time_dim2].dtype)[path[:, 1]]
@@ -157,13 +157,19 @@ def plot_alignment(
     y_coords1 = series1.univariate_values()[path[:, 0]]
     y_coords2 = series2.univariate_values()[path[:, 1]]
 
-    x_coords = np.zeros(n * 3, dtype=xa1[time_dim1].dtype)
+    if series1.has_datetime_index:
+        x_dtype = xa1[time_dim1].dtype
+        x_nan = np.datetime64("NaT")
+    else:
+        x_dtype = np.float64
+        x_nan = np.nan
+
+    x_coords = np.empty(n * 3, dtype=x_dtype)
     y_coords = np.empty(n * 3, dtype=np.float64)
 
     x_coords[0::3] = x_coords1
     x_coords[1::3] = x_coords2
-    if x_coords.dtype == "datetime64[s]":
-        x_coords[2::3] = np.datetime64("NaT")
+    x_coords[2::3] = x_nan
 
     y_coords[0::3] = y_coords1
     y_coords[1::3] = y_coords2


### PR DESCRIPTION
Fixes issue #1871 by modifying the `DTWAlignment.plot_alignment()` method, so it works with both `DateTimeIndex` & `RangeIndex` time dimensions.

### Summary
Currently, `plot_alignment()` converts the x-axis coordinates for the alignment lines into DateTime (lines 154-155). The PR modifies this so the x-axis coordinates match the datatype of the series' time dimensions (DateTime or int). 

I also replaced `np.empty` with `np.zeros` (line 160), as doing `x_coords[2::3] = np.nan` raises an error (not sure why), but leaving `x_coords[2::3]` as all zeroes seems to work for RangeIndex time dimensions.

### Other Information
I tested this fix on the same series with both DateTime and RangeIndex time dimensions, and they produced the same plots. 