### PR TITLE
Fix/unittests m1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 ### For developers of the library:
 
 **Improvements**
-- Refactored the `ForecastingModelExplainer` and `ExplainabilityResult` to simplify implementation of new explainers. [#1392](https://github.com/unit8co/darts/issues/1392) by [Dennis Bader](https://github.com/dennisbader). 
+- Refactored the `ForecastingModelExplainer` and `ExplainabilityResult` to simplify implementation of new explainers. [#1392](https://github.com/unit8co/darts/issues/1392) by [Dennis Bader](https://github.com/dennisbader).
+- Adapted all unit tests to run successfully on M1 devices. [#1933](https://github.com/unit8co/darts/issues/1392) by [Dennis Bader](https://github.com/dennisbader).
 
 ## [0.24.0](https://github.com/unit8co/darts/tree/0.24.0) (2023-04-12)
 ### For users of the library:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improvements**
 - Refactored the `ForecastingModelExplainer` and `ExplainabilityResult` to simplify implementation of new explainers. [#1392](https://github.com/unit8co/darts/issues/1392) by [Dennis Bader](https://github.com/dennisbader).
-- Adapted all unit tests to run successfully on M1 devices. [#1933](https://github.com/unit8co/darts/issues/1392) by [Dennis Bader](https://github.com/dennisbader).
+- Adapted all unit tests to run successfully on M1 devices. [#1933](https://github.com/unit8co/darts/issues/1393) by [Dennis Bader](https://github.com/dennisbader).
 
 ## [0.24.0](https://github.com/unit8co/darts/tree/0.24.0) (2023-04-12)
 ### For users of the library:

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -26,7 +26,6 @@ from darts.models.forecasting.tft_submodels import (
 )
 from darts.models.forecasting.torch_forecasting_model import MixedCovariatesTorchModel
 from darts.utils.data import (
-    MixedCovariatesInferenceDataset,
     MixedCovariatesSequentialDataset,
     MixedCovariatesTrainingDataset,
     TrainingDataset,
@@ -1123,24 +1122,6 @@ class TFTModel(MixedCovariatesTorchModel):
         raise_if_not(
             isinstance(train_dataset, MixedCovariatesTrainingDataset),
             "TFTModel requires a training dataset of type MixedCovariatesTrainingDataset.",
-        )
-
-    def _build_inference_dataset(
-        self,
-        target: Sequence[TimeSeries],
-        n: int,
-        past_covariates: Optional[Sequence[TimeSeries]],
-        future_covariates: Optional[Sequence[TimeSeries]],
-    ) -> MixedCovariatesInferenceDataset:
-
-        return MixedCovariatesInferenceDataset(
-            target_series=target,
-            past_covariates=past_covariates,
-            future_covariates=future_covariates,
-            n=n,
-            input_chunk_length=self.input_chunk_length,
-            output_chunk_length=self.output_chunk_length,
-            use_static_covariates=self.uses_static_covariates,
         )
 
     @property

--- a/darts/tests/base_test_class.py
+++ b/darts/tests/base_test_class.py
@@ -5,6 +5,7 @@ import unittest
 
 # Print something for all tests taking longer than this
 DURATION_THRESHOLD = 2.0
+tfm_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
 
 
 class DartsBaseTestClass(unittest.TestCase):

--- a/darts/tests/base_test_class.py
+++ b/darts/tests/base_test_class.py
@@ -5,6 +5,7 @@ import unittest
 
 # Print something for all tests taking longer than this
 DURATION_THRESHOLD = 2.0
+# prevent PyTorch Lightning from using GPU (M1 system compatibility)
 tfm_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
 
 

--- a/darts/tests/explainability/test_tft_explainer.py
+++ b/darts/tests/explainability/test_tft_explainer.py
@@ -26,8 +26,6 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TFTExplainerTestCase(DartsBaseTestClass):
-        # for running locally on M1 devices
-
         freq = "MS"
         series_lin_pos = tg.linear_timeseries(
             length=10, freq=freq
@@ -376,7 +374,7 @@ if TORCH_AVAILABLE:
                 },
                 index=[0],
             )
-            # M1 gives slightly differently from intel-based
+            # relaxed comparison because M1 chip gives slightly different results than intel chip
             assert ((enc_imp.round(decimals=1) - enc_expected).abs() <= 3).all().all()
 
             dec_expected = pd.DataFrame(
@@ -388,12 +386,13 @@ if TORCH_AVAILABLE:
                 },
                 index=[0],
             )
-            # M1 gives slightly differently from intel-based
+            # relaxed comparison because M1 chip gives slightly different results than intel chip
             assert ((dec_imp.round(decimals=1) - dec_expected).abs() <= 0.6).all().all()
 
             stc_expected = pd.DataFrame(
                 {"num_statcov": 11.9, "cat_statcov": 88.1}, index=[0]
             )
+            # relaxed comparison because M1 chip gives slightly different results than intel chip
             assert ((stc_imp.round(decimals=1) - stc_expected).abs() <= 0.1).all().all()
 
             with patch("matplotlib.pyplot.show") as _:
@@ -441,7 +440,7 @@ if TORCH_AVAILABLE:
                 results = explainer.explain()
 
                 att = results.get_attention()
-                # M1 gives slightly differently from intel-based
+                # relaxed comparison because M1 chip gives slightly different results than intel chip
                 assert np.all(
                     np.abs(np.round(att.values(), decimals=1) - att_exp) <= 0.2
                 )

--- a/darts/tests/explainability/test_tft_explainer.py
+++ b/darts/tests/explainability/test_tft_explainer.py
@@ -8,7 +8,7 @@ import pytest
 
 from darts import TimeSeries
 from darts.logging import get_logger
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -27,7 +27,6 @@ if TORCH_AVAILABLE:
 
     class TFTExplainerTestCase(DartsBaseTestClass):
         # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
 
         freq = "MS"
         series_lin_pos = tg.linear_timeseries(
@@ -494,5 +493,5 @@ if TORCH_AVAILABLE:
                 add_relative_index=add_relative_idx,
                 full_attention=full_attention,
                 random_state=42,
-                **self.model_kwargs
+                **tfm_kwargs
             )

--- a/darts/tests/models/forecasting/test_TCN.py
+++ b/darts/tests/models/forecasting/test_TCN.py
@@ -36,14 +36,22 @@ if TORCH_AVAILABLE:
 
             # Test basic fit and predict
             model = TCNModel(
-                input_chunk_length=12, output_chunk_length=1, n_epochs=10, num_layers=1
+                input_chunk_length=12,
+                output_chunk_length=1,
+                n_epochs=10,
+                num_layers=1,
+                **self.model_kwargs
             )
             model.fit(large_ts[:98])
             pred = model.predict(n=2).values()[0]
 
             # Test whether model trained on one series is better than one trained on another
             model2 = TCNModel(
-                input_chunk_length=12, output_chunk_length=1, n_epochs=10, num_layers=1
+                input_chunk_length=12,
+                output_chunk_length=1,
+                n_epochs=10,
+                num_layers=1,
+                **self.model_kwargs
             )
             model2.fit(small_ts[:98])
             pred2 = model2.predict(n=2).values()[0]
@@ -64,6 +72,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=10,
                 n_epochs=300,
                 random_state=0,
+                **self.model_kwargs
             )
             model.fit(train)
             pred = model.predict(n=10)
@@ -91,6 +100,7 @@ if TORCH_AVAILABLE:
                             dilation_base=dilation_base,
                             weight_norm=False,
                             n_epochs=1,
+                            **self.model_kwargs
                         )
 
                         # we have to fit the model on a dummy series in order to create the internal nn.Module
@@ -138,6 +148,7 @@ if TORCH_AVAILABLE:
                             weight_norm=False,
                             num_layers=model.model.num_layers - 1,
                             n_epochs=1,
+                            **self.model_kwargs
                         )
 
                         # we have to fit the model on a dummy series in order to create the internal nn.Module
@@ -184,7 +195,10 @@ if TORCH_AVAILABLE:
 
         def helper_test_pred_length(self, pytorch_model, series):
             model = pytorch_model(
-                input_chunk_length=12, output_chunk_length=3, n_epochs=1
+                input_chunk_length=12,
+                output_chunk_length=3,
+                n_epochs=1,
+                **self.model_kwargs
             )
             model.fit(series)
             pred = model.predict(7)

--- a/darts/tests/models/forecasting/test_TCN.py
+++ b/darts/tests/models/forecasting/test_TCN.py
@@ -21,6 +21,9 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TCNModelTestCase(DartsBaseTestClass):
+        # for running locally on M1 devices
+        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
+
         def test_creation(self):
             with self.assertRaises(ValueError):
                 # cannot choose a kernel size larger than the input length

--- a/darts/tests/models/forecasting/test_TCN.py
+++ b/darts/tests/models/forecasting/test_TCN.py
@@ -2,7 +2,7 @@ import pytest
 
 from darts.logging import get_logger
 from darts.metrics import mae
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -21,9 +21,6 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TCNModelTestCase(DartsBaseTestClass):
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
-
         def test_creation(self):
             with self.assertRaises(ValueError):
                 # cannot choose a kernel size larger than the input length
@@ -40,7 +37,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 n_epochs=10,
                 num_layers=1,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(large_ts[:98])
             pred = model.predict(n=2).values()[0]
@@ -51,7 +48,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 n_epochs=10,
                 num_layers=1,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model2.fit(small_ts[:98])
             pred2 = model2.predict(n=2).values()[0]
@@ -72,7 +69,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=10,
                 n_epochs=300,
                 random_state=0,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(train)
             pred = model.predict(n=10)
@@ -100,7 +97,7 @@ if TORCH_AVAILABLE:
                             dilation_base=dilation_base,
                             weight_norm=False,
                             n_epochs=1,
-                            **self.model_kwargs
+                            **tfm_kwargs
                         )
 
                         # we have to fit the model on a dummy series in order to create the internal nn.Module
@@ -148,7 +145,7 @@ if TORCH_AVAILABLE:
                             weight_norm=False,
                             num_layers=model.model.num_layers - 1,
                             n_epochs=1,
-                            **self.model_kwargs
+                            **tfm_kwargs
                         )
 
                         # we have to fit the model on a dummy series in order to create the internal nn.Module
@@ -195,10 +192,7 @@ if TORCH_AVAILABLE:
 
         def helper_test_pred_length(self, pytorch_model, series):
             model = pytorch_model(
-                input_chunk_length=12,
-                output_chunk_length=3,
-                n_epochs=1,
-                **self.model_kwargs
+                input_chunk_length=12, output_chunk_length=3, n_epochs=1, **tfm_kwargs
             )
             model.fit(series)
             pred = model.predict(7)

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -28,6 +28,8 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TFTModelTestCase(DartsBaseTestClass):
+        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
+
         def test_quantile_regression(self):
             q_no_50 = [0.1, 0.4, 0.9]
             q_non_symmetric = [0.2, 0.5, 0.9]
@@ -45,7 +47,9 @@ if TORCH_AVAILABLE:
             ts_integer_index = TimeSeries.from_values(values=ts_time_index.values())
 
             # model requires future covariates without cyclic encoding
-            model = TFTModel(input_chunk_length=1, output_chunk_length=1)
+            model = TFTModel(
+                input_chunk_length=1, output_chunk_length=1, **self.model_kwargs
+            )
             with self.assertRaises(ValueError):
                 model.fit(ts_time_index, verbose=False)
 
@@ -54,12 +58,16 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour"}},
+                **self.model_kwargs
             )
             model.fit(ts_time_index, verbose=False)
 
             # should work with relative index both with time index and integer index
             model = TFTModel(
-                input_chunk_length=1, output_chunk_length=1, add_relative_index=True
+                input_chunk_length=1,
+                output_chunk_length=1,
+                add_relative_index=True,
+                **self.model_kwargs
             )
             model.fit(ts_time_index, verbose=False)
             model.fit(ts_integer_index, verbose=False)
@@ -92,6 +100,7 @@ if TORCH_AVAILABLE:
                 "loss_fn": MSELoss(),
                 "random_state": 42,
             }
+            kwargs_TFT_quick_test = dict(kwargs_TFT_quick_test, **self.model_kwargs)
 
             # univariate
             first_var = ts.columns[0]
@@ -156,6 +165,9 @@ if TORCH_AVAILABLE:
                 "random_state": 42,
                 "add_encoders": {"cyclic": {"future": "hour"}},
             }
+            kwargs_TFT_full_coverage = dict(
+                kwargs_TFT_full_coverage, **self.model_kwargs
+            )
 
             self.helper_test_prediction_accuracy(
                 season_length,
@@ -187,7 +199,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=4,
                 add_encoders={"cyclic": {"future": "hour"}},
                 categorical_embedding_sizes={"cat1": 2, "cat2": (2, 2)},
-                pl_trainer_kwargs={"fast_dev_run": True},
+                pl_trainer_kwargs={"fast_dev_run": True, "accelerator": "cpu"},
             )
             model.fit(target_multi, verbose=False)
 
@@ -237,6 +249,7 @@ if TORCH_AVAILABLE:
                 use_static_covariates=False,
                 add_relative_index=True,
                 n_epochs=1,
