### PR TITLE
fix failing dataset unit tests for py38

### DIFF
--- a/darts/tests/datasets/test_datasets.py
+++ b/darts/tests/datasets/test_datasets.py
@@ -507,7 +507,7 @@ if TORCH_AVAILABLE:
             target = self.target1[: -(ocl + ocs)]
 
             ds_covs = {}
-            ds_init_params = set(inspect.signature(ds_cls).parameters)
+            ds_init_params = set(inspect.signature(ds_cls.__init__).parameters)
             for cov_type in ["covariates", "past_covariates", "future_covariates"]:
                 if cov_type in ds_init_params:
                     ds_covs[cov_type] = self.cov1
@@ -1388,7 +1388,7 @@ if TORCH_AVAILABLE:
             target = self.target1[: -(ocl + ocs)]
 
             ds_covs = {}
-            ds_init_params = set(inspect.signature(ds_cls).parameters)
+            ds_init_params = set(inspect.signature(ds_cls.__init__).parameters)
             for cov_type in ["covariates", "past_covariates", "future_covariates"]:
                 if cov_type in ds_init_params:
                     ds_covs[cov_type] = self.cov1


### PR DESCRIPTION
### Summary
- fixes failing dataset unit tests for python 3.8, where `inspect.signature` did not yet access the `cls.__init__()` method directly