### PR TITLE
fixes for pandas >= 2.2.0

### DIFF
--- a/darts/dataprocessing/transformers/midas.py
+++ b/darts/dataprocessing/transformers/midas.py
@@ -93,6 +93,14 @@ class MIDAS(FittableDataTransformer, InvertibleDataTransformer):
         .. [1] https://en.wikipedia.org/wiki/Mixed-data_sampling
         .. [2] https://pandas.pydata.org/docs/user_guide/timeseries.html#dateoffset-objects
         """
+        if pd.tseries.frequencies.get_period_alias(low_freq) is None:
+            raise_log(
+                ValueError(
+                    f"Cannot infer period alias for `low_freq={low_freq}`. "
+                    f"Is it a valid pandas offset/frequency alias?"
+                ),
+                logger=logger,
+            )
         self._low_freq = low_freq
         self._strip = strip
         self._drop_static_covariates = drop_static_covariates

--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -18,6 +18,8 @@ from darts.utils.utils import _build_tqdm_iterator
 
 from .dataset_loaders import DatasetLoaderCSV, DatasetLoaderMetadata
 
+pd_above_v22 = pd.__version__ >= "2.2"
+
 """
     Overall usage of this package:
     from darts.datasets import AirPassengersDataset
@@ -886,6 +888,12 @@ class ElectricityConsumptionZurichDataset(DatasetLoaderCSV):
             df.index.name = "Timestamp"
             df.to_csv(self._get_path_dataset())
 
+        # pandas v2.2.0 introduced some changes
+        hash_expected = (
+            "485d81e9902cc0ccb1f86d7e01fb37cd"
+            if pd_above_v22
+            else "a019125b7f9c1afeacb0ae60ce7455ef"
+        )
         # hash value for dataset with weather data
         super().__init__(
             metadata=DatasetLoaderMetadata(
@@ -895,7 +903,7 @@ class ElectricityConsumptionZurichDataset(DatasetLoaderCSV):
                     "ewz_stromabgabe_netzebenen_stadt_zuerich/"
                     "download/ewz_stromabgabe_netzebenen_stadt_zuerich.csv"
                 ),
-                hash="a019125b7f9c1afeacb0ae60ce7455ef",
+                hash=hash_expected,
                 header_time="Timestamp",
                 freq="15min",
                 pre_process_csv_fn=pre_process_dataset,

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -594,6 +594,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
         freq = "".join(re.split("[^a-zA-Z-]*", freq)).split("-")[0]
 
         seconds_per_day = 86400
+        days = 0
         if freq in ["A", "BA", "Y", "BY", "RE"] or freq.startswith(
             ("A", "BA", "Y", "BY", "RE")
         ):  # year
@@ -612,23 +613,28 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             days = 1 * 7 / 5
         elif freq in ["D"]:  # day
             days = 1.0
-        elif freq in ["H", "BH", "CBH"]:  # hour
-            days = 1 / 24
-        elif freq in ["T", "min"]:  # minute
-            days = 1 / (24 * 60)
-        elif freq in ["S"]:  # second
-            days = 1 / seconds_per_day
-        elif freq in ["L", "ms"]:  # millisecond
-            days = 1 / (seconds_per_day * 10**3)
-        elif freq in ["U", "us"]:  # microsecond
-            days = 1 / (seconds_per_day * 10**6)
-        elif freq in ["N"]:  # nanosecond
-            days = 1 / (seconds_per_day * 10**9)
         else:
-            raise ValueError(
-                "freq {} not understood. Please report if you think this is in error.".format(
-                    freq
-                )
+            # all freqs higher than "D" are lower case in pandas >= 2.2.0
+            freq_lower = freq.lower()
+            if freq_lower in ["h", "bh", "cbh"]:  # hour
+                days = 1 / 24
+            elif freq_lower in ["t", "min"]:  # minute
+                days = 1 / (24 * 60)
+            elif freq_lower in ["s"]:  # second
+                days = 1 / seconds_per_day
+            elif freq_lower in ["l", "ms"]:  # millisecond
+                days = 1 / (seconds_per_day * 10**3)
+            elif freq_lower in ["u", "us"]:  # microsecond
+                days = 1 / (seconds_per_day * 10**6)
+            elif freq_lower in ["n"]:  # nanosecond
+                days = 1 / (seconds_per_day * 10**9)
+
+        if not days:
+            raise_log(
+                ValueError(
+                    f"freq {freq} not understood. Please report if you think this is in error."
+                ),
+                logger=logger,
             )
         return freq_times * days
 

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1155,8 +1155,8 @@ class TestTimeSeries:
         pd_series = pd.Series(range(10), index=times)
         timeseries = TimeSeries.from_series(pd_series)
 
-        resampled_timeseries = timeseries.resample("H")
-        assert resampled_timeseries.freq_str == "H"
+        resampled_timeseries = timeseries.resample("h")
+        assert resampled_timeseries.freq_str.lower() == "h"
         assert resampled_timeseries.pd_series().at[pd.Timestamp("20130101020000")] == 0
         assert resampled_timeseries.pd_series().at[pd.Timestamp("20130102020000")] == 1
         assert resampled_timeseries.pd_series().at[pd.Timestamp("20130109090000")] == 8


### PR DESCRIPTION
### Summary

- fixes all breaking changes from pandas v2.2.0. Mainly the breaking changes come from deprecated frequency/offset aliases (e.g. "M" (month end) becomes "ME", "T" (minutes) becomes "min"). See [here](https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#deprecate-aliases-m-q-y-etc-in-favour-of-me-qe-ye-etc-for-offsets) and [here](https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#other-deprecations).