### PR TITLE
Solve some warnings triggered in unittests

### DIFF
--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -751,9 +751,11 @@ class _RegressionShapExplainers:
         lags_future_covariates_list = self.model.lags.get("future")
 
         X, indexes = create_lagged_prediction_data(
-            target_series=target_series,
-            past_covariates=past_covariates,
-            future_covariates=future_covariates,
+            target_series=target_series if lags_list else None,
+            past_covariates=past_covariates if lags_past_covariates_list else None,
+            future_covariates=future_covariates
+            if lags_future_covariates_list
+            else None,
             lags=lags_list,
             lags_past_covariates=lags_past_covariates_list if past_covariates else None,
             lags_future_covariates=lags_future_covariates_list

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -88,7 +88,7 @@ class PLForecastingModule(pl.LightningModule, ABC):
         super().__init__()
 
         # save hyper parameters for saving/loading
-        self.save_hyperparameters()
+        self.save_hyperparameters(ignore=["loss_fn", "torch_metrics"])
 
         raise_if(
             input_chunk_length is None or output_chunk_length is None,
@@ -397,12 +397,33 @@ class PLForecastingModule(pl.LightningModule, ABC):
         checkpoint["model_dtype"] = self.dtype
         # we must save the shape of the input to be able to instanciate the model without calling fit_from_dataset
         checkpoint["train_sample_shape"] = self.train_sample_shape
+        # we must save the loss to properly restore it when resuming training
+        checkpoint["loss_fn"] = self.criterion
+        # we must save the metrics to continue outputing them when resuming training
+        checkpoint["torch_metrics_train"] = self.train_metrics
+        checkpoint["torch_metrics_val"] = self.val_metrics
 
     def on_load_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
         # by default our models are initialized as float32. For other dtypes, we need to cast to the correct precision
         # before parameters are loaded by PyTorch-Lightning
         dtype = checkpoint["model_dtype"]
         self.to_dtype(dtype)
+
+        # restoring attributes necessary to resume from training properly
+        if (
+            "loss_fn" in checkpoint.keys()
+            and "torch_metrics_train" in checkpoint.keys()
+        ):
+            self.criterion = checkpoint["loss_fn"]
+            self.train_metrics = checkpoint["torch_metrics_train"]
+            self.val_metrics = checkpoint["torch_metrics_val"]
+        else:
+            # explicitly indicate to the user that there is a bug
+            logger.warning(
+                "This checkpoint was generated with darts <= 0.24.0, if a custom loss "
+                "was used to train the model, it won't be properly loaded. Similarly, "
+                "the torch metrics won't be restored from the checkpoint."
+            )
 
     def to_dtype(self, dtype):
         """Cast module precision (float32 by default) to another precision."""

--- a/darts/tests/explainability/test_tft_explainer.py
+++ b/darts/tests/explainability/test_tft_explainer.py
@@ -1,6 +1,7 @@
 import itertools
 from unittest.mock import patch
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -442,26 +443,32 @@ if TORCH_AVAILABLE:
                     _ = explainer.plot_attention(
                         results, plot_type="all", show_index_as="relative"
                     )
+                    plt.close()
                 with patch("matplotlib.pyplot.show") as _:
                     _ = explainer.plot_attention(
                         results, plot_type="all", show_index_as="time"
                     )
+                    plt.close()
                 with patch("matplotlib.pyplot.show") as _:
                     _ = explainer.plot_attention(
                         results, plot_type="time", show_index_as="relative"
                     )
+                    plt.close()
                 with patch("matplotlib.pyplot.show") as _:
                     _ = explainer.plot_attention(
                         results, plot_type="time", show_index_as="time"
                     )
+                    plt.close()
                 with patch("matplotlib.pyplot.show") as _:
                     _ = explainer.plot_attention(
                         results, plot_type="heatmap", show_index_as="relative"
                     )
+                    plt.close()
                 with patch("matplotlib.pyplot.show") as _:
                     _ = explainer.plot_attention(
                         results, plot_type="heatmap", show_index_as="time"
                     )
+                    plt.close()
 
         def helper_create_model(
             self, use_encoders=True, add_relative_idx=True, full_attention=False

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1133,13 +1133,15 @@ class TimeSeriesTestCase(DartsBaseTestClass):
             resampled_timeseries.pd_series().at[pd.Timestamp("20130109")], 8
         )
 
-        # using loffset to avoid nan in the first value
+        # using offset to avoid nan in the first value
         times = pd.date_range(
             start=pd.Timestamp("20200101233000"), periods=10, freq="15T"
         )
         pd_series = pd.Series(range(10), index=times)
         timeseries = TimeSeries.from_series(pd_series)
-        resampled_timeseries = timeseries.resample(freq="1h", loffset="30T")
+        resampled_timeseries = timeseries.resample(
+            freq="1h", offset=pd.Timedelta("30T")
+        )
         self.assertEqual(
             resampled_timeseries.pd_series().at[pd.Timestamp("20200101233000")], 0
         )

--- a/darts/tests/utils/test_statistics.py
+++ b/darts/tests/utils/test_statistics.py
@@ -53,28 +53,24 @@ class TimeSeriesTestCase(DartsBaseTestClass):
 
         # Test univariate
         with self.assertRaises(AssertionError):
-            granger_causality_tests(series_cause_1, series_effect_1, 10, verbose=False)
+            granger_causality_tests(series_cause_1, series_effect_1, 10)
         with self.assertRaises(AssertionError):
-            granger_causality_tests(series_effect_1, series_cause_1, 10, verbose=False)
+            granger_causality_tests(series_effect_1, series_cause_1, 10)
 
         # Test deterministic
         with self.assertRaises(AssertionError):
-            granger_causality_tests(series_cause_1, series_effect_3, 10, verbose=False)
+            granger_causality_tests(series_cause_1, series_effect_3, 10)
         with self.assertRaises(AssertionError):
-            granger_causality_tests(series_effect_3, series_cause_1, 10, verbose=False)
+            granger_causality_tests(series_effect_3, series_cause_1, 10)
 
         # Test Frequency
         with self.assertRaises(ValueError):
-            granger_causality_tests(series_cause_2, series_effect_4, 10, verbose=False)
+            granger_causality_tests(series_cause_2, series_effect_4, 10)
 
         # Test granger basics
-        tests = granger_causality_tests(
-            series_effect_2, series_effect_2, 10, verbose=False
-        )
+        tests = granger_causality_tests(series_effect_2, series_effect_2, 10)
         self.assertTrue(tests[1][0]["ssr_ftest"][1] > 0.99)
-        tests = granger_causality_tests(
-            series_cause_2, series_effect_2, 10, verbose=False
-        )
+        tests = granger_causality_tests(series_cause_2, series_effect_2, 10)
         self.assertTrue(tests[1][0]["ssr_ftest"][1] > 0.01)
 
     def test_stationarity_tests(self):

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3064,7 +3064,7 @@ class TimeSeries:
 
             'backfill': use NEXT valid observation to fill.
         kwargs
-            some keyword arguments for the `xarray.resample` method, notably `loffset` or `base` to indicate where
+            some keyword arguments for the `xarray.resample` method, notably `offset` or `base` to indicate where
             to start the resampling and avoid nan at the first value of the resampled TimeSeries
             For more informations, see the `xarray resample() documentation
             <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.resample.html>`_.
@@ -3086,7 +3086,7 @@ class TimeSeries:
         >>> print(resampled_nokwargs_ts.values())
         [[nan]
         [ 2.]]
-        >>> resampled_ts = ts.resample(freq="1h", loffset="30T")
+        >>> resampled_ts = ts.resample(freq="1h", offset=pd.Timedelta("30T"))
         >>> print(resampled_ts.time_index)
         DatetimeIndex(['2020-01-01 23:30:00', '2020-01-02 00:30:00'],
                       dtype='datetime64[ns]', name='time', freq='H')

--- a/darts/utils/historical_forecasts/optimized_historical_forecasts.py
+++ b/darts/utils/historical_forecasts/optimized_historical_forecasts.py
@@ -85,7 +85,9 @@ def _optimized_historical_forecasts_regression_last_points_only(
             hist_fct_fc_end -= shift * unit
 
         X, times = create_lagged_prediction_data(
-            target_series=series_[hist_fct_tgt_start:hist_fct_tgt_end],
+            target_series=None
+            if len(model.lags.get("target", [])) == 0
+            else series_[hist_fct_tgt_start:hist_fct_tgt_end],
             past_covariates=None
             if past_covariates_ is None
             else past_covariates_[hist_fct_pc_start:hist_fct_pc_end],
@@ -226,7 +228,9 @@ def _optimized_historical_forecasts_regression_all_points(
                 hist_fct_fc_end += shift_end * unit
 
         X, _ = create_lagged_prediction_data(
-            target_series=series_[hist_fct_tgt_start:hist_fct_tgt_end],
+            target_series=None
+            if len(model.lags.get("target", [])) == 0
+            else series_[hist_fct_tgt_start:hist_fct_tgt_end],
             past_covariates=None
             if past_covariates_ is None
             else past_covariates_[hist_fct_pc_start:hist_fct_pc_end],

--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -511,7 +511,6 @@ def granger_causality_tests(
     ts_effect: TimeSeries,
     maxlag: int,
     addconst: bool = True,
-    verbose: bool = True,
 ) -> None:
     """
     Provides four tests for granger non causality of 2 time series using
@@ -532,8 +531,6 @@ def granger_causality_tests(
         If an iterable, computes the tests only for the lags in maxlag.
     addconst
         Include a constant in the model.
-    verbose
-        Print results.
 
     Returns
     -------
@@ -583,7 +580,6 @@ def granger_causality_tests(
         ),
         maxlag,
         addconst,
-        verbose,
     )
 
 


### PR DESCRIPTION
### Summary

Solving various warning messages appearing when running the unit-tests:
- removed deprecated `loffset` argument of `xarray.resample`, used by `TimeSeries.resample`.
- removed deprecated `verbose` argument of `granger_stationarity_test`
- `loss_fn` and `metrics` attributes of `TorchForecastingModels` checkpointing is handled in `on_save/on_load_checkpoints` and ignored in the constructor call to `save_hyperparameters`
- target series is passed to `create_lagged_prediction_data` only when the corresponding lags are defined (optimized historical forecast and shap explainer)
- closing matplotlib figures created in `TFTExplainer` unit-tests

### Other Information

Majority of remaining warnings are caused by statsforecast (ill-conditioned matrix, failure to converge, ...) or p-values outside of the tables that would require changing the dataset used.
Some warnings are caused by the PL callback `ModelCheckpoint` (created in the constructor) tracking the `val_loss`  when `save_checkpionts=True` even if no `val_series` is passed to the `fit()` method. Cannot think of a simple and elegant fix for this.
