### PR TITLE
Update .gitignore to ignore intermediate coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 examples/.ipynb_checkpoints/
 runs/
 .coverage
+.coverage.*
 htmlcov
 coverage.xml
 .darts

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@ build/
 dist/
 examples/.ipynb_checkpoints/
 runs/
-.coverage
-.coverage.*
+.coverage*
 htmlcov
 coverage.xml
 .darts


### PR DESCRIPTION
### Summary

Ignores files such as the following, which get created by coverage measurement tools:

```
.coverage.68a13e4de0d0.43514.XMNYGdrx
.coverage.68a13e4de0d0.43515.XjbvzNqx
```