### PR TITLE
Feat/tz aware dta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - 🚀🚀 Optimized `historical_forecasts()` for pre-trained `TorchForecastingModel` running up to 20 times faster than before!. [#2013](https://github.com/unit8co/darts/pull/2013) by [Dennis Bader](https://github.com/dennisbader).
   - Added callback `darts.utils.callbacks.TFMProgressBar` to customize at which model stages to display the progress bar. [#2020](https://github.com/unit8co/darts/pull/2020) by [Dennis Bader](https://github.com/dennisbader).
 - Improvements to documentation:
-  - Adapted the example notebooks to properly apply data transformers and avoid look-ahead bias. [#2020](https://github.com/unit8co/darts/pull/2020) by [Samriddhi Singh](https://github.com/SimTheGreat). 
+  - Adapted the example notebooks to properly apply data transformers and avoid look-ahead bias. [#2020](https://github.com/unit8co/darts/pull/2020) by [Samriddhi Singh](https://github.com/SimTheGreat).
+- Other improvements:
+  - Added support for time index time zone conversion with parameter `tz` before generating/computing holidays and datetime attributes. Support was added to all Time Axis Encoders (standalone encoders and forecasting models' `add_encoders`, time series generation utils functions `holidays_timeseries()` and `datetime_attribute_timeseries()`, and `TimeSeries` methods `add_datetime_attribute()` and `add_holidays()`. [#2054](https://github.com/unit8co/darts/pull/2054) by [Dennis Bader](https://github.com/dennisbader).
 
 **Fixed**
 - Fixed a bug when calling optimized `historical_forecasts()` for a `RegressionModel` trained with unequal component-specific lags. [#2040](https://github.com/unit8co/darts/pull/2040) by [Antoine Madrona](https://github.com/madtoinou).

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -884,7 +884,7 @@ class SequentialEncoder(Encoder):
             BoxCox(). The transformers will be fitted on the training dataset when calling calling `model.fit()`.
             The training, validation and inference datasets are then transformed equally.
         Supported time zone:
-            optionally, apply a time zone conversion with keyword 'tz'. This converts the time zone-naive index to a
+            Optionally, apply a time zone conversion with keyword 'tz'. This converts the time zone-naive index to a
             timezone `'tz'` before applying the `'cyclic'` or `'datetime_attribute'` temporal encoders.
 
         An example of a valid `add_encoders` dict for hourly data:

--- a/darts/models/forecasting/arima.py
+++ b/darts/models/forecasting/arima.py
@@ -79,7 +79,8 @@ class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
 

--- a/darts/models/forecasting/auto_arima.py
+++ b/darts/models/forecasting/auto_arima.py
@@ -62,7 +62,8 @@ class AutoARIMA(FutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
 

--- a/darts/models/forecasting/block_rnn_model.py
+++ b/darts/models/forecasting/block_rnn_model.py
@@ -249,7 +249,8 @@ class BlockRNNModel(PastCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -74,7 +74,8 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         likelihood

--- a/darts/models/forecasting/croston.py
+++ b/darts/models/forecasting/croston.py
@@ -66,7 +66,8 @@ class Croston(FutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
 

--- a/darts/models/forecasting/dlinear.py
+++ b/darts/models/forecasting/dlinear.py
@@ -350,7 +350,8 @@ class DLinearModel(MixedCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/kalman_forecaster.py
+++ b/darts/models/forecasting/kalman_forecaster.py
@@ -75,7 +75,8 @@ class KalmanForecaster(TransferableFutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
 

--- a/darts/models/forecasting/lgbm.py
+++ b/darts/models/forecasting/lgbm.py
@@ -101,7 +101,8 @@ class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         likelihood

--- a/darts/models/forecasting/linear_regression_model.py
+++ b/darts/models/forecasting/linear_regression_model.py
@@ -94,7 +94,8 @@ class LinearRegressionModel(RegressionModel, _LikelihoodMixin):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         likelihood

--- a/darts/models/forecasting/nbeats.py
+++ b/darts/models/forecasting/nbeats.py
@@ -671,7 +671,8 @@ class NBEATSModel(PastCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/nhits.py
+++ b/darts/models/forecasting/nhits.py
@@ -607,7 +607,8 @@ class NHiTSModel(PastCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/nlinear.py
+++ b/darts/models/forecasting/nlinear.py
@@ -300,7 +300,8 @@ class NLinearModel(MixedCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -106,7 +106,8 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         cap

--- a/darts/models/forecasting/random_forest.py
+++ b/darts/models/forecasting/random_forest.py
@@ -98,7 +98,8 @@ class RandomForest(RegressionModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         n_estimators : int

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -137,7 +137,8 @@ class RegressionModel(GlobalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         model
@@ -1519,7 +1520,8 @@ class RegressionModelWithCategoricalCovariates(RegressionModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         model

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -333,7 +333,8 @@ class RNNModel(DualCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/sf_auto_arima.py
+++ b/darts/models/forecasting/sf_auto_arima.py
@@ -59,7 +59,8 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         autoarima_kwargs

--- a/darts/models/forecasting/sf_auto_ets.py
+++ b/darts/models/forecasting/sf_auto_ets.py
@@ -64,7 +64,8 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         autoets_kwargs

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -372,7 +372,8 @@ class TCNModel(PastCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -819,7 +819,8 @@ class TFTModel(MixedCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/tide_model.py
+++ b/darts/models/forecasting/tide_model.py
@@ -498,7 +498,8 @@ class TiDEModel(MixedCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -223,7 +223,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/transformer_model.py
+++ b/darts/models/forecasting/transformer_model.py
@@ -460,7 +460,8 @@ class TransformerModel(PastCovariatesTorchModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         random_state

--- a/darts/models/forecasting/varima.py
+++ b/darts/models/forecasting/varima.py
@@ -71,7 +71,8 @@ class VARIMA(TransferableFutureCovariatesLocalForecastingModel):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'future': ['relative']},
                     'custom': {'future': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
 

--- a/darts/models/forecasting/xgboost.py
+++ b/darts/models/forecasting/xgboost.py
@@ -116,7 +116,8 @@ class XGBModel(RegressionModel, _LikelihoodMixin):
                     'datetime_attribute': {'future': ['hour', 'dayofweek']},
                     'position': {'past': ['relative'], 'future': ['relative']},
                     'custom': {'past': [encode_year]},
-                    'transformer': Scaler()
+                    'transformer': Scaler(),
+                    'tz': 'CET'
                 }
             ..
         likelihood

--- a/darts/tests/utils/test_timeseries_generation.py
+++ b/darts/tests/utils/test_timeseries_generation.py
@@ -4,9 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from darts import TimeSeries
 from darts.utils.timeseries_generation import (
     autoregressive_timeseries,
     constant_timeseries,
+    datetime_attribute_timeseries,
     gaussian_timeseries,
     generate_index,
     holidays_timeseries,
@@ -183,6 +185,27 @@ class TestTimeSeriesGeneration:
         with pytest.raises(ValueError):
             holidays_timeseries(time_index_3, "US", until=163)
 
+        # test non time zone-naive
+        with pytest.raises(ValueError):
+            holidays_timeseries(time_index_3.tz_localize("UTC"), "US", until=163)
+
+        # test holiday with and without time zone, 1st of August is national holiday in Switzerland
+        # time zone naive (e.g. in UTC)
+        idx = generate_index(
+            start=pd.Timestamp("2000-07-31 22:00:00"), length=3, freq="h"
+        )
+        ts = holidays_timeseries(idx, country_code="CH")
+        np.testing.assert_array_almost_equal(ts.values()[:, 0], np.array([0, 0, 1]))
+
+        # time zone CET (+2 hour compared to UTC)
+        ts = holidays_timeseries(idx, country_code="CH", tz="CET")
+        np.testing.assert_array_almost_equal(ts.values()[:, 0], np.array([1, 1, 1]))
+
+        # check same from TimeSeries
+        series = TimeSeries.from_times_and_values(times=idx, values=np.arange(len(idx)))
+        ts = holidays_timeseries(series, country_code="CH", tz="CET")
+        np.testing.assert_array_almost_equal(ts.values()[:, 0], np.array([1, 1, 1]))
+
     def test_generate_index(self):
         def test_routine(
             expected_length,
@@ -321,3 +344,86 @@ class TestTimeSeriesGeneration:
 
         for coef_assert in [[-1], [-1, 1.618], [1, 2, 3], list(range(10))]:
             test_calculation(coef=coef_assert)
+
+    def test_datetime_attribute_timeseries(self):
+        idx = generate_index(start=pd.Timestamp("2000-01-01"), length=48, freq="h")
+
+        def helper_routine(idx, attr, vals_exp, **kwargs):
+            ts = datetime_attribute_timeseries(idx, attribute=attr, **kwargs)
+            vals_exp = np.array(vals_exp, dtype=ts.dtype)
+            if len(vals_exp.shape) == 1:
+                vals_act = ts.values()[:, 0]
+            else:
+                vals_act = ts.values()
+            np.testing.assert_array_almost_equal(vals_act, vals_exp)
+
+        # no pd.DatetimeIndex
+        with pytest.raises(ValueError):
+            helper_routine(
+                pd.RangeIndex(start=0, stop=len(idx)), "h", vals_exp=np.arange(len(idx))
+            )
+
+        # invalid attribute
+        with pytest.raises(ValueError):
+            helper_routine(idx, "h", vals_exp=np.arange(len(idx)))
+
+        # no time zone aware index
+        with pytest.raises(ValueError):
+            helper_routine(idx.tz_localize("UTC"), "h", vals_exp=np.arange(len(idx)))
+
+        # ===> datetime attribute
+        # hour
+        vals = [i for i in range(24)] * 2
+        helper_routine(idx, "hour", vals_exp=vals)
+
+        # hour from TimeSeries
+        helper_routine(
+            TimeSeries.from_times_and_values(times=idx, values=np.arange(len(idx))),
+            "hour",
+            vals_exp=vals,
+        )
+
+        # tz=CET is +1 hour to UTC
+        vals = vals[1:] + [0]
+        helper_routine(idx, "hour", vals_exp=vals, tz="CET")
+
+        # day
+        vals = [1] * 24 + [2] * 24
+        helper_routine(idx, "day", vals_exp=vals)
+
+        # dayofweek
+        vals = [5] * 24 + [6] * 24
+        helper_routine(idx, "dayofweek", vals_exp=vals)
+
+        # month
+        vals = [1] * 48
+        helper_routine(idx, "month", vals_exp=vals)
+
+        # ===> one hot encoded
+        # month
+        vals = [1] + [0] * 11
+        vals = [vals for _ in range(48)]
+        helper_routine(idx, "month", vals_exp=vals, one_hot=True)
+
+        # tz=CET, month
+        vals = [1] + [0] * 11
+        vals = [vals for _ in range(48)]
+        helper_routine(idx, "month", vals_exp=vals, tz="CET", one_hot=True)
+
+        # ===> sine/cosine cyclic encoding
+        # hour (period = 24 hours in one day)
+        period = 24
+        freq = 2 * np.pi / period
+        vals_dta = [i for i in range(24)] * 2
+        vals = np.array(vals_dta)
+        sin_vals = np.sin(freq * vals)[:, None]
+        cos_vals = np.cos(freq * vals)[:, None]
+        vals = np.concatenate([sin_vals, cos_vals], axis=1)
+        helper_routine(idx, "hour", vals_exp=vals, cyclic=True)
+
+        # tz=CET, hour
+        vals = np.array(vals_dta[1:] + [0])
+        sin_vals = np.sin(freq * vals)[:, None]
+        cos_vals = np.cos(freq * vals)[:, None]
+        vals = np.concatenate([sin_vals, cos_vals], axis=1)
+        helper_routine(idx, "hour", vals_exp=vals, tz="CET", cyclic=True)

--- a/darts/tests/utils/test_timeseries_generation.py
+++ b/darts/tests/utils/test_timeseries_generation.py
@@ -358,18 +358,25 @@ class TestTimeSeriesGeneration:
             np.testing.assert_array_almost_equal(vals_act, vals_exp)
 
         # no pd.DatetimeIndex
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as err:
             helper_routine(
                 pd.RangeIndex(start=0, stop=len(idx)), "h", vals_exp=np.arange(len(idx))
             )
+        assert str(err.value).startswith(
+            "`time_index` must be a pandas `DatetimeIndex`"
+        )
 
         # invalid attribute
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as err:
             helper_routine(idx, "h", vals_exp=np.arange(len(idx)))
+        assert str(err.value).startswith(
+            "attribute `h` needs to be an attribute of pd.DatetimeIndex."
+        )
 
         # no time zone aware index
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as err:
             helper_routine(idx.tz_localize("UTC"), "h", vals_exp=np.arange(len(idx)))
+        assert "`time_index` must be time zone naive." == str(err.value)
 
         # ===> datetime attribute
         # hour

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2991,7 +2991,11 @@ class TimeSeries:
         return self[index if isinstance(index, str) else self.components[index]]
 
     def add_datetime_attribute(
-        self, attribute, one_hot: bool = False, cyclic: bool = False
+        self,
+        attribute,
+        one_hot: bool = False,
+        cyclic: bool = False,
+        tz: Optional[str] = None,
     ) -> "TimeSeries":
         """
         Build a new series with one (or more) additional component(s) that contain an attribute
@@ -3012,6 +3016,8 @@ class TimeSeries:
             Boolean value indicating whether to add the specified attribute as a cyclic encoding.
             Alternative to one_hot encoding, enable only one of the two.
             (adds 2 columns, corresponding to sin and cos transformation).
+        tz
+            Optionally, a time zone to convert the time index to before computing the attributes.
 
         Returns
         -------
@@ -3023,12 +3029,20 @@ class TimeSeries:
 
         return self.stack(
             tg.datetime_attribute_timeseries(
-                self.time_index, attribute, one_hot, cyclic
+                self.time_index,
+                attribute=attribute,
+                one_hot=one_hot,
+                cyclic=cyclic,
+                tz=tz,
             )
         )
 
     def add_holidays(
-        self, country_code: str, prov: str = None, state: str = None
+        self,
+        country_code: str,
+        prov: str = None,
+        state: str = None,
+        tz: Optional[str] = None,
     ) -> "TimeSeries":
         """
         Adds a binary univariate component to the current series that equals 1 at every index that
@@ -3048,6 +3062,8 @@ class TimeSeries:
             The province
         state
             The state
+        tz
+            Optionally, a time zone to convert the time index to before computing the attributes.
 
         Returns
         -------
@@ -3058,7 +3074,13 @@ class TimeSeries:
         from .utils import timeseries_generation as tg
 
         return self.stack(
-            tg.holidays_timeseries(self.time_index, country_code, prov, state)
+            tg.holidays_timeseries(
+                self.time_index,
+                country_code=country_code,
+                prov=prov,
+                state=state,
+                tz=tz,
+            )
         )
 
     def resample(self, freq: str, method: str = "pad", **kwargs) -> Self:

--- a/darts/utils/timeseries_generation.py
+++ b/darts/utils/timeseries_generation.py
@@ -547,7 +547,7 @@ def holidays_timeseries(
     Parameters
     ----------
     time_index
-        Either a `pd.DatetimeIndex` or a `TimeSeries` for which to generate the holidays/
+        Either a `pd.DatetimeIndex` or a `TimeSeries` for which to generate the holidays.
     country_code
         The country ISO code.
     prov
@@ -561,7 +561,7 @@ def holidays_timeseries(
         Extend the time_index by add_length, should match or exceed forecasting window.
         Set only one of until and add_length.
     column_name
-        Optionally, the name of the value column for the returned TimeSeries/
+        Optionally, the name of the value column for the returned TimeSeries.
     dtype
         The desired NumPy dtype (np.float32 or np.float64) for the resulting series.
     tz


### PR DESCRIPTION
fixes #2000.

### Summary
- adds support for time index time zone conversion with parameter `tz` before generating/computing holidays and datetime attributes.
  - `darts.utils.timeseries_generation.datetime_attribute_timeseries`
  - `darts.utils.timeseries_generation.holidays_timeseries`
  - all time axis encoders and `add_encoders` dict for automatic encoders in forecasting models
  - `darts.Timeseries.add_holidays`
  -` darts.Timeseries.add_datetime_attribute`

