### PR TITLE
Fix tft_explainer to import right module

### DIFF
--- a/darts/explainability/tft_explainer.py
+++ b/darts/explainability/tft_explainer.py
@@ -89,7 +89,7 @@ class TFTExplainer(_ForecastingModelExplainer):
         Examples
         --------
         >>> from darts.datasets import AirPassengersDataset
-        >>> from darts.explainability.shap_explainer import ShapExplainer
+        >>> from darts.explainability.tft_explainer import TFTExplainer
         >>> from darts.models import TFTModel
         >>> series = AirPassengersDataset().load()
         >>> model = TFTModel(


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

In tft_explainer it imports shap instead of tft, nothing crazy

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
