### PR TITLE
Fix/RegressionEnsemble with single model regressor and coef access in LinearRegressionModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 - Fixed a bug in probabilistic `LinearRegressionModel.fit()`; the `model` attribute was not giving access to all the underlying estimators. [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
-- Fixed a bug in `RegressionEsembleModel` constructor; an exception is raised when trying to use a `regression_model` created with `multi_models=False` (not supported). [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
+- Raise an error in `RegressionEsembleModel` when the `regression_model` was created with `multi_models=False` (not supported). [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - Added option to exclude some `group_cols` from being added as static covariates when using `TimeSeries.from_group_dataframe()` with parameter `drop_group_cols`.
 
 **Fixed**
+- Fixed a bug in probabilistic `LinearRegressionModel.fit()`; the `model` attribute was not giving access to all the underlying estimators. [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed a bug in `RegressionEsembleModel` constructor; an exception is raised when trying to use a `regression_model` created with `multi_models=False` (not supported). [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 

--- a/darts/models/forecasting/linear_regression_model.py
+++ b/darts/models/forecasting/linear_regression_model.py
@@ -245,6 +245,7 @@ class LinearRegressionModel(RegressionModel, _LikelihoodMixin):
 
             for quantile in self.quantiles:
                 self.kwargs["quantile"] = quantile
+                # assign the Quantile regressor to self.model to leverage existing logic
                 self.model = QuantileRegressor(**self.kwargs)
                 super().fit(
                     series=series,
@@ -255,6 +256,9 @@ class LinearRegressionModel(RegressionModel, _LikelihoodMixin):
                 )
 
                 self._model_container[quantile] = self.model
+
+            # replace the last trained QuantileRegressor with the dictionnary of Regressors.
+            self.model = self._model_container
 
             return self
 

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -123,6 +123,11 @@ class RegressionEnsembleModel(EnsembleModel):
                 lags=None, lags_future_covariates=[0], fit_intercept=False
             )
         elif isinstance(regression_model, RegressionModel):
+            raise_if_not(
+                regression_model.multi_models,
+                "`regression_model.multi_models = False` is not supported for `RegressionEnsembleModel.",
+                logger,
+            )
             regression_model = regression_model
         else:
             # scikit-learn like model

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -125,7 +125,7 @@ class RegressionEnsembleModel(EnsembleModel):
         elif isinstance(regression_model, RegressionModel):
             raise_if_not(
                 regression_model.multi_models,
-                "`regression_model.multi_models = False` is not supported for `RegressionEnsembleModel.",
+                "Cannot use `regression_model` that was created with `multi_models = False`.",
                 logger,
             )
             regression_model = regression_model

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -194,7 +194,7 @@ class RegressionModel(GlobalForecastingModel):
         self.lags: Dict[str, List[int]] = {}
         self.component_lags: Dict[str, Dict[str, List[int]]] = {}
         self.input_dim = None
-        self.multi_models = multi_models
+        self.multi_models = True if multi_models or output_chunk_length == 1 else False
         self._considers_static_covariates = use_static_covariates
         self._static_covariates_shape: Optional[Tuple[int, int]] = None
         self._lagged_feature_names: Optional[List[str]] = None

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -884,6 +884,31 @@ class TestRegressionEnsembleModels:
             pred_ens["linear_q0.05"].values() < pred_ens["linear_q0.50"].values()
         ) and all(pred_ens["linear_q0.50"].values() < pred_ens["linear_q0.95"].values())
 
+    def test_wrong_model_creation_params(self):
+        """Since `multi_models=False` requires to shift the regression model lags in the past (outside of the forecasting
+        model predictions), it is not supported."""
+        forcasting_models = [
+            self.get_deterministic_global_model(2),
+            self.get_deterministic_global_model([-5, -7]),
+        ]
+        RegressionEnsembleModel(
+            forecasting_models=forcasting_models,
+            regression_train_n_points=10,
+            regression_model=LinearRegressionModel(
+                lags_future_covariates=[0], output_chunk_length=2, multi_models=True
+            ),
+        )
+        with pytest.raises(ValueError):
+            RegressionEnsembleModel(
+                forecasting_models=forcasting_models,
+                regression_train_n_points=10,
+                regression_model=LinearRegressionModel(
+                    lags_future_covariates=[0],
+                    output_chunk_length=2,
+                    multi_models=False,
+                ),
+            )
+
     @staticmethod
     def get_probabilistic_global_model(
         lags: Union[int, List[int]],


### PR DESCRIPTION
Fixes #2200.

### Summary
- prevent creation of RegressionEnsemble with a `regression_model` with `multi_models=False` as it would require additional forecasts (and potentially auto-regression) from the `forecasting_models` when calling `predict()`.
- overwrite the `model` attribute of probabilistic `LinearRegressionModel` with the sub-models containers to make the access of the coefficients more intuitive