### PR TITLE
Fix/stasforecast 1 6 release

### DIFF
--- a/darts/models/components/statsforecast_utils.py
+++ b/darts/models/components/statsforecast_utils.py
@@ -14,7 +14,7 @@ def create_normal_samples(
     std: float,
     num_samples: int,
     n: int,
-) -> np.array:
+) -> np.ndarray:
     """Generate samples assuming a Normal distribution."""
     samples = np.random.normal(loc=mu, scale=std, size=(num_samples, n)).T
     samples = np.expand_dims(samples, axis=1)

--- a/darts/models/forecasting/sf_auto_arima.py
+++ b/darts/models/forecasting/sf_auto_arima.py
@@ -32,15 +32,11 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
         It is probabilistic, whereas :class:`AutoARIMA` is not.
 
         We refer to the `statsforecast AutoARIMA documentation
-        <https://nixtla.github.io/statsforecast/models.html#arima-methods>`_
-        for the documentation of the arguments.
+        <https://nixtla.github.io/statsforecast/src/core/models.html#autoarima>`_
+        for the exhaustive documentation of the arguments.
 
         Parameters
         ----------
-        autoarima_args
-            Positional arguments for ``statsforecasts.models.AutoARIMA``.
-        autoarima_kwargs
-            Keyword arguments for ``statsforecasts.models.AutoARIMA``.
         add_encoders
             A large number of future covariates can be automatically generated with `add_encoders`.
             This can be done by adding multiple pre-defined index encoders and/or custom user-made functions that
@@ -61,6 +57,10 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
                     'transformer': Scaler()
                 }
             ..
+
+        .. note::
+            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoARIMA`
+            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
 
         Examples
         --------

--- a/darts/models/forecasting/sf_auto_arima.py
+++ b/darts/models/forecasting/sf_auto_arima.py
@@ -37,6 +37,8 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
 
         Parameters
         ----------
+        autoarima_args
+            Positional arguments for ``statsforecasts.models.AutoARIMA``.
         add_encoders
             A large number of future covariates can be automatically generated with `add_encoders`.
             This can be done by adding multiple pre-defined index encoders and/or custom user-made functions that
@@ -57,10 +59,8 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
                     'transformer': Scaler()
                 }
             ..
-
-        .. note::
-            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoARIMA`
-            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
+        autoarima_kwargs
+            Keyword arguments for ``statsforecasts.models.AutoARIMA``.
 
         Examples
         --------

--- a/darts/models/forecasting/sf_auto_ces.py
+++ b/darts/models/forecasting/sf_auto_ces.py
@@ -23,29 +23,17 @@ class StatsForecastAutoCES(LocalForecastingModel):
 
         Parameters
         ----------
-        season_length
-            Number of observations per cycle. Default: 1.
-        model
-            Single-character string identifying kind of CES model:
-
-            * "N" for simple CES without seasonality,
-            * "S" for simple simple seasonality (lagged CES),
-            * "P" for partial seasonality (without complex part),
-            * "F" for full seasonality (lagged CES with both real and complex seasonality).
-
-            Furthermore, the character "Z" is a placeholder telling statsforecast
-            to search for the best parameter. Default: "Z".
-
-        .. note::
-            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoCES`
-            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
+        autoces_args
+            Positional arguments for ``statsforecasts.models.AutoCES``.
+        autoces_kwargs
+            Keyword arguments for ``statsforecasts.models.AutoCES``.
 
         Examples
         --------
         >>> from darts.models import StatsForecastAutoCES
         >>> from darts.datasets import AirPassengersDataset
         >>> series = AirPassengersDataset().load()
-        >>> model = StatsForecastAutoCES(season_length=12)
+        >>> model = StatsForecastAutoCES(season_length=12, model="Z")
         >>> model.fit(series[:-36])
         >>> pred = model.predict(36, num_samples=100)
         """

--- a/darts/models/forecasting/sf_auto_ces.py
+++ b/darts/models/forecasting/sf_auto_ces.py
@@ -18,17 +18,27 @@ class StatsForecastAutoCES(LocalForecastingModel):
         <https://onlinelibrary.wiley.com/doi/full/10.1002/nav.22074>
 
         We refer to the `statsforecast AutoCES documentation
