### PR TITLE
fix num_samles not being passed to optimized hist fc rountine of torc…

### DIFF
--- a/darts/utils/historical_forecasts/optimized_historical_forecasts_torch.py
+++ b/darts/utils/historical_forecasts/optimized_historical_forecasts_torch.py
@@ -115,6 +115,7 @@ def _optimized_historical_forecasts(
         dataset,
         trainer=None,
         verbose=verbose,
+        num_samples=num_samples,
         predict_likelihood_parameters=predict_likelihood_parameters,
     )
 


### PR DESCRIPTION
fixes #2058 

## Summary
- fixes a bug in `TorchFroecastingModel` where `num_samples` was not passed to `predict_from_dataset` in optimized historical forecast routine