### PR TITLE
Fix/ts prepend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Fixed**
 - Fixed a bug in probabilistic `LinearRegressionModel.fit()`, where the `model` attribute was not pointing to all underlying estimators. [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
 - Raise an error in `RegressionEsembleModel` when the `regression_model` was created with `multi_models=False` (not supported). [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
-- Fixed a bug in `coefficient_of_variaton()` with `intersect=True`, where the coefficient was not computed on the intersection. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed a bug in `coefficient_of_variation()` with `intersect=True`, where the coefficient was not computed on the intersection. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed a bug in `TimeSeries.append/prepend_values()`, where the components names and the hierarchy were reset. [#2237](https://github.com/unit8co/darts/pull/2237) by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug in probabilistic `LinearRegressionModel.fit()`, where the `model` attribute was not pointing to all underlying estimators. [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
 - Raise an error in `RegressionEsembleModel` when the `regression_model` was created with `multi_models=False` (not supported). [#2205](https://github.com/unit8co/darts/pull/2205) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a bug in `coefficient_of_variation()` with `intersect=True`, where the coefficient was not computed on the intersection. [#2202](https://github.com/unit8co/darts/pull/2202) by [Antoine Madrona](https://github.com/madtoinou).
-- Fixed a bug in `TimeSeries.append/prepend_values()`, where the components names and the hierarchy were reset. [#2237](https://github.com/unit8co/darts/pull/2237) by [Antoine Madrona](https://github.com/madtoinou).
+- Fixed a bug in `TimeSeries.append/prepend_values()`, where the components names and the hierarchy were dropped. [#2237](https://github.com/unit8co/darts/pull/2237) by [Antoine Madrona](https://github.com/madtoinou).
 
 ### For developers of the library:
 - Updated pre-commit hooks to the latest version using `pre-commit autoupdate`.

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2809,8 +2809,6 @@ class TimeSeries:
                 times=idx,
                 fill_missing_dates=False,
                 static_covariates=self.static_covariates,
-                columns=self.columns,
-                hierarchy=self.hierarchy,
             )
         )
 

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2742,7 +2742,7 @@ class TimeSeries:
         )
         raise_if_not(
             other.freq == self.freq,
-            "Appended TimeSeries must have the same frequency as the current one",
+            "Both series must have the same frequency.",
             logger,
         )
         raise_if_not(
@@ -2809,6 +2809,8 @@ class TimeSeries:
                 times=idx,
                 fill_missing_dates=False,
                 static_covariates=self.static_covariates,
+                columns=self.columns,
+                hierarchy=self.hierarchy,
             )
         )
 
@@ -2873,6 +2875,8 @@ class TimeSeries:
                 times=idx,
                 fill_missing_dates=False,
                 static_covariates=self.static_covariates,
+                columns=self.columns,
+                hierarchy=self.hierarchy,
             )
         )
 


### PR DESCRIPTION
Fixes #2230.

### Summary

- when calling `append/prepend` on two series, the hierarchy and components names of the series with the "earlier" index are retained
- when calling `append/prepend_values`, the hierarchy and components of the series are retained

### Other Information

Not sure if the hierarchy should be retained or not. Since the components don't change, it should be easy to assign the "old" hierarchy to resulting series but at the same time, adding values should not affect the relationship between the components so keeping by default sounds reasonnable.
