### PR TITLE
Fix/RegressionEnsemble.extreme_lags when models use only covariates lags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 [Full Changelog](https://github.com/unit8co/darts/compare/0.25.0...master)
 
+### For users of the library:
+
+**Fixed**
+- Fixed a bug with `RegressionEnsembleModel.extreme_lags` when the forecasting models have only covariates lags. [#1942](https://github.com/unit8co/darts/pull/1942) by [Antoine Madrona](https://github.com/madtoinou).
+
 ## [0.25.0](https://github.com/unit8co/darts/tree/0.25.0) (2023-08-04)
 ### For users of the library:
 

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -217,7 +217,11 @@ class RegressionEnsembleModel(EnsembleModel):
         Optional[int],
     ]:
         extreme_lags_ = super().extreme_lags
-        return (extreme_lags_[0] - self.train_n_points,) + extreme_lags_[1:]
+        if extreme_lags_[0] is None:
+            return extreme_lags_
+        else:
+            # shift min_target_lag in the past to account for the regression model
+            return (extreme_lags_[0] - self.train_n_points,) + extreme_lags_[1:]
 
     @property
     def output_chunk_length(self) -> int:

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -130,8 +130,8 @@ class RegressionEnsembleModel(EnsembleModel):
 
         raise_if(
             train_n_points_too_big,
-            "`regression_train_n_points` parameter too big (must be smaller or "
-            "equal to the number of points in training_series)",
+            "`regression_train_n_points` parameter too big (must be strictly smaller than "
+            "the number of points in training_series)",
             logger,
         )
 

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -217,10 +217,10 @@ class RegressionEnsembleModel(EnsembleModel):
         Optional[int],
     ]:
         extreme_lags_ = super().extreme_lags
+        # shift min_target_lag in the past to account for the regression model training set
         if extreme_lags_[0] is None:
-            return extreme_lags_
+            return (-self.train_n_points,) + extreme_lags_[1:]
         else:
-            # shift min_target_lag in the past to account for the regression model
             return (extreme_lags_[0] - self.train_n_points,) + extreme_lags_[1:]
 
     @property

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -388,7 +388,7 @@ class RegressionEnsembleModelsTestCase(DartsBaseTestClass):
             regression_train_n_points=train_n_points,
         )
 
-        self.assertEqual(model.extreme_lags, (None, 0, -3, -1, 0, 0))
+        self.assertEqual(model.extreme_lags, (-train_n_points, 0, -3, -1, 0, 0))
 
         # mix of all the lags
         model3 = RandomForest(

--- a/examples/18-TiDE-examples.ipynb
+++ b/examples/18-TiDE-examples.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "- **Learning rate:** The majority of the learning done by a model is in the earlier epochs. As training goes on it is often helpful to reduce the learning rate to fine-tune the model. That being said, it can also lead to significant overfitting.\n",
     "\n",
-    "- **Early stopping:** To avoid overfitting, we can use early stopping. It monitors a metric on the validation set and stops training once the metric is not improving anymore based on custom condition."
+    "- **Early stopping:** To avoid overfitting, we can use early stopping. It monitors a metric on the validation set and stops training once the metric is not improving anymore based on a custom condition."
    ]
   },
   {
@@ -193,7 +193,7 @@
     "# Model configuration\n",
     "Using the already established shared arguments, we can see that the default parameters for NHiTS and TiDE are used. The only exception is that TiDE is tested both with and without [Reversible Instance Normalization](https://openreview.net/forum?id=cGDAkQo1C0p).\n",
     "\n",
-    "We then iterate through the model dictionary and train all of the models. When using early stopping it is important to save checkpoints. This allows for us to continue past the best model configuration and then restore the optimal weights once training has completed."
+    "We then iterate through the model dictionary and train all of the models. When using early stopping it is important to save checkpoints. This allows us to continue past the best model configuration and then restore the optimal weights once training has been completed."
    ]
   },
   {


### PR DESCRIPTION
Fixes #1867.

### Summary

When forecasting models don't use target lags, `RegressionEnsembleModel.extreme_lags` directly returns `EnsembleModel.extreme_lags` instead of subtracting `regression_train_n_points` to `min_target_lags` (which is `None`).