+                **self.model_kwargs
             )
             model.fit(target_multi)
             preds = model.predict(n=2, series=target_multi.with_static_covariates(None))
@@ -248,6 +261,7 @@ if TORCH_AVAILABLE:
                 use_static_covariates=False,
                 add_relative_index=True,
                 n_epochs=1,
+                **self.model_kwargs
             )
             model.fit(target_multi.with_static_covariates(None))
             preds = model.predict(n=2, series=target_multi)
@@ -395,6 +409,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_relative_index=True,
                 norm_type="RMSNorm",
+                **self.model_kwargs
             )
             model1.fit(series, epochs=1)
 
@@ -403,6 +418,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_relative_index=True,
                 norm_type=nn.LayerNorm,
+                **self.model_kwargs
             )
             model2.fit(series, epochs=1)
 
@@ -412,5 +428,6 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     add_relative_index=True,
                     norm_type="invalid",
+                    **self.model_kwargs
                 )
                 model4.fit(series, epochs=1)

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -194,9 +194,9 @@ if TORCH_AVAILABLE:
                 add_encoders={"cyclic": {"future": "hour"}},
                 categorical_embedding_sizes={"cat1": 2, "cat2": (2, 2)},
                 pl_trainer_kwargs={
-                        "fast_dev_run": True,
-                        **tfm_kwargs["pl_trainer_kwargs"],
-                    }
+                    "fast_dev_run": True,
+                    **tfm_kwargs["pl_trainer_kwargs"],
+                },
             )
             model.fit(target_multi, verbose=False)
 

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -193,7 +193,10 @@ if TORCH_AVAILABLE:
                 output_chunk_length=4,
                 add_encoders={"cyclic": {"future": "hour"}},
                 categorical_embedding_sizes={"cat1": 2, "cat2": (2, 2)},
-                pl_trainer_kwargs={"fast_dev_run": True, "accelerator": "cpu"},
+                pl_trainer_kwargs={
+                        "fast_dev_run": True,
+                        **tfm_kwargs["pl_trainer_kwargs"],
+                    }
             )
             model.fit(target_multi, verbose=False)
 

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -5,7 +5,7 @@ import pytest
 from darts import TimeSeries, concatenate
 from darts.dataprocessing.transformers import Scaler
 from darts.logging import get_logger
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -28,9 +28,6 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TFTModelTestCase(DartsBaseTestClass):
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
-
         def test_quantile_regression(self):
             q_no_50 = [0.1, 0.4, 0.9]
             q_non_symmetric = [0.2, 0.5, 0.9]
@@ -48,9 +45,7 @@ if TORCH_AVAILABLE:
             ts_integer_index = TimeSeries.from_values(values=ts_time_index.values())
 
             # model requires future covariates without cyclic encoding
-            model = TFTModel(
-                input_chunk_length=1, output_chunk_length=1, **self.model_kwargs
-            )
+            model = TFTModel(input_chunk_length=1, output_chunk_length=1, **tfm_kwargs)
             with self.assertRaises(ValueError):
                 model.fit(ts_time_index, verbose=False)
 
@@ -59,7 +54,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour"}},
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(ts_time_index, verbose=False)
 
@@ -68,7 +63,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 add_relative_index=True,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(ts_time_index, verbose=False)
             model.fit(ts_integer_index, verbose=False)
@@ -101,7 +96,7 @@ if TORCH_AVAILABLE:
                 "loss_fn": MSELoss(),
                 "random_state": 42,
             }
-            kwargs_TFT_quick_test = dict(kwargs_TFT_quick_test, **self.model_kwargs)
+            kwargs_TFT_quick_test = dict(kwargs_TFT_quick_test, **tfm_kwargs)
 
             # univariate
             first_var = ts.columns[0]
@@ -166,9 +161,7 @@ if TORCH_AVAILABLE:
                 "random_state": 42,
                 "add_encoders": {"cyclic": {"future": "hour"}},
             }
-            kwargs_TFT_full_coverage = dict(
-                kwargs_TFT_full_coverage, **self.model_kwargs
-            )
+            kwargs_TFT_full_coverage = dict(kwargs_TFT_full_coverage, **tfm_kwargs)
 
             self.helper_test_prediction_accuracy(
                 season_length,
@@ -250,7 +243,7 @@ if TORCH_AVAILABLE:
                 use_static_covariates=False,
                 add_relative_index=True,
                 n_epochs=1,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(target_multi)
             preds = model.predict(n=2, series=target_multi.with_static_covariates(None))
@@ -262,7 +255,7 @@ if TORCH_AVAILABLE:
                 use_static_covariates=False,
                 add_relative_index=True,
                 n_epochs=1,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(target_multi.with_static_covariates(None))
             preds = model.predict(n=2, series=target_multi)
@@ -410,7 +403,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_relative_index=True,
                 norm_type="RMSNorm",
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model1.fit(series, epochs=1)
 
@@ -419,7 +412,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_relative_index=True,
                 norm_type=nn.LayerNorm,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model2.fit(series, epochs=1)
 
@@ -429,6 +422,6 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     add_relative_index=True,
                     norm_type="invalid",
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model4.fit(series, epochs=1)

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -28,6 +28,7 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TFTModelTestCase(DartsBaseTestClass):
+        # for running locally on M1 devices
         model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
 
         def test_quantile_regression(self):

--- a/darts/tests/models/forecasting/test_backtesting.py
+++ b/darts/tests/models/forecasting/test_backtesting.py
@@ -102,6 +102,8 @@ def compare_best_against_random(model_class, params, series, stride=1):
 
 
 class BacktestingTestCase(DartsBaseTestClass):
+    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
+
     def test_backtest_forecasting(self):
         linear_series = lt(length=50)
         linear_series_int = TimeSeries.from_values(linear_series.values())
@@ -231,7 +233,11 @@ class BacktestingTestCase(DartsBaseTestClass):
         # multivariate model + univariate series
         if TORCH_AVAILABLE:
             tcn_model = TCNModel(
-                input_chunk_length=12, output_chunk_length=1, batch_size=1, n_epochs=1
+                input_chunk_length=12,
+                output_chunk_length=1,
+                batch_size=1,
+                n_epochs=1,
+                **self.torch_model_kwargs
             )
             # cannot perform historical forecasts with `retrain=False` and untrained model
             with pytest.raises(ValueError):
@@ -265,7 +271,11 @@ class BacktestingTestCase(DartsBaseTestClass):
 
             # univariate model
             tcn_model = TCNModel(
-                input_chunk_length=12, output_chunk_length=1, batch_size=1, n_epochs=1
+                input_chunk_length=12,
+                output_chunk_length=1,
+                batch_size=1,
+                n_epochs=1,
+                **self.torch_model_kwargs
             )
             tcn_model.fit(linear_series, verbose=False)
             # univariate fitted model + multivariate series
@@ -279,7 +289,11 @@ class BacktestingTestCase(DartsBaseTestClass):
                 )
 
             tcn_model = TCNModel(
-                input_chunk_length=12, output_chunk_length=3, batch_size=1, n_epochs=1
+                input_chunk_length=12,
+                output_chunk_length=3,
+                batch_size=1,
+                n_epochs=1,
+                **self.torch_model_kwargs
             )
             pred = tcn_model.historical_forecasts(
                 linear_series_multi,
@@ -588,6 +602,7 @@ class BacktestingTestCase(DartsBaseTestClass):
                     "output_chunk_length": [1, 3],
                     "n_epochs": [1, 5],
                     "random_state": [rng_seed],
+                    "pl_trainer_kwargs": [self.torch_model_kwargs["pl_trainer_kwargs"]],
                 },
             },
         ]
@@ -620,5 +635,6 @@ class BacktestingTestCase(DartsBaseTestClass):
             "n_epochs": [1],
             "batch_size": [1],
             "kernel_size": [2, 3, 4],
+            "pl_trainer_kwargs": [self.torch_model_kwargs["pl_trainer_kwargs"]],
         }
         TCNModel.gridsearch(tcn_params, dummy_series, forecast_horizon=3, metric=mape)

--- a/darts/tests/models/forecasting/test_backtesting.py
+++ b/darts/tests/models/forecasting/test_backtesting.py
@@ -18,7 +18,7 @@ from darts.models import (
     NaiveSeasonal,
     Theta,
 )
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils.timeseries_generation import gaussian_timeseries as gt
 from darts.utils.timeseries_generation import linear_timeseries as lt
 from darts.utils.timeseries_generation import random_walk_timeseries as rt
@@ -102,8 +102,6 @@ def compare_best_against_random(model_class, params, series, stride=1):
 
 
 class BacktestingTestCase(DartsBaseTestClass):
-    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
-
     def test_backtest_forecasting(self):
         linear_series = lt(length=50)
         linear_series_int = TimeSeries.from_values(linear_series.values())
@@ -237,7 +235,7 @@ class BacktestingTestCase(DartsBaseTestClass):
                 output_chunk_length=1,
                 batch_size=1,
                 n_epochs=1,
-                **self.torch_model_kwargs
+                **tfm_kwargs
             )
             # cannot perform historical forecasts with `retrain=False` and untrained model
             with pytest.raises(ValueError):
@@ -275,7 +273,7 @@ class BacktestingTestCase(DartsBaseTestClass):
                 output_chunk_length=1,
                 batch_size=1,
                 n_epochs=1,
-                **self.torch_model_kwargs
+                **tfm_kwargs
             )
             tcn_model.fit(linear_series, verbose=False)
             # univariate fitted model + multivariate series
@@ -293,7 +291,7 @@ class BacktestingTestCase(DartsBaseTestClass):
                 output_chunk_length=3,
                 batch_size=1,
                 n_epochs=1,
-                **self.torch_model_kwargs
+                **tfm_kwargs
             )
             pred = tcn_model.historical_forecasts(
                 linear_series_multi,
@@ -602,7 +600,7 @@ class BacktestingTestCase(DartsBaseTestClass):
                     "output_chunk_length": [1, 3],
                     "n_epochs": [1, 5],
                     "random_state": [rng_seed],
-                    "pl_trainer_kwargs": [self.torch_model_kwargs["pl_trainer_kwargs"]],
+                    "pl_trainer_kwargs": [tfm_kwargs["pl_trainer_kwargs"]],
                 },
             },
         ]
@@ -635,6 +633,6 @@ class BacktestingTestCase(DartsBaseTestClass):
             "n_epochs": [1],
             "batch_size": [1],
             "kernel_size": [2, 3, 4],
-            "pl_trainer_kwargs": [self.torch_model_kwargs["pl_trainer_kwargs"]],
+            "pl_trainer_kwargs": [tfm_kwargs["pl_trainer_kwargs"]],
         }
         TCNModel.gridsearch(tcn_params, dummy_series, forecast_horizon=3, metric=mape)

--- a/darts/tests/models/forecasting/test_block_RNN.py
+++ b/darts/tests/models/forecasting/test_block_RNN.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from darts import TimeSeries
 from darts.logging import get_logger
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 
 logger = get_logger(__name__)
 
@@ -22,8 +22,6 @@ if TORCH_AVAILABLE:
 
     class BlockRNNModelTestCase(DartsBaseTestClass):
         __test__ = True
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         times = pd.date_range("20130101", "20130410")
         pd_series = pd.Series(range(100), index=times)
         series: TimeSeries = TimeSeries.from_series(pd_series)
@@ -64,10 +62,7 @@ if TORCH_AVAILABLE:
         def test_fit(self):
             # Test basic fit()
             model = BlockRNNModel(
-                input_chunk_length=1,
-                output_chunk_length=1,
-                n_epochs=2,
-                **self.model_kwargs
+                input_chunk_length=1, output_chunk_length=1, n_epochs=2, **tfm_kwargs
             )
             model.fit(self.series)
 
@@ -81,7 +76,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 save_checkpoints=True,
                 force_reset=True,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model2.fit(self.series)
             model_loaded = model2.load_from_checkpoint(
@@ -102,7 +97,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 model="RNN",
                 n_epochs=2,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model3.fit(self.series)
             pred3 = model3.predict(n=6)
@@ -119,10 +114,7 @@ if TORCH_AVAILABLE:
 
         def helper_test_pred_length(self, pytorch_model, series):
             model = pytorch_model(
-                input_chunk_length=1,
-                output_chunk_length=3,
-                n_epochs=1,
-                **self.model_kwargs
+                input_chunk_length=1, output_chunk_length=3, n_epochs=1, **tfm_kwargs
             )
             model.fit(series)
             pred = model.predict(7)

--- a/darts/tests/models/forecasting/test_block_RNN.py
+++ b/darts/tests/models/forecasting/test_block_RNN.py
@@ -64,7 +64,10 @@ if TORCH_AVAILABLE:
         def test_fit(self):
             # Test basic fit()
             model = BlockRNNModel(
-                input_chunk_length=1, output_chunk_length=1, n_epochs=2
+                input_chunk_length=1,
+                output_chunk_length=1,
+                n_epochs=2,
+                **self.model_kwargs
             )
             model.fit(self.series)
 
@@ -78,12 +81,14 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 save_checkpoints=True,
                 force_reset=True,
+                **self.model_kwargs
             )
             model2.fit(self.series)
             model_loaded = model2.load_from_checkpoint(
                 model_name="unittest-model-lstm",
                 work_dir=self.temp_work_dir,
                 best=False,
+                map_location="cpu",
             )
             pred1 = model2.predict(n=6)
             pred2 = model_loaded.predict(n=6)
