### PR TITLE
Synthesize window-based normalization

### DIFF
--- a/darts/dataprocessing/transformers/revwinnorm.py
+++ b/darts/dataprocessing/transformers/revwinnorm.py
@@ -1,0 +1,71 @@
+import torch
+import torch.nn as nn
+from typing import Optional
+
+
+class RevWinNorm(nn.Module):
+    def __init__(self, num_features: int, norm_affine: bool=False , eps=1e-5, affine=True):
+        """
+        :param num_features: the number of features or channels
+        :param eps: a value added for numerical stability
+        :param affine: if True, RevIN has learnable affine parameters
+        """
+        super(RevIN, self).__init__()
+        self.num_features = num_features
+        self.eps = eps
+        self.affine = affine
+        if self.affine:
+            self._init_params(norm_affine=norm_affine)
+
+    def forward(self, x, mode: str, scaler: Optional[str], norm_type: str = 'instance'):
+        if mode == "norm":
+            self._get_statistics(x, norm_type=norm_type)
+            x = self._normalize(x, scaler=scaler)
+        elif mode == "denorm":
+            x = self._denormalize(x, scaler=scaler)
+        else:
+            raise NotImplementedError
+        return x
+
+    def _init_params(self, norm_affine: bool=False):
+        # initialize RevIN params: (C,)
+        self.affine_weight = nn.Parameter(torch.ones(self.num_features))
+        self.affine_bias = nn.Parameter(torch.zeros(self.num_features))
+        # enable learnable
+        if norm_affine is True:
+            self.affine_weight.requires_grad = True
+            self.affine_bias.requires_grad = True
+        else:
+            self.affine_weight.requires_grad = False
+            self.affine_bias.requires_grad = False
+
+    def _get_statistics(self, x, norm_type: str='instance'):
+        if norm_type == 'instance':
+            dim2reduce = (1,)  
+        elif norm_type == 'batch':
+            dim2reduce = tuple(range(1, x.ndim - 1))
+        self.mean = torch.mean(x, dim=dim2reduce, keepdim=True).detach()
+        self.stdev = torch.sqrt(torch.var(x, dim=dim2reduce, keepdim=True, unbiased=False) + self.eps).detach()
+
+    def _normalize(self, x, scaler: Optional[str] ='standard'):
+        if scaler == 'standard':
+            x = x - self.mean
+            x = x / self.stdev
+        elif scaler == 'mean':
+            x = x / self.mean
+
+        if self.affine:
+            x = x * self.affine_weight
+            x = x + self.affine_bias
+        return x
+
+    def _denormalize(self, x, norm_type: str='instance', scaler: Optional[str]='standard'):
+        if self.affine:
+            x = x - self.affine_bias
+            x = x / (self.affine_weight + self.eps*self.eps)
+        if scaler == 'standard':
+            x = x * self.stdev
+            x = x + self.mean
+        elif scaler == 'mean':
+            x = x * self.mean
+        return x

--- a/darts/models/forecasting/lgbm.py
+++ b/darts/models/forecasting/lgbm.py
@@ -177,6 +177,7 @@ class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
         self.quantiles = None
         self.likelihood = likelihood
         self._rng = None
+        self.kwargs["n_jobs"] = 1 # -1 does not work on server
 
         # parse likelihood
         available_likelihoods = ["quantile", "poisson"]  # to be extended

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -4,7 +4,8 @@ Recurrent Neural Networks
 """
 
 from typing import Optional, Sequence, Tuple, Union
-
+from darts.dataprocessing.transformers.revwinnorm import RevWinNorm
+from tot.data_processing.scaler import Scaler
 import torch
 import torch.nn as nn
 
@@ -31,6 +32,10 @@ class _RNNModule(PLDualCovariatesModule):
         target_size: int,
         nr_params: int,
         dropout: float = 0.0,
+        scaler: Scaler = None,
+        norm_mode: Optional[str] = None, #revin or pytorch (not applicable)
+        norm_types: Optional[str] = None, #instance or batch 
+        norm_affines: Optional[bool] = False, #learnable or nonlearnable
         **kwargs,
     ):
 
@@ -93,15 +98,31 @@ class _RNNModule(PLDualCovariatesModule):
     def forward(
         self, x_in: Tuple, h: Optional[torch.Tensor] = None
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        
         x, _ = x_in
         # data is of size (batch_size, input_length, input_size)
         batch_size = x.shape[0]
+        
+        # apply window-based normalization if applicable
+        if self.norm_mode is not None:
+            if self.scaler = StandardScaler():
+                scaler = "standard"
+            elif self.scaler = MeanScaler():
+                scaler = "mean"
+            else:
+                scaler = None
+            window_norm_layer = RevWinNorm(x.shape[2])
+            x = window_norm_layer(x, "norm", norm_type=self.norm_type, scaler=scaler, norm_affine=self.norm_affine)
 
         # out is of size (batch_size, input_length, hidden_dim)
         out, last_hidden_state = self.rnn(x) if h is None else self.rnn(x, h)
 
         # Here, we apply the V matrix to every hidden state to produce the outputs
         predictions = self.V(out)
+        
+        #revert window-based normalization if applicable:
+        if self.norm_mode is not None:
+            predictions = window_norm_layer(predictions, "denorm", norm_type=self.norm_type, scaler=scaler, norm_affine=self.norm_affine)
 
         # predictions is of size (batch_size, input_length, target_size)
         predictions = predictions.view(batch_size, -1, self.target_size, self.nr_params)


### PR DESCRIPTION
### Summary
This dart branch implements window-based normalization for the RNN. It considers using the model with or without window-based normalization depending on the preferences set in tot or hpdnorm.

### Features
- optionally enable window-based normalization 
- distinguish between instance and batch norm_type
- distinguish between affine_norm= True or False
- distinguish between mean and standard normalization