-        <https://nixtla.github.io/statsforecast/models.html#autoces>`_
-        for the documentation of the arguments.
+        <https://nixtla.github.io/statsforecast/src/core/models.html#autoces>`_
+        for the exhaustive documentation of the arguments.
 
         Parameters
         ----------
-        autoces_args
-            Positional arguments for ``statsforecasts.models.AutoCES``.
-        autoces_kwargs
-            Keyword arguments for ``statsforecasts.models.AutoCES``.
+        season_length
+            Number of observations per cycle. Default: 1.
+        model
+            Single-character string identifying kind of CES model:
 
-            ..
+            * "N" for simple CES without seasonality,
+            * "S" for simple simple seasonality (lagged CES),
+            * "P" for partial seasonality (without complex part),
+            * "F" for full seasonality (lagged CES with both real and complex seasonality).
+
+            Furthermore, the character "Z" is a placeholder telling statsforecast
+            to search for the best parameter. Default: "Z".
+
+        .. note::
+            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoCES`
+            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
 
         Examples
         --------

--- a/darts/models/forecasting/sf_auto_ets.py
+++ b/darts/models/forecasting/sf_auto_ets.py
@@ -28,8 +28,9 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         but typically requires more time on the first call, because it relies
         on Numba and jit compilation.
 
-        This model accepts the same arguments as the `statsforecast ETS
-        <https://nixtla.github.io/statsforecast/models.html#ets>`_. package.
+        We refer to the `statsforecast AutoTheta documentation
+        <https://nixtla.github.io/statsforecast/src/core/models.html#autoets>`_
+        for the exhaustive documentation of the arguments.
 
         In addition to the StatsForecast implementation, this model can handle future covariates. It does so by first
         regressing the series against the future covariates using the :class:'LinearRegressionModel' model and then
@@ -46,7 +47,7 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
             terminology of Hyndman et al. (2002). Possible values are:
 
             * "A" or "M" for error state,
-            * "N", "A" or "Ad" for trend state,
+            * "N", "A" or "M" for trend state,
             * "N", "A" or "M" for season state.
 
             For instance, "ANN" means additive error, no trend and no seasonality.
@@ -72,6 +73,10 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
                     'transformer': Scaler()
                 }
             ..
+
+        .. note::
+            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoETS`
+            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
 
         Examples
         --------
@@ -122,7 +127,7 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         super()._predict(n, future_covariates, num_samples)
         forecast_dict = self.model.predict(
             h=n,
-            level=(one_sigma_rule,),  # ask one std for the confidence interval
+            level=[one_sigma_rule],  # ask one std for the confidence interval
         )
 
         mu_ets, std = unpack_sf_dict(forecast_dict)

--- a/darts/models/forecasting/sf_auto_ets.py
+++ b/darts/models/forecasting/sf_auto_ets.py
@@ -28,7 +28,7 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         but typically requires more time on the first call, because it relies
         on Numba and jit compilation.
 
-        We refer to the `statsforecast AutoTheta documentation
+        We refer to the `statsforecast AutoETS documentation
         <https://nixtla.github.io/statsforecast/src/core/models.html#autoets>`_
         for the exhaustive documentation of the arguments.
 

--- a/darts/models/forecasting/sf_auto_ets.py
+++ b/darts/models/forecasting/sf_auto_ets.py
@@ -20,7 +20,9 @@ from darts.models.forecasting.forecasting_model import (
 
 
 class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
-    def __init__(self, *ets_args, add_encoders: Optional[dict] = None, **ets_kwargs):
+    def __init__(
+        self, *autoets_args, add_encoders: Optional[dict] = None, **autoets_kwargs
+    ):
         """ETS based on `Statsforecasts package
         <https://github.com/Nixtla/statsforecast>`_.
 
@@ -40,19 +42,8 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
 
         Parameters
         ----------
-        season_length
-            Number of observations per cycle. Default: 1.
-        model
-            Three-character string identifying method using the framework
-            terminology of Hyndman et al. (2002). Possible values are:
-
-            * "A" or "M" for error state,
-            * "N", "A" or "M" for trend state,
-            * "N", "A" or "M" for season state.
-
-            For instance, "ANN" means additive error, no trend and no seasonality.
-            Furthermore, the character "Z" is a placeholder telling statsforecast
-            to search for the best model using AICs. Default: "ZZZ".
+        autoets_args
+            Positional arguments for ``statsforecasts.models.AutoETS``.
         add_encoders
             A large number of future covariates can be automatically generated with `add_encoders`.
             This can be done by adding multiple pre-defined index encoders and/or custom user-made functions that
@@ -73,10 +64,8 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
                     'transformer': Scaler()
                 }
             ..
-
-        .. note::
-            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoETS`
-            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
+        autoets_kwargs
+            Keyword arguments for ``statsforecasts.models.AutoETS``.
 
         Examples
         --------
@@ -88,7 +77,7 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         >>> pred = model.predict(36)
         """
         super().__init__(add_encoders=add_encoders)
-        self.model = SFAutoETS(*ets_args, **ets_kwargs)
+        self.model = SFAutoETS(*autoets_args, **autoets_kwargs)
         self._linreg = None
 
     def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):