@@ -93,7 +98,11 @@ if TORCH_AVAILABLE:
 
             # Another random model should not
             model3 = BlockRNNModel(
-                input_chunk_length=1, output_chunk_length=1, model="RNN", n_epochs=2
+                input_chunk_length=1,
+                output_chunk_length=1,
+                model="RNN",
+                n_epochs=2,
+                **self.model_kwargs
             )
             model3.fit(self.series)
             pred3 = model3.predict(n=6)
@@ -110,7 +119,10 @@ if TORCH_AVAILABLE:
 
         def helper_test_pred_length(self, pytorch_model, series):
             model = pytorch_model(
-                input_chunk_length=1, output_chunk_length=3, n_epochs=1
+                input_chunk_length=1,
+                output_chunk_length=3,
+                n_epochs=1,
+                **self.model_kwargs
             )
             model.fit(series)
             pred = model.predict(7)

--- a/darts/tests/models/forecasting/test_block_RNN.py
+++ b/darts/tests/models/forecasting/test_block_RNN.py
@@ -22,6 +22,8 @@ if TORCH_AVAILABLE:
 
     class BlockRNNModelTestCase(DartsBaseTestClass):
         __test__ = True
+        # for running locally on M1 devices
+        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         times = pd.date_range("20130101", "20130410")
         pd_series = pd.Series(range(100), index=times)
         series: TimeSeries = TimeSeries.from_series(pd_series)

--- a/darts/tests/models/forecasting/test_dlinear_nlinear.py
+++ b/darts/tests/models/forecasting/test_dlinear_nlinear.py
@@ -30,6 +30,8 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class DlinearNlinearModelsTestCase(DartsBaseTestClass):
+        # for running locally on M1 devices
+        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         np.random.seed(42)
         torch.manual_seed(42)
 

--- a/darts/tests/models/forecasting/test_dlinear_nlinear.py
+++ b/darts/tests/models/forecasting/test_dlinear_nlinear.py
@@ -73,7 +73,8 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     n_epochs=10,
                     random_state=42,
-                    **kwargs
+                    **kwargs,
+                    **self.model_kwargs
                 )
                 model.fit(large_ts[:98])
                 pred = model.predict(n=2).values()[0]
@@ -84,6 +85,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     n_epochs=10,
                     random_state=42,
+                    **self.model_kwargs
                 )
                 model2.fit(small_ts[:98])
                 pred2 = model2.predict(n=2).values()[0]
@@ -104,7 +106,10 @@ if TORCH_AVAILABLE:
                     n_epochs=1,
                     log_tensorboard=True,
                     work_dir=self.temp_work_dir,
-                    pl_trainer_kwargs={"log_every_n_steps": 1},
+                    pl_trainer_kwargs={
+                        "log_every_n_steps": 1,
+                        **self.model_kwargs["pl_trainer_kwargs"],
+                    },
                 )
                 model.fit(ts)
                 model.predict(n=2)
@@ -123,6 +128,7 @@ if TORCH_AVAILABLE:
                     const_init=False,
                     shared_weights=True,
                     random_state=42,
+                    **self.model_kwargs
                 )
                 model_not_shared = model_cls(
                     input_chunk_length=5,
@@ -131,6 +137,7 @@ if TORCH_AVAILABLE:
                     const_init=False,
                     shared_weights=False,
                     random_state=42,
+                    **self.model_kwargs
                 )
                 model_shared.fit(ts)
                 model_not_shared.fit(ts)
@@ -187,6 +194,7 @@ if TORCH_AVAILABLE:
                     const_init=True,
                     likelihood=lkl,
                     random_state=42,
+                    **self.model_kwargs
                 )
 
                 model.fit(
@@ -259,7 +267,9 @@ if TORCH_AVAILABLE:
             # can only fit models with past/future covariates when shared_weights=False
             for model in [DLinearModel, NLinearModel]:
                 for shared_weights in [True, False]:
-                    model_instance = model(5, 5, shared_weights=shared_weights)
+                    model_instance = model(
+                        5, 5, shared_weights=shared_weights, **self.model_kwargs
+                    )
                     assert model_instance.supports_past_covariates == (
                         not shared_weights
                     )
@@ -281,6 +291,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=6,
                     use_static_covariates=True,
                     n_epochs=1,
+                    **self.model_kwargs
                 )
                 model.fit(series)
                 with pytest.raises(ValueError):
@@ -292,6 +303,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=6,
                     use_static_covariates=False,
                     n_epochs=1,
+                    **self.model_kwargs
                 )
                 model.fit(series)
                 preds = model.predict(n=2, series=series.with_static_covariates(None))
@@ -303,6 +315,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=6,
                     use_static_covariates=False,
                     n_epochs=1,
+                    **self.model_kwargs
                 )
                 model.fit(series.with_static_covariates(None))
                 preds = model.predict(n=2, series=series)

--- a/darts/tests/models/forecasting/test_dlinear_nlinear.py
+++ b/darts/tests/models/forecasting/test_dlinear_nlinear.py
@@ -9,7 +9,7 @@ import pytest
 from darts import concatenate
 from darts.logging import get_logger
 from darts.metrics import rmse
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -30,8 +30,6 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class DlinearNlinearModelsTestCase(DartsBaseTestClass):
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         np.random.seed(42)
         torch.manual_seed(42)
 
@@ -74,7 +72,7 @@ if TORCH_AVAILABLE:
                     n_epochs=10,
                     random_state=42,
                     **kwargs,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(large_ts[:98])
                 pred = model.predict(n=2).values()[0]
@@ -85,7 +83,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     n_epochs=10,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model2.fit(small_ts[:98])
                 pred2 = model2.predict(n=2).values()[0]
@@ -108,7 +106,7 @@ if TORCH_AVAILABLE:
                     work_dir=self.temp_work_dir,
                     pl_trainer_kwargs={
                         "log_every_n_steps": 1,
-                        **self.model_kwargs["pl_trainer_kwargs"],
+                        **tfm_kwargs["pl_trainer_kwargs"],
                     },
                 )
                 model.fit(ts)
@@ -128,7 +126,7 @@ if TORCH_AVAILABLE:
                     const_init=False,
                     shared_weights=True,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model_not_shared = model_cls(
                     input_chunk_length=5,
@@ -137,7 +135,7 @@ if TORCH_AVAILABLE:
                     const_init=False,
                     shared_weights=False,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model_shared.fit(ts)
                 model_not_shared.fit(ts)
@@ -194,7 +192,7 @@ if TORCH_AVAILABLE:
                     const_init=True,
                     likelihood=lkl,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
 
                 model.fit(
@@ -268,7 +266,7 @@ if TORCH_AVAILABLE:
             for model in [DLinearModel, NLinearModel]:
                 for shared_weights in [True, False]:
                     model_instance = model(
-                        5, 5, shared_weights=shared_weights, **self.model_kwargs
+                        5, 5, shared_weights=shared_weights, **tfm_kwargs
                     )
                     assert model_instance.supports_past_covariates == (
                         not shared_weights
@@ -291,7 +289,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=6,
                     use_static_covariates=True,
                     n_epochs=1,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(series)
                 with pytest.raises(ValueError):
@@ -303,7 +301,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=6,
                     use_static_covariates=False,
                     n_epochs=1,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(series)
                 preds = model.predict(n=2, series=series.with_static_covariates(None))
@@ -315,7 +313,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=6,
                     use_static_covariates=False,
                     n_epochs=1,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(series.with_static_covariates(None))
                 preds = model.predict(n=2, series=series)

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -14,7 +14,7 @@ from darts.models import (
     StatsForecastAutoARIMA,
     Theta,
 )
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -36,7 +36,6 @@ def _make_ts(start_value=0, n=100):
 
 
 class EnsembleModelsTestCase(DartsBaseTestClass):
-    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     series1 = tg.sine_timeseries(value_frequency=(1 / 5), value_y_offset=10, length=50)
     series2 = tg.linear_timeseries(length=50)
 
@@ -249,7 +248,7 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
             input_chunk_length=4,
             output_chunk_length=2,
             likelihood=QuantileRegression([0.05, 0.5, 0.95]),
-            **self.torch_model_kwargs
+            **tfm_kwargs
         )
 
         naive_ensemble = NaiveEnsembleModel([m_proba_quantile1, m_proba_quantile2])
@@ -286,7 +285,7 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
             input_chunk_length=4,
             output_chunk_length=2,
             likelihood=QuantileRegression([0.05, 0.5, 0.95]),
-            **self.torch_model_kwargs
+            **tfm_kwargs
         )
 
         multivariate_series = self.series1.stack(self.series2)
@@ -336,9 +335,9 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
     def test_call_predict_global_models_univariate_input_no_covariates(self):
         naive_ensemble = NaiveEnsembleModel(
             [
-                RNNModel(12, n_epochs=1, **self.torch_model_kwargs),
-                TCNModel(10, 2, n_epochs=1, **self.torch_model_kwargs),
-                NBEATSModel(10, 2, n_epochs=1, **self.torch_model_kwargs),
+                RNNModel(12, n_epochs=1, **tfm_kwargs),
+                TCNModel(10, 2, n_epochs=1, **tfm_kwargs),
+                NBEATSModel(10, 2, n_epochs=1, **tfm_kwargs),
             ]
         )
         with self.assertRaises(Exception):
@@ -351,9 +350,9 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
     def test_call_predict_global_models_multivariate_input_no_covariates(self):
         naive_ensemble = NaiveEnsembleModel(
             [
-                RNNModel(12, n_epochs=1, **self.torch_model_kwargs),
-                TCNModel(10, 2, n_epochs=1, **self.torch_model_kwargs),
-                NBEATSModel(10, 2, n_epochs=1, **self.torch_model_kwargs),
+                RNNModel(12, n_epochs=1, **tfm_kwargs),
+                TCNModel(10, 2, n_epochs=1, **tfm_kwargs),
+                NBEATSModel(10, 2, n_epochs=1, **tfm_kwargs),
             ]
         )
         naive_ensemble.fit(self.seq1)
@@ -363,9 +362,9 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
     def test_call_predict_global_models_multivariate_input_with_covariates(self):
         naive_ensemble = NaiveEnsembleModel(
             [
-                RNNModel(12, n_epochs=1, **self.torch_model_kwargs),
-                TCNModel(10, 2, n_epochs=1, **self.torch_model_kwargs),
-                NBEATSModel(10, 2, n_epochs=1, **self.torch_model_kwargs),
+                RNNModel(12, n_epochs=1, **tfm_kwargs),
+                TCNModel(10, 2, n_epochs=1, **tfm_kwargs),
+                NBEATSModel(10, 2, n_epochs=1, **tfm_kwargs),
             ]
         )
         naive_ensemble.fit(self.seq1, self.cov1)
@@ -379,7 +378,7 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
     def test_input_models_mixed(self):
         # NaiveDrift is local, RNNModel is global
         naive_ensemble = NaiveEnsembleModel(
-            [NaiveDrift(), RNNModel(12, n_epochs=1, **self.torch_model_kwargs)]
+            [NaiveDrift(), RNNModel(12, n_epochs=1, **tfm_kwargs)]
         )
         # ensemble is neither local, nor global
         self.assertFalse(naive_ensemble.is_local_ensemble)
@@ -401,7 +400,7 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
 
         # RNN support future covariates only
         mixed_ensemble_one_covs = NaiveEnsembleModel(
-            [NaiveDrift(), RNNModel(12, n_epochs=1, **self.torch_model_kwargs)]
+            [NaiveDrift(), RNNModel(12, n_epochs=1, **tfm_kwargs)]
         )
         with self.assertRaises(ValueError):
             mixed_ensemble_one_covs.fit(self.series1, past_covariates=self.series2)
@@ -411,7 +410,7 @@ class EnsembleModelsTestCase(DartsBaseTestClass):
         mixed_ensemble_future_covs = NaiveEnsembleModel(
             [
                 StatsForecastAutoARIMA(),
-                RNNModel(12, n_epochs=1, **self.torch_model_kwargs),
+                RNNModel(12, n_epochs=1, **tfm_kwargs),
             ]
         )
         mixed_ensemble_future_covs.fit(self.series1, future_covariates=self.series2)

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -157,7 +157,7 @@ if TORCH_AVAILABLE:
 
     class GlobalForecastingModelsTestCase(
         DartsBaseTestClass
-    ):  # for running locally on M1 devices
+    ):
         # forecasting horizon used in runnability tests
         forecasting_horizon = 12
 

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -12,7 +12,7 @@ from darts.dataprocessing.transformers import Scaler
 from darts.datasets import AirPassengersDataset
 from darts.logging import get_logger
 from darts.metrics import mape
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 from darts.utils.timeseries_generation import linear_timeseries
 
@@ -46,7 +46,6 @@ except ImportError:
 
 
 if TORCH_AVAILABLE:
