### PR TITLE
fix TimeSeries.pd_series not retaining original name

### DIFF
--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -78,6 +78,18 @@ class TestTimeSeries:
         )
         _ = TimeSeries.from_xarray(ar)
 
+    def test_pandas_creation(self):
+        pd_series = pd.Series(range(10), name="test_name", dtype="float32")
+        ts = TimeSeries.from_series(pd_series)
+        ts_pd_series = ts.pd_series()
+        assert ts_pd_series.equals(pd_series)
+        assert ts_pd_series.name == pd_series.name
+
+        pd_df = pd_series.to_frame()
+        ts = TimeSeries.from_dataframe(pd_df)
+        ts_pd_df = ts.pd_dataframe()
+        assert ts_pd_df.equals(pd_df)
+
     def test_integer_range_indexing(self):
         # sanity checks for the integer-indexed series
         range_indexed_data = np.random.randn(

--- a/darts/tests/test_timeseries_static_covariates.py
+++ b/darts/tests/test_timeseries_static_covariates.py
@@ -61,8 +61,7 @@ class TestTimeSeriesStaticCovariate:
                 ts.pd_dataframe(), static_covariates=ts.static_covariates
             ),
         )
-        # ts.pd_series() loses component names -> static covariates have different components names
-        self.helper_test_cov_transfer_values(
+        self.helper_test_cov_transfer(
             ts,
             TimeSeries.from_series(
                 ts.pd_series(), static_covariates=ts.static_covariates

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1472,10 +1472,16 @@ class TimeSeries:
         self._assert_deterministic()
         if copy:
             return pd.Series(
-                self._xa[:, 0, 0].values.copy(), index=self._time_index.copy(), name=self.components[0]
+                self._xa[:, 0, 0].values.copy(),
+                index=self._time_index.copy(),
+                name=self.components[0],
             )
         else:
-            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index, name=self.components[0])
+            return pd.Series(
+                self._xa[:, 0, 0].values,
+                index=self._time_index,
+                name=self.components[0],
+            )
 
     def pd_dataframe(self, copy=True, suppress_warnings=False) -> pd.DataFrame:
         """

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1472,10 +1472,10 @@ class TimeSeries:
         self._assert_deterministic()
         if copy:
             return pd.Series(
-                self._xa[:, 0, 0].values.copy(), index=self._time_index.copy(), name=list(self.components)[0]
+                self._xa[:, 0, 0].values.copy(), index=self._time_index.copy(), name=self.components.array[0]
             )
         else:
-            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index, name=list(self.components)[0])
+            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index, name=self.components.array[0])
 
     def pd_dataframe(self, copy=True, suppress_warnings=False) -> pd.DataFrame:
         """

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1472,10 +1472,10 @@ class TimeSeries:
         self._assert_deterministic()
         if copy:
             return pd.Series(
-                self._xa[:, 0, 0].values.copy(), index=self._time_index.copy(), name=self.components.array[0]
+                self._xa[:, 0, 0].values.copy(), index=self._time_index.copy(), name=self.components[0]
             )
         else:
-            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index, name=self.components.array[0])
+            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index, name=self.components[0])
 
     def pd_dataframe(self, copy=True, suppress_warnings=False) -> pd.DataFrame:
         """

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1472,10 +1472,10 @@ class TimeSeries:
         self._assert_deterministic()
         if copy:
             return pd.Series(
-                self._xa[:, 0, 0].values.copy(), index=self._time_index.copy()
+                self._xa[:, 0, 0].values.copy(), index=self._time_index.copy(), name=list(self.components)[0]
             )
         else:
-            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index)
+            return pd.Series(self._xa[:, 0, 0].values, index=self._time_index, name=list(self.components)[0])
 
     def pd_dataframe(self, copy=True, suppress_warnings=False) -> pd.DataFrame:
         """


### PR DESCRIPTION
<!-- Please mention an issue this pull request addresses. -->
Fixes #2101.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

In this new version of the `TimeSeries.pd_series` method, the newly created `Panda.Series` instance to be returned takes as its name the one from the `TimeSeries` object (stored as the first item in the iterable attribute `self.components`).

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

This new version of the `TimeSeries.pd_series` method returns a new `Pandas.Series` instance with the name of the original `TimeSeries` object (`series`).

```
>>> import pandas as pd
>>> from darts.timeseries import TimeSeries
>>> idx = pd.date_range("2018-01-01", periods=5, freq="D")
>>> ts = pd.Series(range(len(idx)), index=idx, name="series_name")
>>> ts
2018-01-01    0
2018-01-02    1
2018-01-03    2
2018-01-04    3
2018-01-05    4
Freq: D, Name: series_name, dtype: int64
>>> series = TimeSeries.from_series(ts)
>>> series.pd_series()
time
2018-01-01    0.0
2018-01-02    1.0
2018-01-03    2.0
2018-01-04    3.0
2018-01-05    4.0
Freq: D, Name: series_name, dtype: float64
```

<!--Thank you for contributing to darts! -->
