### PR TITLE
cap pandas for python<3.9

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,7 +5,8 @@ lightgbm>=3.2.0
 matplotlib>=3.3.0
 nfoursid>=1.0.0
 numpy>=1.19.0
-pandas>=1.0.5
+pandas>=1.0.5,<2.0.0; python_version < "3.9"
+pandas>=1.0.5; python_version >= "3.9"
 pmdarima>=1.8.0
 prophet>=1.1.1
 pyod>=0.9.5


### PR DESCRIPTION
### Summary
- fixes xarray issues for python<3.9 and pandas>=2.0.0. Caps pandas at <=2.0.0 when installing from python38