-    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     IN_LEN = 24
     OUT_LEN = 12
     models_cls_kwargs_errs = [
@@ -58,7 +57,7 @@ if TORCH_AVAILABLE:
                 "n_rnn_layers": 1,
                 "batch_size": 32,
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             180.0,
         ),
@@ -69,7 +68,7 @@ if TORCH_AVAILABLE:
                 "hidden_dim": 10,
                 "batch_size": 32,
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             180.0,
         ),
@@ -79,7 +78,7 @@ if TORCH_AVAILABLE:
                 "training_length": 12,
                 "n_epochs": 10,
                 "likelihood": GaussianLikelihood(),
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             80.0,
         ),
@@ -88,7 +87,7 @@ if TORCH_AVAILABLE:
             {
                 "n_epochs": 10,
                 "batch_size": 32,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             240.0,
         ),
@@ -102,7 +101,7 @@ if TORCH_AVAILABLE:
                 "dim_feedforward": 16,
                 "batch_size": 32,
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             180.0,
         ),
@@ -114,7 +113,7 @@ if TORCH_AVAILABLE:
                 "num_layers": 2,
                 "layer_widths": 12,
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             180.0,
         ),
@@ -126,7 +125,7 @@ if TORCH_AVAILABLE:
                 "num_attention_heads": 4,
                 "add_relative_index": True,
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             100.0,
         ),
@@ -134,7 +133,7 @@ if TORCH_AVAILABLE:
             NLinearModel,
             {
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             100,
         ),
@@ -142,7 +141,7 @@ if TORCH_AVAILABLE:
             DLinearModel,
             {
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             100,
         ),
@@ -150,7 +149,7 @@ if TORCH_AVAILABLE:
             TiDEModel,
             {
                 "n_epochs": 10,
-                "pl_trainer_kwargs": torch_model_kwargs["pl_trainer_kwargs"],
+                "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],
             },
             100,
         ),
@@ -238,14 +237,14 @@ if TORCH_AVAILABLE:
                     hidden_dim=10,
                     batch_size=32,
                     n_epochs=10,
-                    **torch_model_kwargs,
+                    **tfm_kwargs,
                 ),
                 TCNModel(
                     input_chunk_length=4,
                     output_chunk_length=3,
                     n_epochs=10,
                     batch_size=32,
-                    **torch_model_kwargs,
+                    **tfm_kwargs,
                 ),
             ]:
                 model_path_str = type(model).__name__
@@ -444,7 +443,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=5,
                 n_epochs=20,
                 random_state=0,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(series=self.target_past)
             long_pred_no_cov = model.predict(n=160)
@@ -454,7 +453,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=5,
                 n_epochs=20,
                 random_state=0,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(series=self.target_past, past_covariates=self.covariates_past)
             long_pred_with_cov = model.predict(n=160, past_covariates=self.covariates)
@@ -472,7 +471,7 @@ if TORCH_AVAILABLE:
                 model.predict(n=166, series=self.ts_pass_train)
 
             # recurrent models can only predict data points for time steps where future covariates are available
-            model = RNNModel(12, n_epochs=1, **torch_model_kwargs)
+            model = RNNModel(12, n_epochs=1, **tfm_kwargs)
             model.fit(series=self.target_past, future_covariates=self.covariates_past)
             model.predict(n=160, future_covariates=self.covariates)
             with self.assertRaises(ValueError):
@@ -499,7 +498,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=10,
                 n_epochs=10,
                 random_state=0,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(series=targets[0], past_covariates=self.covariates_past)
             preds_default = model.predict(
@@ -695,7 +694,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=2,
                 n_epochs=2,
                 batch_size=32,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(ts)
 
@@ -711,7 +710,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=2,
                 n_epochs=2,
                 batch_size=32,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
 
             model.fit(ts, max_samples_per_ts=5)
@@ -731,7 +730,7 @@ if TORCH_AVAILABLE:
                 num_layers=1,
                 layer_widths=2,
                 n_epochs=2,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
 
             res = model.residuals(ts)

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -159,7 +159,6 @@ if TORCH_AVAILABLE:
     class GlobalForecastingModelsTestCase(
         DartsBaseTestClass
     ):  # for running locally on M1 devices
-        torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         # forecasting horizon used in runnability tests
         forecasting_horizon = 12
 
@@ -239,14 +238,14 @@ if TORCH_AVAILABLE:
                     hidden_dim=10,
                     batch_size=32,
                     n_epochs=10,
-                    **self.torch_model_kwargs,
+                    **torch_model_kwargs,
                 ),
                 TCNModel(
                     input_chunk_length=4,
                     output_chunk_length=3,
                     n_epochs=10,
                     batch_size=32,
-                    **self.torch_model_kwargs,
+                    **torch_model_kwargs,
                 ),
             ]:
                 model_path_str = type(model).__name__
@@ -445,7 +444,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=5,
                 n_epochs=20,
                 random_state=0,
-                **self.torch_model_kwargs,
+                **torch_model_kwargs,
             )
             model.fit(series=self.target_past)
             long_pred_no_cov = model.predict(n=160)
@@ -455,7 +454,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=5,
                 n_epochs=20,
                 random_state=0,
-                **self.torch_model_kwargs,
+                **torch_model_kwargs,
             )
             model.fit(series=self.target_past, past_covariates=self.covariates_past)
             long_pred_with_cov = model.predict(n=160, past_covariates=self.covariates)
@@ -473,7 +472,7 @@ if TORCH_AVAILABLE:
                 model.predict(n=166, series=self.ts_pass_train)
 
             # recurrent models can only predict data points for time steps where future covariates are available
-            model = RNNModel(12, n_epochs=1, **self.torch_model_kwargs)
+            model = RNNModel(12, n_epochs=1, **torch_model_kwargs)
             model.fit(series=self.target_past, future_covariates=self.covariates_past)
             model.predict(n=160, future_covariates=self.covariates)
             with self.assertRaises(ValueError):
@@ -500,7 +499,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=10,
                 n_epochs=10,
                 random_state=0,
-                **self.torch_model_kwargs,
+                **torch_model_kwargs,
             )
             model.fit(series=targets[0], past_covariates=self.covariates_past)
             preds_default = model.predict(
@@ -696,7 +695,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=2,
                 n_epochs=2,
                 batch_size=32,
-                **self.torch_model_kwargs,
+                **torch_model_kwargs,
             )
             model.fit(ts)
 
@@ -712,7 +711,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=2,
                 n_epochs=2,
                 batch_size=32,
-                **self.torch_model_kwargs,
+                **torch_model_kwargs,
             )
 
             model.fit(ts, max_samples_per_ts=5)
@@ -732,7 +731,7 @@ if TORCH_AVAILABLE:
                 num_layers=1,
                 layer_widths=2,
                 n_epochs=2,
-                **self.torch_model_kwargs,
+                **torch_model_kwargs,
             )
 
             res = model.residuals(ts)

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -155,9 +155,7 @@ if TORCH_AVAILABLE:
         ),
     ]
 
-    class GlobalForecastingModelsTestCase(
-        DartsBaseTestClass
-    ):
+    class GlobalForecastingModelsTestCase(DartsBaseTestClass):
         # forecasting horizon used in runnability tests
         forecasting_horizon = 12
 

--- a/darts/tests/models/forecasting/test_historical_forecasts.py
+++ b/darts/tests/models/forecasting/test_historical_forecasts.py
@@ -18,7 +18,7 @@ from darts.models import (
     NaiveSeasonal,
     NotImportedModule,
 )
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 try:
@@ -92,7 +92,6 @@ models_reg_cov_cls_kwargs = [
 ]
 
 if TORCH_AVAILABLE:
-    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     IN_LEN = 24
     OUT_LEN = 12
 
@@ -109,7 +108,7 @@ if TORCH_AVAILABLE:
                 "n_rnn_layers": 1,
                 "batch_size": 32,
                 "n_epochs": NB_EPOCH,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             # Min of lags needed and max of lags needed
             (IN_LEN, OUT_LEN),
@@ -123,7 +122,7 @@ if TORCH_AVAILABLE:
                 "hidden_dim": 10,
                 "batch_size": 32,
                 "n_epochs": NB_EPOCH,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             # autoregressive model
             (IN_LEN, 1),
@@ -136,7 +135,7 @@ if TORCH_AVAILABLE:
                 "training_length": 12,
                 "n_epochs": NB_EPOCH,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             (IN_LEN, 1),
             "DualCovariates",
@@ -148,7 +147,7 @@ if TORCH_AVAILABLE:
                 "output_chunk_length": OUT_LEN,
                 "n_epochs": NB_EPOCH,
                 "batch_size": 32,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "PastCovariates",
@@ -165,7 +164,7 @@ if TORCH_AVAILABLE:
                 "dim_feedforward": 16,
                 "batch_size": 32,
                 "n_epochs": NB_EPOCH,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "PastCovariates",
@@ -180,7 +179,7 @@ if TORCH_AVAILABLE:
                 "num_layers": 2,
                 "layer_widths": 12,
                 "n_epochs": NB_EPOCH,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "PastCovariates",
@@ -195,7 +194,7 @@ if TORCH_AVAILABLE:
                 "num_attention_heads": 4,
                 "add_relative_index": True,
                 "n_epochs": NB_EPOCH,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "MixedCovariates",
@@ -206,7 +205,7 @@ if TORCH_AVAILABLE:
                 "input_chunk_length": IN_LEN,
                 "output_chunk_length": OUT_LEN,
                 "n_epochs": NB_EPOCH,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "MixedCovariates",
@@ -217,7 +216,7 @@ if TORCH_AVAILABLE:
                 "input_chunk_length": IN_LEN,
                 "output_chunk_length": OUT_LEN,
                 "n_epochs": NB_EPOCH,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "MixedCovariates",
@@ -1444,7 +1443,7 @@ class HistoricalforecastTestCase(DartsBaseTestClass):
                     output_chunk_length=ocl,
                     n_epochs=1,
                     random_state=42,
-                    **torch_model_kwargs,
+                    **tfm_kwargs,
                 )
 
         for model_type in ["regression", "torch"]:

--- a/darts/tests/models/forecasting/test_historical_forecasts.py
+++ b/darts/tests/models/forecasting/test_historical_forecasts.py
@@ -31,6 +31,7 @@ try:
         RNNModel,
         TCNModel,
         TFTModel,
+        TiDEModel,
         TransformerModel,
     )
     from darts.utils.likelihood_models import GaussianLikelihood, QuantileRegression
@@ -91,6 +92,7 @@ models_reg_cov_cls_kwargs = [
 ]
 
 if TORCH_AVAILABLE:
+    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     IN_LEN = 24
     OUT_LEN = 12
 
@@ -107,6 +109,7 @@ if TORCH_AVAILABLE:
                 "n_rnn_layers": 1,
                 "batch_size": 32,
                 "n_epochs": NB_EPOCH,
+                **torch_model_kwargs,
             },
             # Min of lags needed and max of lags needed
             (IN_LEN, OUT_LEN),
@@ -120,6 +123,7 @@ if TORCH_AVAILABLE:
                 "hidden_dim": 10,
                 "batch_size": 32,
                 "n_epochs": NB_EPOCH,
+                **torch_model_kwargs,
             },
             # autoregressive model
             (IN_LEN, 1),
@@ -132,6 +136,7 @@ if TORCH_AVAILABLE:
                 "training_length": 12,
                 "n_epochs": NB_EPOCH,
                 "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
             },
             (IN_LEN, 1),
             "DualCovariates",
@@ -143,6 +148,7 @@ if TORCH_AVAILABLE:
                 "output_chunk_length": OUT_LEN,
                 "n_epochs": NB_EPOCH,
                 "batch_size": 32,
+                **torch_model_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "PastCovariates",
@@ -159,6 +165,7 @@ if TORCH_AVAILABLE:
                 "dim_feedforward": 16,
                 "batch_size": 32,
                 "n_epochs": NB_EPOCH,
+                **torch_model_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "PastCovariates",
@@ -173,6 +180,7 @@ if TORCH_AVAILABLE:
                 "num_layers": 2,
                 "layer_widths": 12,
                 "n_epochs": NB_EPOCH,
+                **torch_model_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "PastCovariates",
@@ -187,6 +195,7 @@ if TORCH_AVAILABLE:
                 "num_attention_heads": 4,
                 "add_relative_index": True,
                 "n_epochs": NB_EPOCH,
+                **torch_model_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "MixedCovariates",
@@ -197,6 +206,18 @@ if TORCH_AVAILABLE:
                 "input_chunk_length": IN_LEN,
                 "output_chunk_length": OUT_LEN,
                 "n_epochs": NB_EPOCH,
+                **torch_model_kwargs,
+            },
+            (IN_LEN, OUT_LEN),
+            "MixedCovariates",
+        ),
+        (
+            TiDEModel,
+            {
+                "input_chunk_length": IN_LEN,
+                "output_chunk_length": OUT_LEN,
+                "n_epochs": NB_EPOCH,
+                **torch_model_kwargs,
             },
             (IN_LEN, OUT_LEN),
             "MixedCovariates",
@@ -1423,6 +1444,7 @@ class HistoricalforecastTestCase(DartsBaseTestClass):
                     output_chunk_length=ocl,
                     n_epochs=1,
                     random_state=42,
+                    **torch_model_kwargs,
                 )
 
         for model_type in ["regression", "torch"]:

