### PR TITLE
fix: time index intersection for coefficient of variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - Added option to exclude some `group_cols` from being added as static covariates when using `TimeSeries.from_group_dataframe()` with parameter `drop_group_cols`.
 
 **Fixed**
+- Fixed a bug in `coefficient_of_variaton()` when `intersect=True`. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - Added option to exclude some `group_cols` from being added as static covariates when using `TimeSeries.from_group_dataframe()` with parameter `drop_group_cols`.
 
 **Fixed**
-- Fixed a bug in `coefficient_of_variaton()` when `intersect=True`. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed a bug in `coefficient_of_variaton()` with `intersect=True`, where the coefficient was not computed on the intersection. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -514,11 +514,11 @@ def coefficient_of_variation(
         The Coefficient of Variation
     """
 
-    return (
-        100
-        * rmse(actual_series, pred_series, intersect)
-        / actual_series.pd_dataframe(copy=False).mean().mean()
+    y_true, y_pred = _get_values_or_raise(
+        actual_series, pred_series, intersect, remove_nan_union=True
     )
+
+    return 100 * rmse(y_true, y_pred) / y_true.pd_dataframe(copy=False).mean().mean()
 
 
 @multi_ts_support

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -7,7 +7,7 @@ Some metrics to compare time series.
 
 from functools import wraps
 from inspect import signature
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Callable, List, Optional, Sequence, Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 # care of dealing with Sequence[TimeSeries] and multivariate TimeSeries on its own (See mase() implementation).
 
 
-def multi_ts_support(func):
+def multi_ts_support(func) -> Union[float, List[float]]:
     """
     This decorator further adapts the metrics that took as input two univariate/multivariate ``TimeSeries`` instances,
     adding support for equally-sized sequences of ``TimeSeries`` instances. The decorator computes the pairwise metric
@@ -107,7 +107,7 @@ def multi_ts_support(func):
     return wrapper_multi_ts_support
 
 
-def multivariate_support(func):
+def multivariate_support(func) -> Union[float, List[float]]:
     """
     This decorator transforms a metric function that takes as input two univariate TimeSeries instances
     into a function that takes two equally-sized multivariate TimeSeries instances, computes the pairwise univariate
@@ -279,7 +279,7 @@ def mae(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Mean Absolute Error (MAE)
     """
 
@@ -336,7 +336,7 @@ def mse(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Mean Squared Error (MSE)
     """
 
@@ -393,7 +393,7 @@ def rmse(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Root Mean Squared Error (RMSE)
     """
     return np.sqrt(mse(actual_series, pred_series, intersect))
@@ -448,7 +448,7 @@ def rmsle(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Root Mean Squared Log Error (RMSLE)
     """
 
@@ -510,7 +510,7 @@ def coefficient_of_variation(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Coefficient of Variation
     """
 
@@ -577,7 +577,7 @@ def mape(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Mean Absolute Percentage Error (MAPE)
     """
 
@@ -650,7 +650,7 @@ def smape(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The symmetric Mean Absolute Percentage Error (sMAPE)
     """
 
@@ -725,7 +725,7 @@ def mase(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Mean Absolute Scaled Error (MASE)
     """
 
@@ -907,7 +907,7 @@ def ope(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Overall Percentage Error (OPE)
     """
 
@@ -977,7 +977,7 @@ def marre(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Mean Absolute Ranged Relative Error (MARRE)
     """
 
@@ -1042,7 +1042,7 @@ def r2_score(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The Coefficient of Determination :math:`R^2`
     """
     y1, y2 = _get_values_or_raise(
@@ -1185,7 +1185,7 @@ def rho_risk(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The rho-risk metric
     """
 
@@ -1263,7 +1263,7 @@ def quantile_loss(
 
     Returns
     -------
-    float
+    Union[float, List[float]]
         The quantile loss metric
     """
 

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -518,7 +518,7 @@ def coefficient_of_variation(
         actual_series, pred_series, intersect, remove_nan_union=True
     )
     # not calling rmse as y_true and y_pred are np.ndarray
-    return 100 * np.mean((y_true - y_pred) ** 2) / y_true.mean()
+    return 100 * np.sqrt(np.mean((y_true - y_pred) ** 2)) / y_true.mean()
 
 
 @multi_ts_support

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -517,8 +517,8 @@ def coefficient_of_variation(
     y_true, y_pred = _get_values_or_raise(
         actual_series, pred_series, intersect, remove_nan_union=True
     )
-
-    return 100 * rmse(y_true, y_pred) / y_true.pd_dataframe(copy=False).mean().mean()
+    # not calling rmse as y_true and y_pred are np.ndarray
+    return 100 * np.mean((y_true - y_pred) ** 2) / y_true.mean()
 
 
 @multi_ts_support


### PR DESCRIPTION
Fixes #2157.

### Summary

- use `_get_values_or_raise` in `coefficient_of_variation` to have the appropriate denominator when `intersect = True`