### PR TITLE
Fix/docs optional dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ void docSteps() {
 }
 
 task buildDocs() {
-    dependsOn pip_core, pip_notorch, pip_release, installLocally
+    dependsOn pip_notorch, pip_release, installLocally
     // dependsOn cleanDocs
     doLast {
         docSteps()

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ void docSteps() {
 }
 
 task buildDocs() {
-    dependsOn pip_core, pip_release, installLocally
+    dependsOn pip_core, pip_notorch, pip_release, installLocally
     // dependsOn cleanDocs
     doLast {
         docSteps()


### PR DESCRIPTION
Docs builder did not include "notorch" requirements and consequently excluded the documentation for the affected models.