### PR TITLE
fix typo in documentation

### DIFF
--- a/examples/01-multi-time-series-and-covariates.ipynb
+++ b/examples/01-multi-time-series-and-covariates.ipynb
@@ -1078,7 +1078,7 @@
     "\n",
     "### Comments on training using multivariate series\n",
     "\n",
-    "All the features shown ealier on univariate `TimeSeries`, notably using covariates (past and future) or sequence of series, are of course also compatible with multivariate `TimeSeries` (just make sure that the model used actually support them).\n",
+    "All the features shown ealier on univariate `TimeSeries`, notably using covariates (past and future) or sequence of series, are of course also compatible with multivariate `TimeSeries` (just make sure that the model used actually supports them).\n",
     "\n",
     "Furthermore, the models supporting multivariates series might use different approaches. `TFTModel` for example, uses a specialized module to select the relevant features whereas `NBEATSModel` flatten the serie's components into an univariate serie and rely on its fully connected layers to capture the interactions between the features."
    ]

--- a/examples/01-multi-time-series-and-covariates.ipynb
+++ b/examples/01-multi-time-series-and-covariates.ipynb
@@ -1078,7 +1078,7 @@
     "\n",
     "### Comments on training using multivariate series\n",
     "\n",
-    "All the features shown ealier on univariate `TimeSeries`, notably using covariates (past and future) or sequence of serie, are of course also compatible with multivariate `TimeSeries` (just make sure that the model used actually support them).\n",
+    "All the features shown ealier on univariate `TimeSeries`, notably using covariates (past and future) or sequence of series, are of course also compatible with multivariate `TimeSeries` (just make sure that the model used actually support them).\n",
     "\n",
     "Furthermore, the models supporting multivariates series might use different approaches. `TFTModel` for example, uses a specialized module to select the relevant features whereas `NBEATSModel` flatten the serie's components into an univariate serie and rely on its fully connected layers to capture the interactions between the features."
    ]


### PR DESCRIPTION
### Summary

fix 2 typos in docs:

https://unit8co.github.io/darts/examples/01-multi-time-series-and-covariates.html

At the end, this page has typos:

> sequence of serie, 

> the model used actually support them
