### PR TITLE
upper cap pytorch lightning for ckpt symlink fix

### DIFF
--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,3 +1,3 @@
-pytorch-lightning>=1.5.0
+pytorch-lightning>=1.5.0,<=2.1.2
 tensorboardX>=2.1
 torch>=1.8.0


### PR DESCRIPTION
see #2133

## Summary
- fixes currently failing unit tests
- sets an upper cap on pytorch lightning <=2.1.2 to fix the checkpoint symlink issue.
- pytorch lightning already reverted these changes [here](https://github.com/Lightning-AI/pytorch-lightning/pull/19191). Will relax the cap once they release the new version
