### PR TITLE
Fix formula in example notebook #20 (single-shot vs. auto-regressive forecasting)

### DIFF
--- a/examples/20-RegressionModel-examples.ipynb
+++ b/examples/20-RegressionModel-examples.ipynb
@@ -502,7 +502,7 @@
     "This key parameter sets the *number of time steps that can be predicted at once by the internal regression model*.\n",
     "\n",
     "It is not the same as forecast horizon `n` from `predict()` which is the **desired** the number of generated prediction points, that is achieved either with:\n",
-    "- a single shot forecast (if `output_chunk_length <= n`), or\n",
+    "- a single shot forecast (if `n <= output_chunk_length`), or\n",
     "- an auto-regressive forecast, consuming its own forecast (and future values of covariates) as input for additional predictions (otherwise)\n",
     "\n",
     "For example, if we want our model to forecast the next 24 hours of electricity consumption based on the last day of consumption, setting `output_chunk_length=24` ensures that the model will not consume its forecasts or future values of our covariates to predict the entire day."


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #2094.

### Summary

Fixes the formula in the description of the single-shot forecast in the `examples/20-RegressionModel-examples.ipynb` example notebook.
