### PR TITLE
fix torch covariates support tables in user guide

### DIFF
--- a/docs/userguide/torch_forecasting_models.md
+++ b/docs/userguide/torch_forecasting_models.md
@@ -95,27 +95,27 @@ Under the hood, Darts has 5 types of `{X}CovariatesModel` classes implemented to
 
 | Class                   | past covariates | future past covariates | future covariates | historic future covariates |
 |-------------------------|:---------------:|:----------------------:|:-----------------:|:--------------------------:|
-| `PastCovariatesModel`   | ✅              | ✅                     |                  |                           |
-| `FutureCovariatesModel` |                |                       | ✅                |                           |
-| `DualCovariatesModel`   |                |                       | ✅                | ✅                         |
-| `MixedCovariatesModel`  | ✅              | ✅                     | ✅                | ✅                         |
-| `SplitCovariatesModel`  | ✅              | ✅                     | ✅                |                           |
+| `PastCovariatesModel`   |        ✅        |           ✅            |                   |                            |
+| `FutureCovariatesModel` |                 |                        |         ✅         |                            |
+| `DualCovariatesModel`   |                 |                        |         ✅         |             ✅              |
+| `SplitCovariatesModel`  |        ✅        |           ✅            |         ✅         |                            |
+| `MixedCovariatesModel`  |        ✅        |           ✅            |         ✅         |             ✅              |
 
 **Table 1: Darts' "{X}CovariatesModels" covariate support**
 
 Each Torch Forecasting Model inherits from one `{X}CovariatesModel` (covariate class names are abbreviated by the `X`-part):
 
-| TFM                | `Past` | `Future` | `Dual` | `Mixed` | `Split` |
+| TFM                | `Past` | `Future` | `Dual` | `Split` | `Mixed` |
 |--------------------|:------:|:--------:|:------:|:-------:|:-------:|
-| `RNNModel`         |       |         | ✅     |        |        |
-| `BlockRNNModel`    | ✅     |         |       |        |        |
-| `NBEATSModel`      | ✅     |         |       |        |        |
-| `TCNModel`         | ✅     |         |       |        |        |
-| `TransformerModel` | ✅     |         |       |        |        |
-| `TFTModel`         |       |         |       | ✅      |        |
-| `NLinearModel`     |       |         |       | ✅      |        |
-| `DLinearModel`     |       |         |       | ✅      |        |
-| `TiDEModel`        |       |         |       | ✅      |        |
+| `RNNModel`         |        |          |   ✅    |         |         |
+| `BlockRNNModel`    |   ✅    |          |        |         |         |
+| `NBEATSModel`      |   ✅    |          |        |         |         |
+| `TCNModel`         |   ✅    |          |        |         |         |
+| `TransformerModel` |   ✅    |          |        |         |         |
+| `TFTModel`         |        |          |        |         |    ✅    |
+| `NLinearModel`     |        |          |        |         |    ✅    |
+| `DLinearModel`     |        |          |        |         |    ✅    |
+| `TiDEModel`        |        |          |        |         |    ✅    |
 
 **Table 2: Darts' Torch Forecasting Model covariate support**
 


### PR DESCRIPTION
Fixes #2171

### Summary
- fixes covariates support table for torch models in TFM user guide. For some reason sphinx (or other docs dependencies) do not recognize last cell in a  table if it is empty.