--- a/darts/tests/models/forecasting/test_nbeats_nhits.py
+++ b/darts/tests/models/forecasting/test_nbeats_nhits.py
@@ -22,6 +22,9 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class NbeatsNhitsModelTestCase(DartsBaseTestClass):
+        # for running locally on M1 devices
+        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
+
         def setUp(self):
             self.temp_work_dir = tempfile.mkdtemp(prefix="darts")
 

--- a/darts/tests/models/forecasting/test_nbeats_nhits.py
+++ b/darts/tests/models/forecasting/test_nbeats_nhits.py
@@ -4,7 +4,7 @@ import tempfile
 import numpy as np
 
 from darts.logging import get_logger
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -22,9 +22,6 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class NbeatsNhitsModelTestCase(DartsBaseTestClass):
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
-
         def setUp(self):
             self.temp_work_dir = tempfile.mkdtemp(prefix="darts")
 
@@ -63,7 +60,7 @@ if TORCH_AVAILABLE:
                     num_blocks=1,
                     layer_widths=20,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(large_ts[:98])
                 pred = model.predict(n=2).values()[0]
@@ -77,7 +74,7 @@ if TORCH_AVAILABLE:
                     num_blocks=1,
                     layer_widths=20,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model2.fit(small_ts[:98])
                 pred2 = model2.predict(n=2).values()[0]
@@ -99,7 +96,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     n_epochs=20,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
 
                 model.fit(series_multivariate)
@@ -122,7 +119,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=4,
                     n_epochs=5,
                     random_state=42,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(series_multivariate, past_covariates=series_covariates)
 
@@ -191,7 +188,7 @@ if TORCH_AVAILABLE:
                     generic_architecture=architecture,
                     pl_trainer_kwargs={
                         "log_every_n_steps": 1,
-                        **self.model_kwargs["pl_trainer_kwargs"],
+                        **tfm_kwargs["pl_trainer_kwargs"],
                     },
                 )
                 model.fit(ts)
@@ -210,7 +207,7 @@ if TORCH_AVAILABLE:
                     layer_widths=20,
                     random_state=42,
                     activation="LeakyReLU",
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(ts)
 
@@ -224,6 +221,6 @@ if TORCH_AVAILABLE:
                         layer_widths=20,
                         random_state=42,
                         activation="invalid",
-                        **self.model_kwargs
+                        **tfm_kwargs
                     )
                     model.fit(ts)

--- a/darts/tests/models/forecasting/test_nbeats_nhits.py
+++ b/darts/tests/models/forecasting/test_nbeats_nhits.py
@@ -63,6 +63,7 @@ if TORCH_AVAILABLE:
                     num_blocks=1,
                     layer_widths=20,
                     random_state=42,
+                    **self.model_kwargs
                 )
                 model.fit(large_ts[:98])
                 pred = model.predict(n=2).values()[0]
@@ -76,6 +77,7 @@ if TORCH_AVAILABLE:
                     num_blocks=1,
                     layer_widths=20,
                     random_state=42,
+                    **self.model_kwargs
                 )
                 model2.fit(small_ts[:98])
                 pred2 = model2.predict(n=2).values()[0]
@@ -97,6 +99,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     n_epochs=20,
                     random_state=42,
+                    **self.model_kwargs
                 )
 
                 model.fit(series_multivariate)
@@ -119,6 +122,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=4,
                     n_epochs=5,
                     random_state=42,
+                    **self.model_kwargs
                 )
                 model.fit(series_multivariate, past_covariates=series_covariates)
 
@@ -185,7 +189,10 @@ if TORCH_AVAILABLE:
                     log_tensorboard=True,
                     work_dir=self.temp_work_dir,
                     generic_architecture=architecture,
-                    pl_trainer_kwargs={"log_every_n_steps": 1},
+                    pl_trainer_kwargs={
+                        "log_every_n_steps": 1,
+                        **self.model_kwargs["pl_trainer_kwargs"],
+                    },
                 )
                 model.fit(ts)
                 model.predict(n=2)
@@ -203,6 +210,7 @@ if TORCH_AVAILABLE:
                     layer_widths=20,
                     random_state=42,
                     activation="LeakyReLU",
+                    **self.model_kwargs
                 )
                 model.fit(ts)
 
@@ -216,5 +224,6 @@ if TORCH_AVAILABLE:
                         layer_widths=20,
                         random_state=42,
                         activation="invalid",
+                        **self.model_kwargs
                     )
                     model.fit(ts)

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -1,3 +1,5 @@
+import platform
+
 import numpy as np
 import pytest
 
@@ -30,8 +32,11 @@ try:
         NBEATSModel,
         RNNModel,
         TCNModel,
+        TFTModel,
+        TiDEModel,
         TransformerModel,
     )
+    from darts.models.forecasting.torch_forecasting_model import TorchForecastingModel
     from darts.utils.likelihood_models import (
         BernoulliLikelihood,
         BetaLikelihood,
@@ -93,6 +98,7 @@ models_cls_kwargs_errs += [
 ]
 
 if TORCH_AVAILABLE:
+    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     models_cls_kwargs_errs += [
         (
             RNNModel,
@@ -102,8 +108,9 @@ if TORCH_AVAILABLE:
                 "n_epochs": 20,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
             },
-            1.9,
+            0.04,
         ),
         (
             TCNModel,
@@ -113,8 +120,9 @@ if TORCH_AVAILABLE:
                 "n_epochs": 60,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
             },
-            0.28,
+            0.08,
         ),
         (
             BlockRNNModel,
@@ -124,8 +132,9 @@ if TORCH_AVAILABLE:
                 "n_epochs": 20,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
             },
-            1,
+            0.04,
         ),
         (
             TransformerModel,
@@ -135,8 +144,9 @@ if TORCH_AVAILABLE:
                 "n_epochs": 20,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
             },
-            1,
+            0.2,
         ),
         (
             NBEATSModel,
@@ -146,14 +156,40 @@ if TORCH_AVAILABLE:
                 "n_epochs": 10,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
             },
-            1,
+            0.3,
+        ),
+        (
+            TFTModel,
+            {
+                "input_chunk_length": 10,
+                "output_chunk_length": 5,
+                "n_epochs": 10,
+                "random_state": 0,
+                "add_relative_index": True,
+                "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
+            },
+            0.1,
+        ),
+        (
+            TiDEModel,
+            {
+                "input_chunk_length": 10,
+                "output_chunk_length": 5,
+                "n_epochs": 10,
+                "random_state": 0,
+                "likelihood": GaussianLikelihood(),
+                **torch_model_kwargs,
+            },
+            0.05,
         ),
     ]
 
 
 @pytest.mark.slow
-class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
+class ProbabilisticModelsTestCase(DartsBaseTestClass):
     np.random.seed(0)
 
     constant_ts = tg.constant_timeseries(length=200, value=0.5)
@@ -162,17 +198,22 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
     constant_noisy_multivar_ts = constant_noisy_ts.stack(constant_noisy_ts)
     num_samples = 5
 
+    constant_noisy_ts_short = constant_noisy_ts[:30]
+
     @pytest.mark.slow
     def test_fit_predict_determinism(self):
-
         for model_cls, model_kwargs, _ in models_cls_kwargs_errs:
+            if issubclass(model_cls, TorchForecastingModel):
+                fit_kwargs = {"epochs": 1, "max_samples_per_ts": 3}
+            else:
+                fit_kwargs = {}
             # whether the first predictions of two models initiated with the same random state are the same
             model = model_cls(**model_kwargs)
-            model.fit(self.constant_noisy_ts)
+            model.fit(self.constant_noisy_ts_short, **fit_kwargs)
             pred1 = model.predict(n=10, num_samples=2).values()
 
             model = model_cls(**model_kwargs)
-            model.fit(self.constant_noisy_ts)
+            model.fit(self.constant_noisy_ts_short, **fit_kwargs)
             pred2 = model.predict(n=10, num_samples=2).values()
 
             self.assertTrue((pred1 == pred2).all())
@@ -302,6 +343,7 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
     """ More likelihood tests
     """
     if TORCH_AVAILABLE:
+        runs_on_m1 = platform.processor() == "arm"
         np.random.seed(42)
         torch.manual_seed(42)
 
@@ -318,7 +360,7 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
         bounded_series = TimeSeries.from_values(np.random.beta(2, 5, size=(100, 2)))
         simplex_series = bounded_series["0"].stack(1.0 - bounded_series["0"])
 
-        lkl_series = (
+        lkl_series = [
             (GaussianLikelihood(), real_series, 0.1, 3),
             (PoissonLikelihood(), discrete_pos_series, 2, 2),
             (NegativeBinomialLikelihood(), discrete_pos_series, 0.5, 0.5),
@@ -336,7 +378,7 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
             (LogNormalLikelihood(), real_pos_series, 0.3, 1),
             (WeibullLikelihood(), real_pos_series, 0.2, 2.5),
             (QuantileRegression(), real_series, 0.2, 1),
-        )
+        ]
 
         def test_likelihoods_and_resulting_mean_forecasts(self):
             def _get_avgs(series):
@@ -345,7 +387,9 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
                 )
 
             for lkl, series, diff1, diff2 in self.lkl_series:
-                model = RNNModel(input_chunk_length=5, likelihood=lkl)
+                model = RNNModel(
+                    input_chunk_length=5, likelihood=lkl, **torch_model_kwargs
+                )
                 model.fit(series, epochs=50)
                 pred = model.predict(n=50, num_samples=50)
 
@@ -387,12 +431,15 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
                 (BetaLikelihood(), [0.5, 0.5]),
                 (ExponentialLikelihood(), [1.0]),
                 (GeometricLikelihood(), [0.3]),
-                (CauchyLikelihood(), [0, 1]),
                 (ContinuousBernoulliLikelihood(), [0.4]),
                 (HalfNormalLikelihood(), [1]),
                 (LogNormalLikelihood(), [0, 0.25]),
                 (WeibullLikelihood(), [1, 1.5]),
             ]
+            if not self.runs_on_m1:
+                list_lkl.append(
+                    (CauchyLikelihood(), [0, 1]),
+                )
 
             n_times = 100
             n_comp = 1
@@ -420,9 +467,30 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
 
                 # [DualCovariatesModule, PastCovariatesModule, MixedCovariatesModule]
                 models = [
-                    RNNModel(4, "RNN", likelihood=lkl, n_epochs=1, random_state=seed),
-                    NBEATSModel(4, 1, likelihood=lkl, n_epochs=1, random_state=seed),
-                    DLinearModel(4, 1, likelihood=lkl, n_epochs=1, random_state=seed),
+                    RNNModel(
+                        4,
+                        "RNN",
+                        likelihood=lkl,
+                        n_epochs=1,
+                        random_state=seed,
+                        **torch_model_kwargs,
+                    ),
+                    NBEATSModel(
+                        4,
+                        1,
+                        likelihood=lkl,
+                        n_epochs=1,
+                        random_state=seed,
+                        **torch_model_kwargs,
+                    ),
+                    DLinearModel(
+                        4,
+                        1,
+                        likelihood=lkl,
+                        n_epochs=1,
+                        random_state=seed,
+                        **torch_model_kwargs,
+                    ),
                 ]
 
                 true_lkl_params = np.array(lkl_params)
@@ -483,9 +551,13 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
 
                 # [DualCovariatesModule, PastCovariatesModule, MixedCovariatesModule]
                 models = [
-                    RNNModel(4, "RNN", likelihood=lkl, n_epochs=1),
-                    TCNModel(4, 1, likelihood=lkl, n_epochs=1),
-                    DLinearModel(4, 1, likelihood=lkl, n_epochs=1),
+                    RNNModel(
+                        4, "RNN", likelihood=lkl, n_epochs=1, **torch_model_kwargs
+                    ),
+                    TCNModel(4, 1, likelihood=lkl, n_epochs=1, **torch_model_kwargs),
+                    DLinearModel(
+                        4, 1, likelihood=lkl, n_epochs=1, **torch_model_kwargs
+                    ),
                 ]
 
                 for model in models:
@@ -507,7 +579,10 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
         def test_predict_likelihood_parameters_wrong_args(self):
             # deterministic model
             model = DLinearModel(
-                input_chunk_length=4, output_chunk_length=4, n_epochs=1
+                input_chunk_length=4,
+                output_chunk_length=4,
+                n_epochs=1,
+                **torch_model_kwargs,
             )
             model.fit(self.constant_noisy_ts)
             with self.assertRaises(ValueError):
@@ -518,6 +593,7 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=4,
                 n_epochs=1,
                 likelihood=GaussianLikelihood(),
+                **torch_model_kwargs,
             )
             model.fit(self.constant_noisy_ts)
             # num_samples > 1
@@ -529,7 +605,7 @@ class ProbabilisticTorchModelsTestCase(DartsBaseTestClass):
             model.predict(n=4, num_samples=1, predict_likelihood_parameters=True)
 
         def test_stochastic_inputs(self):
