### PR TITLE
fix wrong pandas freqstr for py38

### DIFF
--- a/darts/dataprocessing/transformers/midas.py
+++ b/darts/dataprocessing/transformers/midas.py
@@ -101,7 +101,7 @@ class MIDAS(FittableDataTransformer, InvertibleDataTransformer):
                 ),
                 logger=logger,
             )
-        self._low_freq = low_freq
+        self._low_freq = pd.tseries.frequencies.to_offset(low_freq).freqstr
         self._strip = strip
         self._drop_static_covariates = drop_static_covariates
         self._sep = "_midas_"


### PR DESCRIPTION
### Summary
- fixes last failing unit tests for py38 due to pandas version 2.2.0