### PR TITLE
Fix typo in examples Ensemble Model

### DIFF
--- a/examples/19-EnsembleModel-examples.ipynb
+++ b/examples/19-EnsembleModel-examples.ipynb
@@ -173,7 +173,7 @@
     "Before creating the new `NaiveEnsemble`, we will screen models to identify which ones would do well together. The candidates are : \n",
     "- `LinearRegressionModel` : classic and simple model\n",
     "- `ExponentialSmoothing` : moving window model\n",
-    "- `FalmanForecaster` : a filter-based model\n",
+    "- `KalmanForecaster` : a filter-based model\n",
     "- `RandomForest` : decision trees model"
    ]
   },


### PR DESCRIPTION
In `19-EnsembleModel-examples.ipynb`: Falman -> Kalman