-            model = RNNModel(input_chunk_length=5)
+            model = RNNModel(input_chunk_length=5, **torch_model_kwargs)
             model.fit(self.constant_ts, epochs=2)
 
             # build a stochastic series

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -18,7 +18,7 @@ from darts.models import (
     XGBModel,
 )
 from darts.models.forecasting.forecasting_model import GlobalForecastingModel
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -98,7 +98,6 @@ models_cls_kwargs_errs += [
 ]
 
 if TORCH_AVAILABLE:
-    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     models_cls_kwargs_errs += [
         (
             RNNModel,
@@ -108,7 +107,7 @@ if TORCH_AVAILABLE:
                 "n_epochs": 20,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             0.04,
         ),
@@ -120,7 +119,7 @@ if TORCH_AVAILABLE:
                 "n_epochs": 60,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             0.08,
         ),
@@ -132,7 +131,7 @@ if TORCH_AVAILABLE:
                 "n_epochs": 20,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             0.04,
         ),
@@ -144,7 +143,7 @@ if TORCH_AVAILABLE:
                 "n_epochs": 20,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             0.2,
         ),
@@ -156,7 +155,7 @@ if TORCH_AVAILABLE:
                 "n_epochs": 10,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             0.3,
         ),
@@ -169,7 +168,7 @@ if TORCH_AVAILABLE:
                 "random_state": 0,
                 "add_relative_index": True,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             0.1,
         ),
@@ -181,7 +180,7 @@ if TORCH_AVAILABLE:
                 "n_epochs": 10,
                 "random_state": 0,
                 "likelihood": GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             },
             0.05,
         ),
@@ -387,9 +386,7 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
                 )
 
             for lkl, series, diff1, diff2 in self.lkl_series:
-                model = RNNModel(
-                    input_chunk_length=5, likelihood=lkl, **torch_model_kwargs
-                )
+                model = RNNModel(input_chunk_length=5, likelihood=lkl, **tfm_kwargs)
                 model.fit(series, epochs=50)
                 pred = model.predict(n=50, num_samples=50)
 
@@ -473,7 +470,7 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
                         likelihood=lkl,
                         n_epochs=1,
                         random_state=seed,
-                        **torch_model_kwargs,
+                        **tfm_kwargs,
                     ),
                     NBEATSModel(
                         4,
@@ -481,7 +478,7 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
                         likelihood=lkl,
                         n_epochs=1,
                         random_state=seed,
-                        **torch_model_kwargs,
+                        **tfm_kwargs,
                     ),
                     DLinearModel(
                         4,
@@ -489,7 +486,7 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
                         likelihood=lkl,
                         n_epochs=1,
                         random_state=seed,
-                        **torch_model_kwargs,
+                        **tfm_kwargs,
                     ),
                 ]
 
@@ -551,13 +548,9 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
 
                 # [DualCovariatesModule, PastCovariatesModule, MixedCovariatesModule]
                 models = [
-                    RNNModel(
-                        4, "RNN", likelihood=lkl, n_epochs=1, **torch_model_kwargs
-                    ),
-                    TCNModel(4, 1, likelihood=lkl, n_epochs=1, **torch_model_kwargs),
-                    DLinearModel(
-                        4, 1, likelihood=lkl, n_epochs=1, **torch_model_kwargs
-                    ),
+                    RNNModel(4, "RNN", likelihood=lkl, n_epochs=1, **tfm_kwargs),
+                    TCNModel(4, 1, likelihood=lkl, n_epochs=1, **tfm_kwargs),
+                    DLinearModel(4, 1, likelihood=lkl, n_epochs=1, **tfm_kwargs),
                 ]
 
                 for model in models:
@@ -582,7 +575,7 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
                 input_chunk_length=4,
                 output_chunk_length=4,
                 n_epochs=1,
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(self.constant_noisy_ts)
             with self.assertRaises(ValueError):
@@ -593,7 +586,7 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=4,
                 n_epochs=1,
                 likelihood=GaussianLikelihood(),
-                **torch_model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(self.constant_noisy_ts)
             # num_samples > 1
@@ -605,7 +598,7 @@ class ProbabilisticModelsTestCase(DartsBaseTestClass):
             model.predict(n=4, num_samples=1, predict_likelihood_parameters=True)
 
         def test_stochastic_inputs(self):
-            model = RNNModel(input_chunk_length=5, **torch_model_kwargs)
+            model = RNNModel(input_chunk_length=5, **tfm_kwargs)
             model.fit(self.constant_ts, epochs=2)
 
             # build a stochastic series

--- a/darts/tests/models/forecasting/test_ptl_trainer.py
+++ b/darts/tests/models/forecasting/test_ptl_trainer.py
@@ -4,7 +4,7 @@ import tempfile
 import numpy as np
 
 from darts.logging import get_logger
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils.timeseries_generation import linear_timeseries
 
 logger = get_logger(__name__)
@@ -28,8 +28,6 @@ if TORCH_AVAILABLE:
             "logger": False,
             "enable_checkpointing": False,
         }
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         series = linear_timeseries(length=100).astype(np.float32)
         pl_200_or_above = int(pl.__version__.split(".")[0]) >= 2
         precisions = {
@@ -55,7 +53,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 save_checkpoints=True,
                 random_state=42,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
             # fit model with custom trainer
@@ -64,7 +62,7 @@ if TORCH_AVAILABLE:
                 enable_checkpointing=True,
                 logger=False,
                 callbacks=model.trainer_params["callbacks"],
-                **self.model_kwargs["pl_trainer_kwargs"],
+                **tfm_kwargs["pl_trainer_kwargs"],
             )
             model.fit(self.series, trainer=trainer)
 
@@ -80,14 +78,14 @@ if TORCH_AVAILABLE:
             self.assertEqual(model.predict(n=4), model_loaded.predict(n=4))
 
         def test_prediction_custom_trainer(self):
-            model = RNNModel(12, "RNN", 10, 10, random_state=42, **self.model_kwargs)
-            model2 = RNNModel(12, "RNN", 10, 10, random_state=42, **self.model_kwargs)
+            model = RNNModel(12, "RNN", 10, 10, random_state=42, **tfm_kwargs)
+            model2 = RNNModel(12, "RNN", 10, 10, random_state=42, **tfm_kwargs)
 
             # fit model with custom trainer
             trainer = pl.Trainer(
                 **self.trainer_params,
                 precision=self.precisions[32],
-                **self.model_kwargs["pl_trainer_kwargs"],
+                **tfm_kwargs["pl_trainer_kwargs"],
             )
             model.fit(self.series, trainer=trainer)
 
@@ -98,13 +96,13 @@ if TORCH_AVAILABLE:
             self.assertEqual(model.predict(n=4), model2.predict(n=4))
 
         def test_custom_trainer_setup(self):
-            model = RNNModel(12, "RNN", 10, 10, random_state=42, **self.model_kwargs)
+            model = RNNModel(12, "RNN", 10, 10, random_state=42, **tfm_kwargs)
 
             # trainer with wrong precision should raise ValueError
             trainer = pl.Trainer(
                 **self.trainer_params,
                 precision=self.precisions[64],
-                **self.model_kwargs["pl_trainer_kwargs"],
+                **tfm_kwargs["pl_trainer_kwargs"],
             )
             with self.assertRaises(ValueError):
                 model.fit(self.series, trainer=trainer)
@@ -113,7 +111,7 @@ if TORCH_AVAILABLE:
             trainer = pl.Trainer(
                 **self.trainer_params,
                 precision=self.precisions[32],
-                **self.model_kwargs["pl_trainer_kwargs"],
+                **tfm_kwargs["pl_trainer_kwargs"],
             )
             model.fit(self.series, trainer=trainer)
 
@@ -125,7 +123,7 @@ if TORCH_AVAILABLE:
             with self.assertRaises(TypeError):
                 invalid_trainer_kwarg = {
                     "precisionn": self.precisions[32],
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 }
                 model = RNNModel(
                     12,
@@ -141,7 +139,7 @@ if TORCH_AVAILABLE:
             with self.assertRaises(ValueError):
                 invalid_trainer_kwarg = {
                     "precision": "16-mixed",
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 }
                 model = RNNModel(
                     12,
@@ -157,7 +155,7 @@ if TORCH_AVAILABLE:
             with self.assertRaises(ValueError):
                 invalid_trainer_kwarg = {
                     "precision": self.precisions[64],
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 }
                 model = RNNModel(
                     12,
@@ -172,7 +170,7 @@ if TORCH_AVAILABLE:
             for precision in [64, 32]:
                 valid_trainer_kwargs = {
                     "precision": self.precisions[precision],
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 }
 
                 # valid parameters shouldn't raise error
@@ -210,7 +208,7 @@ if TORCH_AVAILABLE:
                 random_state=42,
                 pl_trainer_kwargs={
                     "callbacks": [my_counter_0, my_counter_2],
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 },
             )
 
@@ -234,7 +232,7 @@ if TORCH_AVAILABLE:
                 save_checkpoints=True,
                 pl_trainer_kwargs={
                     "callbacks": [CounterCallback(0), CounterCallback(2)],
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 },
             )
             # we expect 3 callbacks
@@ -267,7 +265,7 @@ if TORCH_AVAILABLE:
                 random_state=42,
                 pl_trainer_kwargs={
                     "callbacks": [my_stopper],
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 },
             )
 
@@ -289,7 +287,7 @@ if TORCH_AVAILABLE:
                 random_state=42,
                 pl_trainer_kwargs={
                     "callbacks": [my_stopper],
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 },
             )
 

--- a/darts/tests/models/forecasting/test_ptl_trainer.py
+++ b/darts/tests/models/forecasting/test_ptl_trainer.py
@@ -27,8 +27,8 @@ if TORCH_AVAILABLE:
             "max_epochs": 1,
             "logger": False,
             "enable_checkpointing": False,
+            "accelerator": "cpu",  # for running locally on M1 devices
         }
-
         series = linear_timeseries(length=100).astype(np.float32)
         pl_200_or_above = int(pl.__version__.split(".")[0]) >= 2
         precisions = {

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -37,6 +37,7 @@ except ImportError:
 
 
 class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
+    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     RANDOM_SEED = 111
 
     sine_series = tg.sine_timeseries(
@@ -77,12 +78,14 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=output_chunk_length,
                 n_epochs=1,
                 random_state=42,
+                **self.torch_model_kwargs,
             ),
             BlockRNNModel(
                 input_chunk_length=20,
                 output_chunk_length=output_chunk_length,
                 n_epochs=1,
                 random_state=42,
+                **self.torch_model_kwargs,
             ),
         ]
 
@@ -156,10 +159,18 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
     @unittest.skipUnless(TORCH_AVAILABLE, "requires torch")
     def test_torch_models_retrain(self):
         model1 = BlockRNNModel(
-            input_chunk_length=12, output_chunk_length=1, random_state=0, n_epochs=2
+            input_chunk_length=12,
+            output_chunk_length=1,
+            random_state=0,
+            n_epochs=2,
+            **self.torch_model_kwargs,
         )
         model2 = BlockRNNModel(
-            input_chunk_length=12, output_chunk_length=1, random_state=0, n_epochs=2
+            input_chunk_length=12,
+            output_chunk_length=1,
+            random_state=0,
+            n_epochs=2,
+            **self.torch_model_kwargs,
         )
 
         ensemble = RegressionEnsembleModel([model1], 5)
@@ -310,12 +321,14 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
+                **self.torch_model_kwargs,
             ),
             BlockRNNModel(
                 input_chunk_length=20,
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
+                **self.torch_model_kwargs,
             ),
             RegressionModel(lags_past_covariates=[-1]),
         ]
@@ -337,12 +350,14 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
+                **self.torch_model_kwargs,
             ),
             BlockRNNModel(
                 input_chunk_length=20,
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
+                **self.torch_model_kwargs,
             ),
             RegressionModel(lags_past_covariates=[-1]),
             RegressionModel(lags_past_covariates=[-1]),

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -18,7 +18,7 @@ from darts.models import (
     RegressionModel,
     Theta,
 )
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.tests.models.forecasting.test_ensemble_models import _make_ts
 from darts.tests.models.forecasting.test_regression_models import train_test_split
 from darts.utils import timeseries_generation as tg
@@ -37,7 +37,6 @@ except ImportError:
 
 
 class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
-    torch_model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
     RANDOM_SEED = 111
 
     sine_series = tg.sine_timeseries(
@@ -78,14 +77,14 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=output_chunk_length,
                 n_epochs=1,
                 random_state=42,
-                **self.torch_model_kwargs,
+                **tfm_kwargs,
             ),
             BlockRNNModel(
                 input_chunk_length=20,
                 output_chunk_length=output_chunk_length,
                 n_epochs=1,
                 random_state=42,
-                **self.torch_model_kwargs,
+                **tfm_kwargs,
             ),
         ]
 
@@ -163,14 +162,14 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
             output_chunk_length=1,
             random_state=0,
             n_epochs=2,
-            **self.torch_model_kwargs,
+            **tfm_kwargs,
         )
         model2 = BlockRNNModel(
             input_chunk_length=12,
             output_chunk_length=1,
             random_state=0,
             n_epochs=2,
-            **self.torch_model_kwargs,
+            **tfm_kwargs,
         )
 
         ensemble = RegressionEnsembleModel([model1], 5)
