### PR TITLE
Pre commit hooks upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     rev: v3.15.0
     hooks:
     -   id: pyupgrade
-        args: ['--py39-plus']
+        args: ['--py38-plus']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.1.1
     hooks:
       - id: black-jupyter
         language_version: python3
@@ -12,12 +12,12 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.13.2
     hooks:
       -  id: isort
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
-        args: ['--py37-plus']
+        args: ['--py39-plus']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
     -   id: flake8
         language_version: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug in `coefficient_of_variaton()` with `intersect=True`, where the coefficient was not computed on the intersection. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
+- Updated pre-commit hooks to the latest version using `pre-commit autoupdate`.
+- Change `pyupgrade` pre-commit hook argument to `--py39-plus`. This allows for [type rewriting](https://github.com/asottile/pyupgrade?tab=readme-ov-file#pep-585-typing-rewrites).
 
 ## [0.27.2](https://github.com/unit8co/darts/tree/0.27.2) (2023-01-21)
 ### For users of the library:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 ### For developers of the library:
 - Updated pre-commit hooks to the latest version using `pre-commit autoupdate`.
-- Change `pyupgrade` pre-commit hook argument to `--py39-plus`. This allows for [type rewriting](https://github.com/asottile/pyupgrade?tab=readme-ov-file#pep-585-typing-rewrites).
+- Change `pyupgrade` pre-commit hook argument to `--py38-plus`. This allows for [type rewriting](https://github.com/asottile/pyupgrade?tab=readme-ov-file#pep-585-typing-rewrites).
 
 ## [0.27.2](https://github.com/unit8co/darts/tree/0.27.2) (2023-01-21)
 ### For users of the library:


### PR DESCRIPTION
Update pre-commit hooks to their latest version.

it originated with a bug with flake8 hook on my computer that didn't want to run. The upgrade fixed it.