### PR TITLE
fix: update hierarchy for single transform window_transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - Added option to exclude some `group_cols` from being added as static covariates when using `TimeSeries.from_group_dataframe()` with parameter `drop_group_cols`.
 - Improvements to `TorchForecastingModel`:
   - Added support for additional lr scheduler configuration parameters for more control ("interval", "frequency", "monitor", "strict", "name"). [#2218](https://github.com/unit8co/darts/pull/2218) by [Dennis Bader](https://github.com/dennisbader).
+- Improvements to `WindowTransformer` and `window_transform`:
+  - Added `keep_old_names` argument to indicated if transformed components should be renamed. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
 
 **Fixed**
 - Fixed bug when calling `window_transform` on a `TimeSeries` with a hierarchy; the hierarchy is preserved for single transformations applied to all components, or removed (`None`) otherwise. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - Added option to exclude some `group_cols` from being added as static covariates when using `TimeSeries.from_group_dataframe()` with parameter `drop_group_cols`.
 
 **Fixed**
-- Fixed bug when calling `window_transform` on a `TimeSeries` with a hierarchy; the hierachy is preserved for single transform applied to all the components, or set one `None` otherwise. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed bug when calling `window_transform` on a `TimeSeries` with a hierarchy; the hierarchy is preserved for single transformations applied to all components, or removed (`None`) otherwise. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - Added option to exclude some `group_cols` from being added as static covariates when using `TimeSeries.from_group_dataframe()` with parameter `drop_group_cols`.
 
 **Fixed**
+- Fixed bug when calling `window_transform` on a `TimeSeries` with a hierarchy; the hierachy is preserved for single transform applied to all the components, or set one `None` otherwise. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Improvements to `TorchForecastingModel`:
   - Added support for additional lr scheduler configuration parameters for more control ("interval", "frequency", "monitor", "strict", "name"). [#2218](https://github.com/unit8co/darts/pull/2218) by [Dennis Bader](https://github.com/dennisbader).
 - Improvements to `WindowTransformer` and `window_transform`:
-  - Added `keep_old_names` argument to indicated if transformed components should be renamed. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
+  - Added argument `keep_names` to indicate whether the original component names should be kept. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
 
 **Fixed**
-- Fixed bug when calling `window_transform` on a `TimeSeries` with a hierarchy; the hierarchy is preserved for single transformations applied to all components, or removed (`None`) otherwise. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed a bug when calling `window_transform` on a `TimeSeries` with a hierarchy. The hierarchy is now only preseved for single transformations applied to all components, or removed otherwise. [#2207](https://github.com/unit8co/darts/pull/2207)by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug in probabilistic `LinearRegressionModel.fit()`, where the `model` attribute was not pointing to all underlying estimators. [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
 - Raise an error in `RegressionEsembleModel` when the `regression_model` was created with `multi_models=False` (not supported). [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug in `coefficient_of_variaton()` with `intersect=True`, where the coefficient was not computed on the intersection. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).

--- a/darts/dataprocessing/transformers/window_transformer.py
+++ b/darts/dataprocessing/transformers/window_transformer.py
@@ -20,6 +20,7 @@ class WindowTransformer(BaseDataTransformer):
         forecasting_safe: Optional[bool] = True,
         keep_non_transformed: Optional[bool] = False,
         include_current: Optional[bool] = True,
+        keep_old_names: Optional[bool] = False,
         name: str = "WindowTransformer",
         n_jobs: int = 1,
         verbose: bool = False,
@@ -128,6 +129,10 @@ class WindowTransformer(BaseDataTransformer):
         include_current
             ``True`` to include the current time step in the window, ``False`` to exclude it. Default is ``True``.
 
+        keep_old_names
+            Indicate if the transformed components should be renamed or not. Must be set to ``False`` if
+            `keep_non_transformed = True` or the number of transformation is greater than 1.
+
         name
             A specific name for the transformer.
 
@@ -147,6 +152,7 @@ class WindowTransformer(BaseDataTransformer):
         self.treat_na = treat_na
         self.forecasting_safe = forecasting_safe
         self.include_current = include_current
+        self.keep_old_names = keep_old_names
         super().__init__(name, n_jobs, verbose)
 
     @staticmethod

--- a/darts/dataprocessing/transformers/window_transformer.py
+++ b/darts/dataprocessing/transformers/window_transformer.py
@@ -20,7 +20,7 @@ class WindowTransformer(BaseDataTransformer):
         forecasting_safe: Optional[bool] = True,
         keep_non_transformed: Optional[bool] = False,
         include_current: Optional[bool] = True,
-        keep_old_names: Optional[bool] = False,
+        keep_names: Optional[bool] = False,
         name: str = "WindowTransformer",
         n_jobs: int = 1,
         verbose: bool = False,
@@ -124,14 +124,14 @@ class WindowTransformer(BaseDataTransformer):
 
         keep_non_transformed
             ``False`` to return the transformed components only, ``True`` to return all original components along
-            the transformed ones. Default is ``False``.
+            the transformed ones. Default is ``False``. If the series has a hierarchy, must be set to ``False``.
 
         include_current
             ``True`` to include the current time step in the window, ``False`` to exclude it. Default is ``True``.
 
-        keep_old_names
-            Indicate if the transformed components should be renamed or not. Must be set to ``False`` if
-            `keep_non_transformed = True` or the number of transformation is greater than 1.
+        keep_names
+            Whether the transformed components should keep the original component names or. Must be set to ``False``
+            if `keep_non_transformed = True` or the number of transformation is greater than 1.
 
         name
             A specific name for the transformer.
@@ -152,7 +152,7 @@ class WindowTransformer(BaseDataTransformer):
         self.treat_na = treat_na
         self.forecasting_safe = forecasting_safe
         self.include_current = include_current
-        self.keep_old_names = keep_old_names
+        self.keep_names = keep_names
         super().__init__(name, n_jobs, verbose)
 
     @staticmethod

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -152,7 +152,7 @@ class TestTimeSeriesWindowTransform:
             }  # forecating_safe=True vs center=True
             self.series_univ_det.window_transform(transforms=window_transformations)
 
-        # keep_old_names and overlapping transforms
+        # keep_names and overlapping transforms
         with pytest.raises(ValueError) as err:
             window_transformations = [
                 {
@@ -169,14 +169,14 @@ class TestTimeSeriesWindowTransform:
                 },
             ]
             self.series_multi_det.window_transform(
-                transforms=window_transformations, keep_old_names=True
+                transforms=window_transformations, keep_names=True
             )
         assert str(err.value) == (
-            "Cannot keep the original components names as some transforms are overlapping "
-            "(applied to the same components). Set `keep_old_names` to `False`."
+            "Cannot keep the original component names as some transforms are overlapping "
+            "(applied to the same components). Set `keep_names` to `False`."
         )
 
-        # keep_old_names and keep_non_transformed
+        # keep_names and keep_non_transformed
         with pytest.raises(ValueError) as err:
             window_transformations = [
                 {
@@ -188,12 +188,11 @@ class TestTimeSeriesWindowTransform:
             ]
             self.series_multi_det.window_transform(
                 transforms=window_transformations,
-                keep_old_names=True,
+                keep_names=True,
                 keep_non_transformed=True,
             )
         assert str(err.value) == (
-            "`keep_old_names = True` and `keep_non_transformed = True` is not supported due to "
-            "the ambiguity."
+            "`keep_names = True` and `keep_non_transformed = True` cannot be used together."
         )
 
     def test_ts_windowtransf_output_series(self):
@@ -563,7 +562,7 @@ class TestTimeSeriesWindowTransform:
         }
 
         # keeping original components name
-        ts_tr = ts.window_transform(transforms=transforms, keep_old_names=True)
+        ts_tr = ts.window_transform(transforms=transforms, keep_names=True)
         assert ts_tr.hierarchy == ts.hierarchy == {"C": ["A"], "B": ["A"]}
 
     @pytest.mark.parametrize(
@@ -762,7 +761,7 @@ class TestWindowTransformer:
         # keeping old components
         window_transformer = WindowTransformer(
             transforms=transform,
-            keep_old_names=True,
+            keep_names=True,
         )
         ts_tr = window_transformer.transform(ts)
         assert ts_tr.hierarchy == ts.hierarchy == {"C": ["A"], "B": ["A"]}

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4521,9 +4521,9 @@ class TimeSeries:
 
         time_dim = xa.dims[0]
         sorted_xa = cls._sort_index(xa, copy=False)
-        time_index: Union[pd.Index, pd.RangeIndex, pd.DatetimeIndex] = (
-            sorted_xa.get_index(time_dim)
-        )
+        time_index: Union[
+            pd.Index, pd.RangeIndex, pd.DatetimeIndex
+        ] = sorted_xa.get_index(time_dim)
 
         if isinstance(time_index, pd.DatetimeIndex):
             has_datetime_index = True

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3610,10 +3610,9 @@ class TimeSeries:
         comp_names_map = None
         if self.hierarchy:
             several_transforms = len(transforms) > 1
-            partial_transform = (
-                "components" in transforms[0]
-                and transforms[0]["components"] != self.components
-            )
+            partial_transform = "components" in transforms[0] and len(
+                set(transforms[0]["components"]).intersection(set(self.components))
+            ) == len(self.components)
             # warning message in case of transform introducing ambiguity in the hierarchy
             if several_transforms or partial_transform:
                 logger.warning(

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4521,7 +4521,9 @@ class TimeSeries:
 
         time_dim = xa.dims[0]
         sorted_xa = cls._sort_index(xa, copy=False)
-        time_index: Union[pd.Index, pd.RangeIndex, pd.DatetimeIndex] = (
+        time_index: Union[
+            pd.Index, pd.RangeIndex, pd.DatetimeIndex
+        ] = (
             sorted_xa.get_index(time_dim)
         )
 

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4521,9 +4521,7 @@ class TimeSeries:
 
         time_dim = xa.dims[0]
         sorted_xa = cls._sort_index(xa, copy=False)
-        time_index: Union[
-            pd.Index, pd.RangeIndex, pd.DatetimeIndex
-        ] = (
+        time_index: Union[pd.Index, pd.RangeIndex, pd.DatetimeIndex] = (
             sorted_xa.get_index(time_dim)
         )
 

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3607,7 +3607,7 @@ class TimeSeries:
         if isinstance(transforms, dict):
             transforms = [transforms]
 
-        comp_names_map = None
+        convert_hierarchy = False
         if self.hierarchy:
             several_transforms = len(transforms) > 1
             partial_transform = "components" in transforms[0] and len(
@@ -3618,6 +3618,8 @@ class TimeSeries:
                 logger.warning(
                     "The hierarchy cannot be automatically updated, due to partial or chained transforms."
                 )
+            else:
+                convert_hierarchy = True
                 comp_names_map = dict()
 
         raise_if_not(
@@ -3701,7 +3703,7 @@ class TimeSeries:
                 [f"{name_prefix}_{comp_name}" for comp_name in comps_to_transform]
             )
 
-            if comp_names_map:
+            if convert_hierarchy:
                 comp_names_map.update(
                     {
                         comp_name: f"{name_prefix}_{comp_name}"
@@ -3762,7 +3764,7 @@ class TimeSeries:
         # revert dataframe to TimeSeries
         new_index = original_index.__class__(resulting_transformations.index)
 
-        if comp_names_map:
+        if convert_hierarchy:
             new_hierarchy = dict()
             for k, v in self.hierarchy.items():
                 new_hierarchy[comp_names_map[k]] = [

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -3234,7 +3234,7 @@ class TimeSeries:
         # TODO: check
         if method == "pad":
             new_xa = resample.pad()
-        elif method == "bfill":
+        elif method in ["bfill", "backfill"]:
             new_xa = resample.backfill()
         else:
             raise_log(ValueError(f"Unknown method: {method}"), logger)


### PR DESCRIPTION
Fixes #2204, fixes #2209.

### Summary

- If `window_transform()` is called with only one transform on all the components of the series, update the hierarchy with the new components names, otherwise, it's dropped.