@@ -321,14 +320,14 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
-                **self.torch_model_kwargs,
+                **tfm_kwargs,
             ),
             BlockRNNModel(
                 input_chunk_length=20,
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
-                **self.torch_model_kwargs,
+                **tfm_kwargs,
             ),
             RegressionModel(lags_past_covariates=[-1]),
         ]
@@ -350,14 +349,14 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
-                **self.torch_model_kwargs,
+                **tfm_kwargs,
             ),
             BlockRNNModel(
                 input_chunk_length=20,
                 output_chunk_length=horizon,
                 n_epochs=1,
                 random_state=self.RANDOM_SEED,
-                **self.torch_model_kwargs,
+                **tfm_kwargs,
             ),
             RegressionModel(lags_past_covariates=[-1]),
             RegressionModel(lags_past_covariates=[-1]),

--- a/darts/tests/models/forecasting/test_tide_model.py
+++ b/darts/tests/models/forecasting/test_tide_model.py
@@ -27,6 +27,8 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TiDEModelModelTestCase(DartsBaseTestClass):
+        # for running locally on M1 devices
+        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         np.random.seed(42)
         torch.manual_seed(42)
 

--- a/darts/tests/models/forecasting/test_tide_model.py
+++ b/darts/tests/models/forecasting/test_tide_model.py
@@ -56,6 +56,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 n_epochs=10,
                 random_state=42,
+                **self.model_kwargs
             )
 
             model.fit(large_ts[:98])
@@ -67,6 +68,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 n_epochs=10,
                 random_state=42,
+                **self.model_kwargs
             )
 
             model2.fit(small_ts[:98])
@@ -87,7 +89,10 @@ if TORCH_AVAILABLE:
                 n_epochs=1,
                 log_tensorboard=True,
                 work_dir=self.temp_work_dir,
-                pl_trainer_kwargs={"log_every_n_steps": 1},
+                pl_trainer_kwargs={
+                    "log_every_n_steps": 1,
+                    **self.model_kwargs["pl_trainer_kwargs"],
+                },
             )
             model.fit(ts)
             model.predict(n=2)
@@ -100,6 +105,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour"}},
                 use_reversible_instance_norm=False,
+                **self.model_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -108,6 +114,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour"}},
                 use_reversible_instance_norm=True,
+                **self.model_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -118,6 +125,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour", "past": "hour"}},
+                **self.model_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -128,6 +136,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"past": "hour"}},
+                **self.model_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -142,6 +151,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     add_encoders={"cyclic": {"future": "hour", "past": "hour"}},
                     use_reversible_instance_norm=enable_rin,
+                    **self.model_kwargs
                 )
                 model.fit(ts_time_index, ts_time_index, verbose=False, epochs=1)
 
@@ -151,6 +161,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     add_encoders={"cyclic": {"future": "hour", "past": "hour"}},
                     use_reversible_instance_norm=enable_rin,
+                    **self.model_kwargs
                 )
                 model.fit(
                     ts_time_index, ts_time_index, ts_time_index, verbose=False, epochs=1
@@ -173,7 +184,10 @@ if TORCH_AVAILABLE:
                 input_chunk_length=3,
                 output_chunk_length=4,
                 add_encoders={"cyclic": {"future": "hour"}},
-                pl_trainer_kwargs={"fast_dev_run": True},
+                pl_trainer_kwargs={
+                    "fast_dev_run": True,
+                    **self.model_kwargs["pl_trainer_kwargs"],
+                },
             )
             model.fit(target_multi, verbose=False)
 
@@ -200,6 +214,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=4,
                 use_static_covariates=False,
                 n_epochs=1,
+                **self.model_kwargs
             )
             model.fit(target_multi)
             preds = model.predict(n=2, series=target_multi.with_static_covariates(None))
@@ -210,6 +225,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=4,
                 use_static_covariates=False,
                 n_epochs=1,
+                **self.model_kwargs
             )
             model.fit(target_multi.with_static_covariates(None))
             preds = model.predict(n=2, series=target_multi)

--- a/darts/tests/models/forecasting/test_tide_model.py
+++ b/darts/tests/models/forecasting/test_tide_model.py
@@ -7,7 +7,7 @@ import pytest
 
 from darts import concatenate
 from darts.logging import get_logger
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -27,8 +27,6 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TiDEModelModelTestCase(DartsBaseTestClass):
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         np.random.seed(42)
         torch.manual_seed(42)
 
@@ -56,7 +54,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 n_epochs=10,
                 random_state=42,
-                **self.model_kwargs
+                **tfm_kwargs
             )
 
             model.fit(large_ts[:98])
@@ -68,7 +66,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 n_epochs=10,
                 random_state=42,
-                **self.model_kwargs
+                **tfm_kwargs
             )
 
             model2.fit(small_ts[:98])
@@ -91,7 +89,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 pl_trainer_kwargs={
                     "log_every_n_steps": 1,
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 },
             )
             model.fit(ts)
@@ -105,7 +103,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour"}},
                 use_reversible_instance_norm=False,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -114,7 +112,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour"}},
                 use_reversible_instance_norm=True,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -125,7 +123,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"future": "hour", "past": "hour"}},
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -136,7 +134,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 add_encoders={"cyclic": {"past": "hour"}},
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(ts_time_index, verbose=False, epochs=1)
 
@@ -151,7 +149,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     add_encoders={"cyclic": {"future": "hour", "past": "hour"}},
                     use_reversible_instance_norm=enable_rin,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(ts_time_index, ts_time_index, verbose=False, epochs=1)
 
@@ -161,7 +159,7 @@ if TORCH_AVAILABLE:
                     output_chunk_length=1,
                     add_encoders={"cyclic": {"future": "hour", "past": "hour"}},
                     use_reversible_instance_norm=enable_rin,
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model.fit(
                     ts_time_index, ts_time_index, ts_time_index, verbose=False, epochs=1
@@ -186,7 +184,7 @@ if TORCH_AVAILABLE:
                 add_encoders={"cyclic": {"future": "hour"}},
                 pl_trainer_kwargs={
                     "fast_dev_run": True,
-                    **self.model_kwargs["pl_trainer_kwargs"],
+                    **tfm_kwargs["pl_trainer_kwargs"],
                 },
             )
             model.fit(target_multi, verbose=False)
@@ -214,7 +212,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=4,
                 use_static_covariates=False,
                 n_epochs=1,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(target_multi)
             preds = model.predict(n=2, series=target_multi.with_static_covariates(None))
@@ -225,7 +223,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=4,
                 use_static_covariates=False,
                 n_epochs=1,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model.fit(target_multi.with_static_covariates(None))
             preds = model.predict(n=2, series=target_multi)

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -13,7 +13,7 @@ from darts.dataprocessing.encoders import SequentialEncoder
 from darts.dataprocessing.transformers import BoxCox, Scaler
 from darts.logging import get_logger
 from darts.metrics import mape
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils.timeseries_generation import linear_timeseries
 
 logger = get_logger(__name__)
@@ -43,9 +43,6 @@ except ImportError:
 if TORCH_AVAILABLE:
 
     class TestTorchForecastingModel(DartsBaseTestClass):
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
-
         def setUp(self):
             self.temp_work_dir = tempfile.mkdtemp(prefix="darts")
 
@@ -61,7 +58,7 @@ if TORCH_AVAILABLE:
 
         def test_save_model_parameters(self):
             # check if re-created model has same params as original
-            model = RNNModel(12, "RNN", 10, 10, **self.model_kwargs)
+            model = RNNModel(12, "RNN", 10, 10, **tfm_kwargs)
             self.assertTrue(model._model_params, model.untrained_model()._model_params)
 
         @patch(
@@ -77,7 +74,7 @@ if TORCH_AVAILABLE:
                 model_name=model_name,
                 work_dir=self.temp_work_dir,
                 save_checkpoints=False,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             model2 = RNNModel(
                 12,
@@ -88,7 +85,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 force_reset=True,
                 save_checkpoints=False,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
             model1.fit(self.series, epochs=1)
@@ -117,7 +114,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 save_checkpoints=False,
                 random_state=42,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             model_auto_save = RNNModel(
                 12,
@@ -128,7 +125,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 save_checkpoints=True,
                 random_state=42,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
             # save model without training
@@ -246,7 +243,7 @@ if TORCH_AVAILABLE:
                     input_chunk_length=4,
                     output_chunk_length=1,
                     **kwargs,
-                    **self.model_kwargs,
+                    **tfm_kwargs,
                 )
 
             model_dir = os.path.join(self.temp_work_dir)
@@ -295,7 +292,7 @@ if TORCH_AVAILABLE:
                     save_checkpoints=save_checkpoints,
                     random_state=42,
                     force_reset=True,
-                    **self.model_kwargs,
+                    **tfm_kwargs,
                 )
 
             model_dir = os.path.join(self.temp_work_dir)
@@ -560,7 +557,7 @@ if TORCH_AVAILABLE:
                     likelihood=likelihood,
                     random_state=42,
                     force_reset=True,
-                    **self.model_kwargs,
+                    **tfm_kwargs,
                 )
 
             model_dir = os.path.join(self.temp_work_dir)
@@ -654,13 +651,9 @@ if TORCH_AVAILABLE:
                 )
 
         def test_create_instance_new_model_no_name_set(self):
-            RNNModel(
-                12, "RNN", 10, 10, work_dir=self.temp_work_dir, **self.model_kwargs
-            )
+            RNNModel(12, "RNN", 10, 10, work_dir=self.temp_work_dir, **tfm_kwargs)
             # no exception is raised
-            RNNModel(
-                12, "RNN", 10, 10, work_dir=self.temp_work_dir, **self.model_kwargs
-            )
+            RNNModel(12, "RNN", 10, 10, work_dir=self.temp_work_dir, **tfm_kwargs)
             # no exception is raised
 
         def test_create_instance_existing_model_with_name_no_fit(self):
@@ -672,7 +665,7 @@ if TORCH_AVAILABLE:
                 10,
                 work_dir=self.temp_work_dir,
                 model_name=model_name,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             # no exception is raised
 
@@ -683,7 +676,7 @@ if TORCH_AVAILABLE:
                 10,
                 work_dir=self.temp_work_dir,
                 model_name=model_name,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             # no exception is raised
 
@@ -701,7 +694,7 @@ if TORCH_AVAILABLE:
                 10,
                 work_dir=self.temp_work_dir,
                 model_name=model_name,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             # no exception is raised
             # since no fit, there is no data stored for the model, hence `force_reset` does noting
@@ -714,7 +707,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 model_name=model_name,
                 force_reset=True,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             patch_reset_model.assert_not_called()
 
@@ -733,7 +726,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 model_name=model_name,
                 save_checkpoints=True,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             # no exception is raised
 
@@ -748,7 +741,7 @@ if TORCH_AVAILABLE:
                 model_name=model_name,
                 save_checkpoints=True,
                 force_reset=True,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             patch_reset_model.assert_called_once()
 
@@ -765,7 +758,7 @@ if TORCH_AVAILABLE:
                 10,
                 n_epochs=20,
                 work_dir=self.temp_work_dir,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
             model1.fit(self.series)
@@ -781,7 +774,7 @@ if TORCH_AVAILABLE:
                 10,
                 n_epochs=20,
                 work_dir=self.temp_work_dir,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
             model1.fit(self.series)
@@ -799,7 +792,7 @@ if TORCH_AVAILABLE:
                 10,
                 n_epochs=20,
                 work_dir=self.temp_work_dir,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
             # simulate the case that user interrupted training with Ctrl-C after 10 epochs
@@ -818,7 +811,7 @@ if TORCH_AVAILABLE:
                 10,
                 n_epochs=20,
                 work_dir=self.temp_work_dir,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
             # simulate the case that user interrupted training with Ctrl-C after 10 epochs
@@ -843,7 +836,7 @@ if TORCH_AVAILABLE:
                 save_checkpoints=True,
                 model_name=original_model_name,
                 random_state=1,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(ts_training)
             original_preds = model.predict(10)
