### PR TITLE
fix: remove dataframe.columns name to avoid error with xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 [Full Changelog](https://github.com/unit8co/darts/compare/0.25.0...master)
 
+### For users of the library:
+
+**Fixed**
+- Fixed a bug with `TimeSeries.from_dataframe()` for dataframe with `df.columns.name`!= `None`. [#1938](https://github.com/unit8co/darts/pull/1938) by [Antoine Madrona](https://github.com/madtoinou).
+
+
 ## [0.25.0](https://github.com/unit8co/darts/tree/0.25.0) (2023-08-04)
 ### For users of the library:
 

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ void docSteps() {
 }
 
 task buildDocs() {
-    dependsOn pip_core, pip_release, installLocally
+    dependsOn pip_notorch, pip_release, installLocally
     // dependsOn cleanDocs
     doLast {
         docSteps()

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -10,7 +10,11 @@ from scipy.stats import kurtosis, skew
 
 from darts import TimeSeries, concatenate
 from darts.tests.base_test_class import DartsBaseTestClass
-from darts.utils.timeseries_generation import constant_timeseries, linear_timeseries
+from darts.utils.timeseries_generation import (
+    constant_timeseries,
+    generate_index,
+    linear_timeseries,
+)
 
 
 class TimeSeriesTestCase(DartsBaseTestClass):
@@ -2201,6 +2205,17 @@ class TimeSeriesFromDataFrameTestCase(DartsBaseTestClass):
 
         with self.assertRaises(AttributeError):
             TimeSeries.from_dataframe(df=df, time_col="Time")
+
+    def test_df_named_columns_index(self):
+        df = pd.DataFrame(
+            data=np.random.randint(0, 10, size=(10, 1)),
+            index=generate_index(start=pd.Timestamp("2000-01-01"), length=10, freq="D"),
+            columns=["y"],
+        ).reset_index()
+        df["id"] = list("AB") * 5
+        df = df.pivot(columns="id", values="y", index="index").reset_index()
+
+        TimeSeries.from_dataframe(df, time_col="index")
 
 
 class SimpleStatisticsTestCase(DartsBaseTestClass):

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -2215,18 +2215,17 @@ class TimeSeriesFromDataFrameTestCase(DartsBaseTestClass):
             index=time_index,
             columns=["y"],
         ).reset_index()
-        df["id"] = list("AB") * 2
-        # df.columns.name = "id"
-        df = df.pivot(columns="id", values="y", index="index").reset_index()
-
-        ts = TimeSeries.from_dataframe(df, time_col="index", fillna_value=-1)
-
+        df.columns.name = "id"
+        ts = TimeSeries.from_dataframe(df, time_col="index")
         exp_ts = TimeSeries.from_times_and_values(
             times=time_index,
-            values=np.array([[0, -1], [-1, 1], [2, -1], [-1, 3]]),
-            columns=pd.Index(["A", "B"]),
+            values=np.array([0, 1, 2, 3]),
+            columns=pd.Index(["y"]),
         )
+        # check that series are exactly identical
         self.assertEqual(ts, exp_ts)
+        # check that the original df was not changed
+        self.assertEqual(df.columns.name, "id")
 
 
 class SimpleStatisticsTestCase(DartsBaseTestClass):

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -2214,13 +2214,14 @@ class TimeSeriesFromDataFrameTestCase(DartsBaseTestClass):
             data=np.arange(4),
             index=time_index,
             columns=["y"],
-        ).reset_index()
+        )
         df.columns.name = "id"
-        ts = TimeSeries.from_dataframe(df, time_col="index")
+        ts = TimeSeries.from_dataframe(df)
+
         exp_ts = TimeSeries.from_times_and_values(
             times=time_index,
-            values=np.array([0, 1, 2, 3]),
-            columns=pd.Index(["y"]),
+            values=np.arange(4),
+            columns=["y"],
         )
         # check that series are exactly identical
         self.assertEqual(ts, exp_ts)

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -2207,15 +2207,26 @@ class TimeSeriesFromDataFrameTestCase(DartsBaseTestClass):
             TimeSeries.from_dataframe(df=df, time_col="Time")
 
     def test_df_named_columns_index(self):
+        time_index = generate_index(
+            start=pd.Timestamp("2000-01-01"), length=4, freq="D", name="index"
+        )
         df = pd.DataFrame(
-            data=np.random.randint(0, 10, size=(10, 1)),
-            index=generate_index(start=pd.Timestamp("2000-01-01"), length=10, freq="D"),
+            data=np.arange(4),
+            index=time_index,
             columns=["y"],
         ).reset_index()
-        df["id"] = list("AB") * 5
+        df["id"] = list("AB") * 2
+        # df.columns.name = "id"
         df = df.pivot(columns="id", values="y", index="index").reset_index()
 
-        TimeSeries.from_dataframe(df, time_col="index")
+        ts = TimeSeries.from_dataframe(df, time_col="index", fillna_value=-1)
+
+        exp_ts = TimeSeries.from_times_and_values(
+            times=time_index,
+            values=np.array([[0, -1], [-1, 1], [2, -1], [-1, 3]]),
+            columns=pd.Index(["A", "B"]),
+        )
+        self.assertEqual(ts, exp_ts)
 
 
 class SimpleStatisticsTestCase(DartsBaseTestClass):

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -710,6 +710,9 @@ class TimeSeries:
         if not time_index.name:
             time_index.name = time_col if time_col else DIMS[0]
 
+        if series_df.columns.name:
+            series_df.columns.name = None
+
         xa = xr.DataArray(
             series_df.values[:, :, np.newaxis],
             dims=(time_index.name,) + DIMS[-2:],


### PR DESCRIPTION
Fixes #1522.

### Summary

xarray constructor raise an error when the `Index` containing the name of the columns has a `name` (which not necessarily the name of the index itself, even if it can be displayed as such). Simply setting this name to `None` solve the problem without impacting the attributes of the generated `TimeSeries`.
