### PR TITLE
Fix/Updated tests with release 2.0.0 of XGBoost

### DIFF
--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -179,14 +179,10 @@ class TestRegressionModels:
         LinearRegressionModel, likelihood="poisson", random_state=42
     )
     PoissonXGBModel = partialclass(
-        XGBModel,
-        likelihood="poisson",
-        random_state=42,
+        XGBModel, likelihood="poisson", random_state=42, tree_method="exact"
     )
     QuantileXGBModel = partialclass(
-        XGBModel,
-        likelihood="quantile",
-        random_state=42,
+        XGBModel, likelihood="quantile", random_state=42, tree_method="exact"
     )
     # targets for poisson regression must be positive, so we exclude them for some tests
     models.extend(
@@ -1165,10 +1161,24 @@ class TestRegressionModels:
         lags = 4
 
         models = [
-            XGBModel(lags=lags, output_chunk_length=1, multi_models=True),
-            XGBModel(lags=lags, output_chunk_length=1, multi_models=False),
-            XGBModel(lags=lags, output_chunk_length=2, multi_models=True),
-            XGBModel(lags=lags, output_chunk_length=2, multi_models=False),
+            XGBModel(
+                lags=lags, output_chunk_length=1, multi_models=True, tree_method="exact"
+            ),
+            XGBModel(
+                lags=lags,
+                output_chunk_length=1,
+                multi_models=False,
+                tree_method="exact",
+            ),
+            XGBModel(
+                lags=lags, output_chunk_length=2, multi_models=True, tree_method="exact"
+            ),
+            XGBModel(
+                lags=lags,
+                output_chunk_length=2,
+                multi_models=False,
+                tree_method="exact",
+            ),
         ]
         if lgbm_available:
             models += [


### PR DESCRIPTION
### Summary

Force `tree_method='exact'` in the unittests as the default value changed to `'hist'` (which was resulting in slightly worse performance in the tests).

### Other Information

[Link](https://github.com/dmlc/xgboost/releases) to the full changelog.