@@ -859,7 +852,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 model_name=retrained_model_name,
                 random_state=1,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             model_rt.load_weights_from_checkpoint(
                 model_name=original_model_name,
@@ -899,7 +892,7 @@ if TORCH_AVAILABLE:
 
             # raise Exception when trying to pass `weights_only`=True to `torch.load()`
             with self.assertRaises(ValueError):
-                model_rt = RNNModel(12, "RNN", 5, 5, **self.model_kwargs)
+                model_rt = RNNModel(12, "RNN", 5, 5, **tfm_kwargs)
                 model_rt.load_weights_from_checkpoint(
                     model_name=original_model_name,
                     work_dir=self.temp_work_dir,
@@ -923,7 +916,7 @@ if TORCH_AVAILABLE:
                 save_checkpoints=False,
                 model_name=original_model_name,
                 random_state=1,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(ts_training)
             path_manual_save = os.path.join(self.temp_work_dir, "RNN_manual_save.pt")
@@ -941,7 +934,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 model_name=retrained_model_name,
                 random_state=1,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             model_rt.load_weights(path=path_manual_save, map_location="cpu")
 
@@ -1007,7 +1000,7 @@ if TORCH_AVAILABLE:
                 save_checkpoints=True,
                 force_reset=True,
                 loss_fn=torch.nn.L1Loss(),
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
             model.fit(self.series)
 
@@ -1026,7 +1019,7 @@ if TORCH_AVAILABLE:
             # model with one torch_metrics
             pl_trainer_kwargs = dict(
                 {"logger": DummyLogger(), "log_every_n_steps": 1},
-                **self.model_kwargs["pl_trainer_kwargs"],
+                **tfm_kwargs["pl_trainer_kwargs"],
             )
             model = RNNModel(
                 12,
@@ -1073,7 +1066,7 @@ if TORCH_AVAILABLE:
                     10,
                     optimizer_cls=optim_cls,
                     optimizer_kwargs=optim_kwargs,
-                    **self.model_kwargs,
+                    **tfm_kwargs,
                 )
                 # should not raise an error
                 model.fit(self.series, epochs=1)
@@ -1097,7 +1090,7 @@ if TORCH_AVAILABLE:
                     10,
                     lr_scheduler_cls=lr_scheduler_cls,
                     lr_scheduler_kwargs=lr_scheduler_kwargs,
-                    **self.model_kwargs,
+                    **tfm_kwargs,
                 )
                 # should not raise an error
                 model.fit(self.series, epochs=1)
@@ -1122,7 +1115,7 @@ if TORCH_AVAILABLE:
             model_kwargs = {
                 "logger": DummyLogger(),
                 "log_every_n_steps": 1,
-                **self.model_kwargs["pl_trainer_kwargs"],
+                **tfm_kwargs["pl_trainer_kwargs"],
             }
             # test single metric
             model = RNNModel(
@@ -1168,7 +1161,7 @@ if TORCH_AVAILABLE:
             model_kwargs = {
                 "logger": DummyLogger(),
                 "log_every_n_steps": 1,
-                **self.model_kwargs["pl_trainer_kwargs"],
+                **tfm_kwargs["pl_trainer_kwargs"],
             }
             # test single metric
             model = RNNModel(
@@ -1219,14 +1212,14 @@ if TORCH_AVAILABLE:
                     10,
                     n_epochs=1,
                     torch_metrics=torch_metrics,
-                    **self.model_kwargs,
+                    **tfm_kwargs,
                 )
                 model.fit(self.series)
 
         @pytest.mark.slow
         def test_lr_find(self):
             train_series, val_series = self.series[:-40], self.series[-40:]
-            model = RNNModel(12, "RNN", 10, 10, random_state=42, **self.model_kwargs)
+            model = RNNModel(12, "RNN", 10, 10, random_state=42, **tfm_kwargs)
             # find the learning rate
             res = model.lr_find(series=train_series, val_series=val_series, epochs=50)
             assert isinstance(res, _LRFinder)
@@ -1239,7 +1232,7 @@ if TORCH_AVAILABLE:
                 model.predict(n=3, series=self.series)
 
             # check that results are reproducible
-            model = RNNModel(12, "RNN", 10, 10, random_state=42, **self.model_kwargs)
+            model = RNNModel(12, "RNN", 10, 10, random_state=42, **tfm_kwargs)
             res2 = model.lr_find(series=train_series, val_series=val_series, epochs=50)
             assert res.suggestion() == res2.suggestion()
 
@@ -1257,7 +1250,7 @@ if TORCH_AVAILABLE:
                     random_state=42,
                     optimizer_cls=torch.optim.Adam,
                     optimizer_kwargs={"lr": lr},
-                    **self.model_kwargs,
+                    **tfm_kwargs,
                 )
                 model.fit(train_series)
                 scores[lr_name] = mape(
@@ -1351,7 +1344,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 force_reset=True,
                 save_checkpoints=True,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )
 
         def helper_create_DLinearModel(self):
@@ -1362,5 +1355,5 @@ if TORCH_AVAILABLE:
                     "datetime_attribute": {"past": ["hour"], "future": ["month"]}
                 },
                 n_epochs=1,
-                **self.model_kwargs,
+                **tfm_kwargs,
             )

--- a/darts/tests/models/forecasting/test_transformer_model.py
+++ b/darts/tests/models/forecasting/test_transformer_model.py
@@ -32,6 +32,8 @@ if TORCH_AVAILABLE:
 
     class TransformerModelTestCase(DartsBaseTestClass):
         __test__ = True
+        # for running locally on M1 devices
+        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         times = pd.date_range("20130101", "20130410")
         pd_series = pd.Series(range(100), index=times)
         series: TimeSeries = TimeSeries.from_series(pd_series)

--- a/darts/tests/models/forecasting/test_transformer_model.py
+++ b/darts/tests/models/forecasting/test_transformer_model.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from darts import TimeSeries
 from darts.logging import get_logger
-from darts.tests.base_test_class import DartsBaseTestClass
+from darts.tests.base_test_class import DartsBaseTestClass, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -32,8 +32,6 @@ if TORCH_AVAILABLE:
 
     class TransformerModelTestCase(DartsBaseTestClass):
         __test__ = True
-        # for running locally on M1 devices
-        model_kwargs = {"pl_trainer_kwargs": {"accelerator": "cpu"}}
         times = pd.date_range("20130101", "20130410")
         pd_series = pd.Series(range(100), index=times)
         series: TimeSeries = TimeSeries.from_series(pd_series)
@@ -72,7 +70,7 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 save_checkpoints=True,
                 force_reset=True,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model2.fit(self.series)
             model_loaded = model2.load_from_checkpoint(
@@ -89,10 +87,7 @@ if TORCH_AVAILABLE:
 
             # Another random model should not
             model3 = TransformerModel(
-                input_chunk_length=1,
-                output_chunk_length=1,
-                n_epochs=1,
-                **self.model_kwargs
+                input_chunk_length=1, output_chunk_length=1, n_epochs=1, **tfm_kwargs
             )
             model3.fit(self.series)
             pred3 = model3.predict(n=6)
@@ -109,10 +104,7 @@ if TORCH_AVAILABLE:
 
         def helper_test_pred_length(self, pytorch_model, series):
             model = pytorch_model(
-                input_chunk_length=1,
-                output_chunk_length=3,
-                n_epochs=1,
-                **self.model_kwargs
+                input_chunk_length=1, output_chunk_length=3, n_epochs=1, **tfm_kwargs
             )
             model.fit(series)
             pred = model.predict(7)
@@ -134,7 +126,7 @@ if TORCH_AVAILABLE:
                     input_chunk_length=1,
                     output_chunk_length=1,
                     activation="invalid",
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model1.fit(self.series, epochs=1)
 
@@ -143,7 +135,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 activation="gelu",
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model2.fit(self.series, epochs=1)
             assert isinstance(
@@ -158,7 +150,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 activation="SwiGLU",
-                **self.model_kwargs
+                **tfm_kwargs
             )
             model3.fit(self.series, epochs=1)
             assert isinstance(
@@ -175,7 +167,7 @@ if TORCH_AVAILABLE:
 
             # default norm_type is None
             model0 = base_model(
-                input_chunk_length=1, output_chunk_length=1, **self.model_kwargs
+                input_chunk_length=1, output_chunk_length=1, **tfm_kwargs
             )
             y0 = model0.fit(self.series, epochs=1)
 
@@ -183,7 +175,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 norm_type="RMSNorm",
-                **self.model_kwargs
+                **tfm_kwargs
             )
             y1 = model1.fit(self.series, epochs=1)
 
@@ -191,7 +183,7 @@ if TORCH_AVAILABLE:
                 input_chunk_length=1,
                 output_chunk_length=1,
                 norm_type=nn.LayerNorm,
-                **self.model_kwargs
+                **tfm_kwargs
             )
             y2 = model2.fit(self.series, epochs=1)
 
@@ -200,7 +192,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 activation="gelu",
                 norm_type="RMSNorm",
-                **self.model_kwargs
+                **tfm_kwargs
             )
             y3 = model3.fit(self.series, epochs=1)
 
@@ -214,6 +206,6 @@ if TORCH_AVAILABLE:
                     input_chunk_length=1,
                     output_chunk_length=1,
                     norm_type="invalid",
-                    **self.model_kwargs
+                    **tfm_kwargs
                 )
                 model4.fit(self.series, epochs=1)

--- a/darts/tests/models/forecasting/test_transformer_model.py
+++ b/darts/tests/models/forecasting/test_transformer_model.py
@@ -72,12 +72,14 @@ if TORCH_AVAILABLE:
                 work_dir=self.temp_work_dir,
                 save_checkpoints=True,
                 force_reset=True,
+                **self.model_kwargs
             )
             model2.fit(self.series)
             model_loaded = model2.load_from_checkpoint(
                 model_name="unittest-model-transformer",
                 work_dir=self.temp_work_dir,
                 best=False,
+                map_location="cpu",
             )
             pred1 = model2.predict(n=6)
             pred2 = model_loaded.predict(n=6)
@@ -87,7 +89,10 @@ if TORCH_AVAILABLE:
 
             # Another random model should not
             model3 = TransformerModel(
-                input_chunk_length=1, output_chunk_length=1, n_epochs=1
+                input_chunk_length=1,
+                output_chunk_length=1,
+                n_epochs=1,
+                **self.model_kwargs
             )
             model3.fit(self.series)
             pred3 = model3.predict(n=6)
@@ -104,7 +109,10 @@ if TORCH_AVAILABLE:
 
         def helper_test_pred_length(self, pytorch_model, series):
             model = pytorch_model(
-                input_chunk_length=1, output_chunk_length=3, n_epochs=1
+                input_chunk_length=1,
+                output_chunk_length=3,
+                n_epochs=1,
+                **self.model_kwargs
             )
             model.fit(series)
             pred = model.predict(7)
@@ -123,13 +131,19 @@ if TORCH_AVAILABLE:
         def test_activations(self):
             with self.assertRaises(ValueError):
                 model1 = TransformerModel(
-                    input_chunk_length=1, output_chunk_length=1, activation="invalid"
+                    input_chunk_length=1,
+                    output_chunk_length=1,
+                    activation="invalid",
+                    **self.model_kwargs
                 )
                 model1.fit(self.series, epochs=1)
 
             # internal activation function uses PyTorch TransformerEncoderLayer
             model2 = TransformerModel(
-                input_chunk_length=1, output_chunk_length=1, activation="gelu"
+                input_chunk_length=1,
+                output_chunk_length=1,
+                activation="gelu",
+                **self.model_kwargs
             )
             model2.fit(self.series, epochs=1)
             assert isinstance(
@@ -141,7 +155,10 @@ if TORCH_AVAILABLE:
 
             # glue variant FFN uses our custom _FeedForwardEncoderLayer
             model3 = TransformerModel(
-                input_chunk_length=1, output_chunk_length=1, activation="SwiGLU"
+                input_chunk_length=1,
+                output_chunk_length=1,
+                activation="SwiGLU",
+                **self.model_kwargs
             )
             model3.fit(self.series, epochs=1)
             assert isinstance(
@@ -157,16 +174,24 @@ if TORCH_AVAILABLE:
             base_model = TransformerModel
 
             # default norm_type is None
-            model0 = base_model(input_chunk_length=1, output_chunk_length=1)
+            model0 = base_model(
+                input_chunk_length=1, output_chunk_length=1, **self.model_kwargs
+            )
             y0 = model0.fit(self.series, epochs=1)
 
             model1 = base_model(
-                input_chunk_length=1, output_chunk_length=1, norm_type="RMSNorm"
+                input_chunk_length=1,
+                output_chunk_length=1,
+                norm_type="RMSNorm",
+                **self.model_kwargs
             )
             y1 = model1.fit(self.series, epochs=1)
 
             model2 = base_model(
-                input_chunk_length=1, output_chunk_length=1, norm_type=nn.LayerNorm
+                input_chunk_length=1,
+                output_chunk_length=1,
+                norm_type=nn.LayerNorm,
+                **self.model_kwargs
             )
             y2 = model2.fit(self.series, epochs=1)
 
@@ -175,6 +200,7 @@ if TORCH_AVAILABLE:
                 output_chunk_length=1,
                 activation="gelu",
                 norm_type="RMSNorm",
+                **self.model_kwargs
             )
             y3 = model3.fit(self.series, epochs=1)
 
@@ -185,6 +211,9 @@ if TORCH_AVAILABLE:
 
             with self.assertRaises(AttributeError):
                 model4 = base_model(
-                    input_chunk_length=1, output_chunk_length=1, norm_type="invalid"
+                    input_chunk_length=1,
+                    output_chunk_length=1,
+                    norm_type="invalid",
+                    **self.model_kwargs
                 )
                 model4.fit(self.series, epochs=1)


### PR DESCRIPTION
### Summary
Fixes unit tests to run locally on M1 devices
- run all torch models on CPU
  - by default most time series are float64 which is not supported by M1 GPU
  - not all torch functionalities that we use in our TorchForecastingModel are supported on M1 GPU
- fixes a bug in TiDE model where it was not possible to predict with `n < output_chunk_length`