--- a/darts/models/forecasting/sf_auto_theta.py
+++ b/darts/models/forecasting/sf_auto_theta.py
@@ -33,7 +33,7 @@ class StatsForecastAutoTheta(LocalForecastingModel):
         ----------
         autotheta_args
             Positional arguments for ``statsforecasts.models.AutoTheta``.
-        autothta_kwargs
+        autotheta_kwargs
             Keyword arguments for ``statsforecasts.models.AutoTheta``.
 
         Examples

--- a/darts/models/forecasting/sf_auto_theta.py
+++ b/darts/models/forecasting/sf_auto_theta.py
@@ -31,12 +31,10 @@ class StatsForecastAutoTheta(LocalForecastingModel):
 
         Parameters
         ----------
-        season_length
-            Number of observations per cycle. Default: 1.
-
-        .. note::
-            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoTheta`
-            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
+        autotheta_args
+            Positional arguments for ``statsforecasts.models.AutoTheta``.
+        autothta_kwargs
+            Keyword arguments for ``statsforecasts.models.AutoTheta``.
 
         Examples
         --------

--- a/darts/models/forecasting/sf_auto_theta.py
+++ b/darts/models/forecasting/sf_auto_theta.py
@@ -26,17 +26,17 @@ class StatsForecastAutoTheta(LocalForecastingModel):
         It is probabilistic, whereas :class:`FourTheta` is not.
 
         We refer to the `statsforecast AutoTheta documentation
-        <https://nixtla.github.io/statsforecast/models.html#autotheta>`_
-        for the documentation of the arguments.
+        <https://nixtla.github.io/statsforecast/src/core/models.html#autotheta>`_
+        for the exhaustive documentation of the arguments.
 
         Parameters
         ----------
-        autotheta_args
-            Positional arguments for ``statsforecasts.models.AutoTheta``.
-        autotheta_kwargs
-            Keyword arguments for ``statsforecasts.models.AutoTheta``.
+        season_length
+            Number of observations per cycle. Default: 1.
 
-            ..
+        .. note::
+            Positional and keyword arguments can be used to pass additional parameters to statsforecast's `AutoTheta`
+            constructor, such as ``prediction_intervals`` to compute the conformal prediction intervals.
 
         Examples
         --------

--- a/darts/tests/models/forecasting/test_local_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_local_forecasting_models.py
@@ -56,7 +56,7 @@ models = [
     (StatsForecastAutoARIMA(season_length=12), 4.6),
     (StatsForecastAutoTheta(season_length=12), 5.5),
     (StatsForecastAutoCES(season_length=12, model="Z"), 7.3),
-    (StatsForecastAutoETS(season_length=12, model="AAZ"), 4.1),
+    (StatsForecastAutoETS(season_length=12, model="AAZ"), 7.3),
     (Croston(version="classic"), 23),
     (Croston(version="tsb", alpha_d=0.1, alpha_p=0.1), 23),
     (Theta(), 11),


### PR DESCRIPTION
### Summary

- Stasforecast fixed a bug allowing `AutoETS` model to use the `"A*M"` and `"AM*"` combination when passing `"Z"` as parameter for the trend and/or seasonality. Darts' unittest was using `"AAZ"`, effectively relying on an invalid error value (which was increased from 4.2 to 7.3 in this PR)
- Updated the links to statsforecast documentation as they modified the repository organization.
- Updated the documentation of all the models to make them more homogeneous and included a little note about conformal prediction (introduced in their 1.6.0 release).

### Other Information
- The fitted parameters (values of the "Z" placeholder after training) can be found using `model.model.model_["components"]`
