### PR TITLE
Fix doc formatting of LinearRegressionModel

### DIFF
--- a/darts/models/forecasting/fft.py
+++ b/darts/models/forecasting/fft.py
@@ -255,6 +255,7 @@ class FFT(LocalForecastingModel):
         >>> FFT(required_matches={'month'}, trend='exp')
 
         Simple usage example, using one of the dataset available in darts
+
         >>> from darts.datasets import AirPassengersDataset
         >>> from darts.models import FFT
         >>> series = AirPassengersDataset().load()

--- a/darts/models/forecasting/linear_regression_model.py
+++ b/darts/models/forecasting/linear_regression_model.py
@@ -124,6 +124,7 @@ class LinearRegressionModel(RegressionModel, _LikelihoodMixin):
         Examples
         --------
         Deterministic forecasting, using past/future covariates (optional)
+
         >>> from darts.datasets import WeatherDataset
         >>> from darts.models import LinearRegressionModel
         >>> series = WeatherDataset().load()

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1,6 +1,5 @@
 """
 TorchForecastingModel
----------------------
 
 This file contains several abstract classes:
 

--- a/darts/models/forecasting/xgboost.py
+++ b/darts/models/forecasting/xgboost.py
@@ -140,6 +140,7 @@ class XGBModel(RegressionModel, _LikelihoodMixin):
         Examples
         --------
         Deterministic forecasting, using past/future covariates (optional)
+
         >>> from darts.datasets import WeatherDataset
         >>> from darts.models import XGBModel
         >>> series = WeatherDataset().load()


### PR DESCRIPTION
It previously looked like this:

![Screenshot 2023-10-31 at 12 27 45](https://github.com/unit8co/darts/assets/4403130/2576e648-0ab2-4697-8f5d-6d508d2dc152)

How can we check that it is now better?