### PR TITLE
Fix/unit test pandas v2 0 3

### DIFF
--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -623,7 +623,7 @@ class UberTLCDataset(DatasetLoaderCSV):
                 if sample_freq == "hourly"
                 else "24f9fd67e4b9e53f0214a90268cd9bee",
                 header_time="Pickup_date",
-                format_time="%Y-%m-%d %H:%M",
+                format_time="%Y-%m-%d %H:%M:%S",
                 pre_process_zipped_csv_fn=pre_proces_fn,
                 multivariate=multivariate,
             )

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -15,7 +15,7 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
     series_from_values = TimeSeries.from_values(
         np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     )
-    target = TimeSeries.from_times_and_values(times, range(1, 11))
+    target = TimeSeries.from_times_and_values(times, np.array(range(1, 11)))
 
     series_multi_prob = (
         (target + 10)
@@ -271,7 +271,7 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         )
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            [0, 1, 1, 2, 2, 2, 2, 2, 2, 2],
+            np.array([0, 1, 1, 2, 2, 2, 2, 2, 2, 2]),
             columns=["rolling_udf_5_0"],
         )
         self.assertEqual(transformed_ts, expected_transformed_series)
@@ -303,7 +303,7 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         )
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            [100, 3, 6, 9, 12, 15, 18, 21, 24, 27],
+            np.array([100, 3, 6, 9, 12, 15, 18, 21, 24, 27]),
             columns=["rolling_sum_3_2_0"],
         )
         self.assertEqual(transformed_ts, expected_transformed_series)
@@ -314,7 +314,7 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         )
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times[1:],
-            [3, 6, 9, 12, 15, 18, 21, 24, 27],
+            np.array([3, 6, 9, 12, 15, 18, 21, 24, 27]),
             columns=["rolling_sum_3_2_0"],
         )
         self.assertEqual(transformed_ts, expected_transformed_series)
@@ -326,7 +326,7 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         # backfill works only with forecasting_safe=False
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            [3, 3, 6, 9, 12, 15, 18, 21, 24, 27],
+            np.array([3, 3, 6, 9, 12, 15, 18, 21, 24, 27]),
             columns=["rolling_sum_3_2_0"],
         )
         self.assertEqual(transformed_ts, expected_transformed_series)
