### PR TITLE
fix ElectricityConsumptionZurich dataset hash

### DIFF
--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -18,8 +18,6 @@ from darts.utils.utils import _build_tqdm_iterator
 
 from .dataset_loaders import DatasetLoaderCSV, DatasetLoaderMetadata
 
-pd_above_v22 = pd.__version__ >= "2.2"
-
 """
     Overall usage of this package:
     from darts.datasets import AirPassengersDataset
@@ -890,12 +888,8 @@ class ElectricityConsumptionZurichDataset(DatasetLoaderCSV):
             df.index.name = "Timestamp"
             df.to_csv(self._get_path_dataset())
 
-        # pandas v2.2.0 introduced some changes
-        hash_expected = (
-            "485d81e9902cc0ccb1f86d7e01fb37cd"
-            if pd_above_v22
-            else "a019125b7f9c1afeacb0ae60ce7455ef"
-        )
+        # pandas v2.2.0 introduced a bug that was fixed in v2.2.1; the expected hash for 2.2.0
+        # is "485d81e9902cc0ccb1f86d7e01fb37cd"
         # hash value for dataset with weather data
         super().__init__(
             metadata=DatasetLoaderMetadata(
@@ -905,7 +899,7 @@ class ElectricityConsumptionZurichDataset(DatasetLoaderCSV):
                     "ewz_stromabgabe_netzebenen_stadt_zuerich/"
                     "download/ewz_stromabgabe_netzebenen_stadt_zuerich.csv"
                 ),
-                hash=hash_expected,
+                hash="a019125b7f9c1afeacb0ae60ce7455ef",
                 header_time="Timestamp",
                 freq="15min",
                 pre_process_csv_fn=pre_process_dataset,


### PR DESCRIPTION
### Summary

- pandas v2.2.0. introduced a bug which resulted in a different hash for the ElectricityConsumptionZurich dataset
- the bug was fixed in v2.2.1, and we can use the original hash again