### PR TITLE
Fix/optimized historical forecast with component specific lags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 [Full Changelog](https://github.com/unit8co/darts/compare/0.26.0...master)
 
 ### For users of the library:
+
+**Improved**
 - Improvements to `TorchForecastingModel`:
   - Added callback `darts.utils.callbacks.TFMProgressBar` to customize at which model stages to display the progress bar. [#2020](https://github.com/unit8co/darts/pull/2020) by [Dennis Bader](https://github.com/dennisbader).
 - Improvements to documentation:
-  - Adapted the example notebooks to properly apply data transformers and avoid look-ahead bias. [#2020](https://github.com/unit8co/darts/pull/2020) by [Samriddhi Singh](https://github.com/SimTheGreat). 
+  - Adapted the example notebooks to properly apply data transformers and avoid look-ahead bias. [#2020](https://github.com/unit8co/darts/pull/2020) by [Samriddhi Singh](https://github.com/SimTheGreat).
+
+**Fixed**
+- Fixed a bug when calling optimized `historical_forecasts()` for a `RegressionModel`` trained with inequal component-specific lags. [#2040](https://github.com/unit8co/darts/pull/2040) by [Antoine Madrona](https://github.com/madtoinou).
+
 ### For developers of the library:
 
 ## [0.26.0](https://github.com/unit8co/darts/tree/0.26.0) (2023-09-16)

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -223,6 +223,7 @@ class RegressionModel(GlobalForecastingModel):
         )
 
         # convert lags arguments to list of int
+        # lags attribute should always be accessed with self._get_lags(), not self.lags.get()
         self.lags, self.component_lags = self._generate_lags(
             lags=lags,
             lags_past_covariates=lags_past_covariates,
@@ -373,7 +374,7 @@ class RegressionModel(GlobalForecastingModel):
         if lags_type in self.component_lags:
             return self.component_lags[lags_type]
         else:
-            return self.lags.get(lags_type)
+            return self.lags.get(lags_type, None)
 
     @property
     def _model_encoder_settings(

--- a/darts/utils/historical_forecasts/optimized_historical_forecasts.py
+++ b/darts/utils/historical_forecasts/optimized_historical_forecasts.py
@@ -93,7 +93,7 @@ def _optimized_historical_forecasts_regression_last_points_only(
 
         X, times = create_lagged_prediction_data(
             target_series=None
-            if len(model.lags.get("target", [])) == 0
+            if model._get_lags("target") is None
             else series_[hist_fct_tgt_start:hist_fct_tgt_end],
             past_covariates=None
             if past_covariates_ is None
@@ -101,9 +101,9 @@ def _optimized_historical_forecasts_regression_last_points_only(
             future_covariates=None
             if future_covariates_ is None
             else future_covariates_[hist_fct_fc_start:hist_fct_fc_end],
-            lags=model.lags.get("target", None),
-            lags_past_covariates=model.lags.get("past", None),
-            lags_future_covariates=model.lags.get("future", None),
+            lags=model._get_lags("target"),
+            lags_past_covariates=model._get_lags("past"),
+            lags_future_covariates=model._get_lags("future"),
             uses_static_covariates=model.uses_static_covariates,
             last_static_covariates_shape=model._static_covariates_shape,
             max_samples_per_ts=None,
@@ -238,7 +238,7 @@ def _optimized_historical_forecasts_regression_all_points(
 
         X, _ = create_lagged_prediction_data(
             target_series=None
-            if len(model.lags.get("target", [])) == 0
+            if model._get_lags("target") is None
             else series_[hist_fct_tgt_start:hist_fct_tgt_end],
             past_covariates=None
             if past_covariates_ is None
@@ -246,9 +246,9 @@ def _optimized_historical_forecasts_regression_all_points(
             future_covariates=None
             if future_covariates_ is None
             else future_covariates_[hist_fct_fc_start:hist_fct_fc_end],
-            lags=model.lags.get("target", None),
-            lags_past_covariates=model.lags.get("past", None),
-            lags_future_covariates=model.lags.get("future", None),
+            lags=model._get_lags("target"),
+            lags_past_covariates=model._get_lags("past"),
+            lags_future_covariates=model._get_lags("future"),
             uses_static_covariates=model.uses_static_covariates,
             last_static_covariates_shape=model._static_covariates_shape,
             max_samples_per_ts=None,


### PR DESCRIPTION
### Summary

Optimized historical forecasts with regression models would raise an exception when using component-specific lags with different number of lags because `create_lagged_prediction_data()` was calling `model.lags.get()` instead of the dedicated method `model._get_lags()` which properly accounts for the component-specific lags.

### Other Information

Code snippet to reproduce the bug:
```python
from darts.models import LinearRegressionModel
from darts.datasets import AirPassengersDataset

# future_cov components: darts_enc_fc_cyc_month_sin and darts_enc_fc_cyc_month_cos
model = LinearRegressionModel(
    lags=3,
    lags_future_covariates={'default_lags':[-4, -2],
                            'darts_enc_fc_cyc_month_sin':[-1]
                           },
    add_encoders={
        "cyclic": {"future": ["month"]},
    }
)

series = AirPassengersDataset().load()
model.fit(series)
model.historical_forecasts(series=series, retrain=False)
```