@@ -375,7 +375,7 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         }
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            ["NaN", 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            np.array(["NaN", 1, 2, 3, 4, 5, 6, 7, 8, 9]),
             columns=["rolling_sum_1_0"],
         )
         transformed_ts = self.target.window_transform(
@@ -387,7 +387,7 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         transformation = {"function": "sum", "mode": "rolling", "window": 1}
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            ["NaN", 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            np.array(["NaN", 1, 2, 3, 4, 5, 6, 7, 8, 9]),
             columns=["rolling_sum_1_0"],
         )
         transformed_ts = self.target.window_transform(
@@ -401,18 +401,20 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
         ]
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            [
-                ["NaN", "NaN"],
-                [1, 1],
-                [2, 2],
-                [3, 3],
-                [4, 4],
-                [5, 5],
-                [6, 6],
-                [7, 7],
-                [8, 8],
-                [9, 9],
-            ],
+            np.array(
+                [
+                    ["NaN", "NaN"],
+                    [1, 1],
+                    [2, 2],
+                    [3, 3],
+                    [4, 4],
+                    [5, 5],
+                    [6, 6],
+                    [7, 7],
+                    [8, 8],
+                    [9, 9],
+                ]
+            ),
             columns=["rolling_sum_1_0", "ewm_sum_0"],
         )
         transformed_ts = self.target.window_transform(
@@ -422,18 +424,20 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
 
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            [
-                [1, 1],
-                [1, 1],
-                [2, 2],
-                [3, 3],
-                [4, 4],
-                [5, 5],
-                [6, 6],
-                [7, 7],
-                [8, 8],
-                [9, 9],
-            ],
+            np.array(
+                [
+                    [1, 1],
+                    [1, 1],
+                    [2, 2],
+                    [3, 3],
+                    [4, 4],
+                    [5, 5],
+                    [6, 6],
+                    [7, 7],
+                    [8, 8],
+                    [9, 9],
+                ]
+            ),
             columns=["rolling_sum_1_0", "ewm_sum_0"],
         )
         transformed_ts = self.target.window_transform(
@@ -457,18 +461,20 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
 
         expected_transformed_series = TimeSeries.from_times_and_values(
             self.times,
-            [
-                ["NaN", "NaN"],
-                ["NaN", "NaN"],
-                [3, 2],
-                [5, 3],
-                [7, 4],
-                [9, 5],
-                [11, 6],
-                [13, 7],
-                [15, 8],
-                [17, 9],
-            ],
+            np.array(
+                [
+                    ["NaN", "NaN"],
+                    ["NaN", "NaN"],
+                    [3, 2],
+                    [5, 3],
+                    [7, 4],
+                    [9, 5],
+                    [11, 6],
+                    [13, 7],
+                    [15, 8],
+                    [17, 9],
+                ]
+            ),
             columns=["rolling_sum_2_2_0", "ewm_sum_2_0"],
         )
 
@@ -481,9 +487,11 @@ class TimeSeriesWindowTransformTestCase(unittest.TestCase):
 class WindowTransformerTestCase(unittest.TestCase):
 
     times = pd.date_range("20130101", "20130110")
-    target = TimeSeries.from_times_and_values(times, range(1, 11))
+    target = TimeSeries.from_times_and_values(times, np.array(range(1, 11)))
     times_hourly = pd.date_range(start="20130101", freq="1H", periods=10)
-    target_hourly = TimeSeries.from_times_and_values(times_hourly, range(1, 11))
+    target_hourly = TimeSeries.from_times_and_values(
+        times_hourly, np.array(range(1, 11))
+    )
 
     series_multi_prob = (
         (target + 10)
@@ -571,11 +579,11 @@ class WindowTransformerTestCase(unittest.TestCase):
         """
 
         times1 = pd.date_range("20130101", "20130110")
-        series_1 = TimeSeries.from_times_and_values(times1, range(1, 11))
+        series_1 = TimeSeries.from_times_and_values(times1, np.array(range(1, 11)))
 
         expected_transformed_series = TimeSeries.from_times_and_values(
             times1,
-            [100, 15, 30, 45, 60, 75, 90, 105, 120, 135],
+            np.array([100, 15, 30, 45, 60, 75, 90, 105, 120, 135]),
             columns=["rolling_sum_3_2_0"],
         )
 

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1150,9 +1150,41 @@ class TimeSeriesTestCase(DartsBaseTestClass):
             TimeSeries.from_times_and_values(
                 pd.date_range("20130101", "20130102"), range(2), fill_missing_dates=True
             )
-        # test empty pandas series error
+        # test empty pandas series with DatetimeIndex
+        freq = "D"
+        # fails without freq
         with self.assertRaises(ValueError):
-            TimeSeries.from_series(pd.Series(dtype="object"), freq="D")
+            TimeSeries.from_series(pd.Series(index=pd.DatetimeIndex([])))
+        # works with index having freq, or setting freq at TimeSeries creation
+        series_a = TimeSeries.from_series(
+            pd.Series(index=pd.DatetimeIndex([], freq=freq))
+        )
+        assert series_a.freq == freq
+        assert len(series_a) == 0
+        series_b = TimeSeries.from_series(
+            pd.Series(index=pd.DatetimeIndex([])), freq=freq
+        )
+        assert series_a == series_b
+
+        # test empty pandas series with DatetimeIndex
+        freq = 2
+        # fails pd.Index (IntIndex)
+        with self.assertRaises(ValueError):
+            TimeSeries.from_series(pd.Series(index=pd.Index([])))
+        # works with pd.RangeIndex as freq (step) is given by default (step=1)
+        series_a = TimeSeries.from_series(pd.Series(index=pd.RangeIndex(start=0)))
+        assert series_a.freq == 1
+        # works with RangeIndex of different freq, or setting freq at TimeSeries creation
+        series_a = TimeSeries.from_series(
+            pd.Series(index=pd.RangeIndex(start=0, step=freq))
+        )
+        assert series_a.freq == freq
+        assert len(series_a) == 0
+        series_b = TimeSeries.from_series(
+            pd.Series(index=pd.RangeIndex(start=0)), freq=freq
+        )
+        assert series_a == series_b
+
         # frequency should be ignored when fill_missing_dates is False
         seriesA = TimeSeries.from_times_and_values(
             pd.date_range("20130101", "20130105"),

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3600,7 +3600,7 @@ class TimeSeries:
                     if isinstance(treat_na, (int, float))
                     else resulting_transformations.values[s_idx, i : (i + n_samples)]
                 )
-                resulting_transformations.values[:s_idx, i : (i + n_samples)] = value
+                resulting_transformations.iloc[:s_idx, i : (i + n_samples)] = value
         elif treat_na == "dropna":
             # can only drop the NaN rows that are common among the columns
             drop_before_index = original_index[np.min(added_na)]


### PR DESCRIPTION
### Summary
Fixes all unit tests failing from new pandas version 2.0.3.
- empty pd.Series are now indexed with RangeIndex
- fix treat_na for window transformation with use of `iloc` instead of overwriting the values
- adjust Uber dataset datetime format string
