### PR TITLE
Add supports probabilistic prediction

### DIFF
--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -162,7 +162,7 @@ class ShapExplainer(_ForecastingModelExplainer):
             test_stationarity=True,
         )
 
-        if model._is_probabilistic:
+        if model.supports_probabilistic_prediction:
             logger.warning(
                 "The model is probabilistic, but num_samples=1 will be used for explainability."
             )

--- a/darts/models/forecasting/arima.py
+++ b/darts/models/forecasting/arima.py
@@ -233,7 +233,7 @@ class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
         return self._build_forecast_series(forecast)
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True
 
     @property

--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -326,7 +326,7 @@ class CatBoostModel(RegressionModel, _LikelihoodMixin):
             return None
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return self.likelihood is not None
 
     @property

--- a/darts/models/forecasting/croston.py
+++ b/darts/models/forecasting/croston.py
@@ -164,7 +164,3 @@ class Croston(FutureCovariatesLocalForecastingModel):
     @property
     def _supports_range_index(self) -> bool:
         return True
-
-    @property
-    def supports_probabilistic_prediction(self) -> bool:
-        return False

--- a/darts/models/forecasting/croston.py
+++ b/darts/models/forecasting/croston.py
@@ -166,5 +166,5 @@ class Croston(FutureCovariatesLocalForecastingModel):
         return True
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return False

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -119,7 +119,7 @@ class EnsembleModel(GlobalForecastingModel):
         raise_if(
             train_num_samples is not None
             and train_num_samples > 1
-            and all([not m._is_probabilistic for m in forecasting_models]),
+            and all([not m.supports_probabilistic_prediction for m in forecasting_models]),
             "`train_num_samples` is greater than 1 but the `RegressionEnsembleModel` "
             "contains only deterministic `forecasting_models`.",
             logger,
@@ -261,7 +261,7 @@ class EnsembleModel(GlobalForecastingModel):
                 future_covariates=(
                     future_covariates if model.supports_future_covariates else None
                 ),
-                num_samples=num_samples if model._is_probabilistic else 1,
+                num_samples=num_samples if model.supports_probabilistic_prediction else 1,
                 predict_likelihood_parameters=predict_likelihood_parameters,
             )
             for model in self.forecasting_models
@@ -432,7 +432,7 @@ class EnsembleModel(GlobalForecastingModel):
 
     @property
     def _models_are_probabilistic(self) -> bool:
-        return all([model._is_probabilistic for model in self.forecasting_models])
+        return all([model.supports_probabilistic_prediction for model in self.forecasting_models])
 
     @property
     def _models_same_likelihood(self) -> bool:
@@ -480,7 +480,7 @@ class EnsembleModel(GlobalForecastingModel):
         )
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return self._models_are_probabilistic
 
     @property

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -159,7 +159,7 @@ class ExponentialSmoothing(LocalForecastingModel):
         return False
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True
 
     @property

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -250,7 +250,6 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         """
         Whether the model supports prediction for any input `series`.
         """
-        pass
 
     @property
     def uses_past_covariates(self) -> bool:
@@ -488,7 +487,6 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         >>> model.extreme_lags
         (-10, 6, None, None, 4, 6, 0)
         """
-        pass
 
     @property
     def _training_sample_time_index_length(self) -> int:
@@ -1870,7 +1868,6 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         Must return Tuple (input_chunk_length, output_chunk_length, takes_past_covariates, takes_future_covariates,
         lags_past_covariates, lags_future_covariates).
         """
-        pass
 
     @classmethod
     def _sample_params(model_class, params, n_random_samples):
@@ -2481,7 +2478,6 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
         """Fits/trains the model on the provided series.
         DualCovariatesModels must implement the fit logic in this method.
         """
-        pass
 
     def predict(
         self,
@@ -2575,7 +2571,6 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
         """Forecasts values for a certain number of time steps after the end of the series.
         DualCovariatesModels must implement the predict logic in this method.
         """
-        pass
 
     @property
     def _model_encoder_settings(
@@ -2778,7 +2773,6 @@ class TransferableFutureCovariatesLocalForecastingModel(
         """Forecasts values for a certain number of time steps after the end of the series.
         TransferableFutureCovariatesLocalForecastingModel must implement the predict logic in this method.
         """
-        pass
 
     @property
     def supports_transferrable_series_prediction(self) -> bool:

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -192,9 +192,10 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         return True
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         """
-        Checks if the forecasting model supports probabilistic predictions.
+        Checks if the forecasting model with this configuration supports probabilistic predictions.
+
         By default, returns False. Needs to be overwritten by models that do support
         probabilistic predictions.
         """
@@ -204,7 +205,9 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
     def _supports_non_retrainable_historical_forecasts(self) -> bool:
         """
         Checks if the forecasting model supports historical forecasts without retraining
-        the model. By default, returns False. Needs to be overwritten by models that do
+        the model.
+
+        By default, returns False. Needs to be overwritten by models that do
         support historical forecasts without retraining.
         """
         return False
@@ -346,7 +349,7 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
                 logger=logger,
             )
 
-        if not self._is_probabilistic and num_samples > 1:
+        if not self.supports_probabilistic_prediction and num_samples > 1:
             raise_log(
                 ValueError(
                     "`num_samples > 1` is only supported for probabilistic models."

--- a/darts/models/forecasting/global_baseline_models.py
+++ b/darts/models/forecasting/global_baseline_models.py
@@ -235,7 +235,7 @@ class _GlobalNaiveModel(MixedCovariatesTorchModel, ABC):
     def supports_likelihood_parameter_prediction(self) -> bool:
         return False
 
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return False
 
     @property

--- a/darts/models/forecasting/kalman_forecaster.py
+++ b/darts/models/forecasting/kalman_forecaster.py
@@ -171,5 +171,5 @@ class KalmanForecaster(TransferableFutureCovariatesLocalForecastingModel):
         return True
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True

--- a/darts/models/forecasting/lgbm.py
+++ b/darts/models/forecasting/lgbm.py
@@ -310,7 +310,7 @@ class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
             )
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return self.likelihood is not None
 
     @property

--- a/darts/models/forecasting/linear_regression_model.py
+++ b/darts/models/forecasting/linear_regression_model.py
@@ -305,5 +305,5 @@ class LinearRegressionModel(RegressionModel, _LikelihoodMixin):
             )
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return self.likelihood is not None

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -468,7 +468,7 @@ class PLForecastingModule(pl.LightningModule, ABC):
             module.mc_dropout_enabled = active
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return self.likelihood is not None or len(self._get_mc_dropout_modules()) > 0
 
     def _produce_predict_output(self, x: Tuple) -> torch.Tensor:

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -386,7 +386,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
         return False
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True
 
     def _stochastic_samples(self, predict_df, n_samples) -> np.ndarray:

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -222,7 +222,7 @@ class RegressionEnsembleModel(EnsembleModel):
                 ),
                 forecast_horizon=model.output_chunk_length,
                 stride=model.output_chunk_length,
-                num_samples=num_samples if model._is_probabilistic else 1,
+                num_samples=num_samples if model.supports_probabilistic_prediction else 1,
                 start=-start_hist_forecasts,
                 start_format="position",
                 retrain=False,
@@ -486,9 +486,9 @@ class RegressionEnsembleModel(EnsembleModel):
         )
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         """
         A RegressionEnsembleModel is probabilistic if its regression
         model is probabilistic (ensembling layer)
         """
-        return self.regression_model._is_probabilistic
+        return self.regression_model.supports_probabilistic_prediction

--- a/darts/models/forecasting/sf_auto_arima.py
+++ b/darts/models/forecasting/sf_auto_arima.py
@@ -134,5 +134,5 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
         return True
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True

--- a/darts/models/forecasting/sf_auto_ces.py
+++ b/darts/models/forecasting/sf_auto_ces.py
@@ -86,5 +86,5 @@ class StatsForecastAutoCES(LocalForecastingModel):
         return True
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return False

--- a/darts/models/forecasting/sf_auto_ces.py
+++ b/darts/models/forecasting/sf_auto_ces.py
@@ -84,7 +84,3 @@ class StatsForecastAutoCES(LocalForecastingModel):
     @property
     def _supports_range_index(self) -> bool:
         return True
-
-    @property
-    def supports_probabilistic_prediction(self) -> bool:
-        return False

--- a/darts/models/forecasting/sf_auto_ets.py
+++ b/darts/models/forecasting/sf_auto_ets.py
@@ -164,5 +164,5 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         return True
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True

--- a/darts/models/forecasting/sf_auto_theta.py
+++ b/darts/models/forecasting/sf_auto_theta.py
@@ -99,5 +99,5 @@ class StatsForecastAutoTheta(LocalForecastingModel):
         return True
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True

--- a/darts/models/forecasting/tbats_model.py
+++ b/darts/models/forecasting/tbats_model.py
@@ -248,7 +248,7 @@ class _BaseBatsTbatsModel(LocalForecastingModel, ABC):
         return False
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True
 
     @property

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -2051,9 +2051,9 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         )
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return (
-            self.model._is_probabilistic
+            self.model.supports_probabilistic_prediction
             if self.model_created
             else True  # all torch models can be probabilistic (via Dropout)
         )

--- a/darts/models/forecasting/varima.py
+++ b/darts/models/forecasting/varima.py
@@ -254,7 +254,7 @@ class VARIMA(TransferableFutureCovariatesLocalForecastingModel):
         return 30
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return True
 
     @property

--- a/darts/models/forecasting/xgboost.py
+++ b/darts/models/forecasting/xgboost.py
@@ -328,7 +328,7 @@ class XGBModel(RegressionModel, _LikelihoodMixin):
             )
 
     @property
-    def _is_probabilistic(self) -> bool:
+    def supports_probabilistic_prediction(self) -> bool:
         return self.likelihood is not None
 
     @property

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -381,7 +381,7 @@ if TORCH_AVAILABLE:
                 series=series,
                 past_covariates=past_covariates,
                 future_covariates=future_covariates,
-                num_samples=(100 if model._is_probabilistic else 1),
+                num_samples=(100 if model.supports_probabilistic_prediction else 1),
             )
 
             if isinstance(y_hat, TimeSeries):

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -199,7 +199,7 @@ class TestEnsembleModels:
 
         # only probabilistic forecasting models
         naive_ensemble_proba = NaiveEnsembleModel([model_proba_1, model_proba_2])
-        assert naive_ensemble_proba._is_probabilistic
+        assert naive_ensemble_proba.supports_probabilistic_prediction
 
         naive_ensemble_proba.fit(self.series1 + self.series2)
         # by default, only 1 sample

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -447,7 +447,7 @@ if TORCH_AVAILABLE:
             )
 
             # when model is fit using 1 training and 1 covariate series, time series args are optional
-            if model._is_probabilistic:
+            if model.supports_probabilistic_prediction:
                 return
             model = model_cls(
                 input_chunk_length=IN_LEN, output_chunk_length=OUT_LEN, **kwargs
@@ -661,7 +661,7 @@ if TORCH_AVAILABLE:
             model.fit(multiple_ts)
 
             # safe random state for two successive identical predictions
-            if model._is_probabilistic:
+            if model.supports_probabilistic_prediction:
                 random_state = deepcopy(model._random_instance)
             else:
                 random_state = None

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -610,7 +610,7 @@ class TestRegressionEnsembleModels:
         )
 
         assert ensemble_allproba._models_are_probabilistic
-        assert ensemble_allproba._is_probabilistic
+        assert ensemble_allproba.supports_probabilistic_prediction
         ensemble_allproba.fit(self.ts_random_walk[:100])
         # probabilistic forecasting is supported
         pred = ensemble_allproba.predict(5, num_samples=10)
@@ -627,7 +627,7 @@ class TestRegressionEnsembleModels:
         )
 
         assert not ensemble_mixproba._models_are_probabilistic
-        assert ensemble_mixproba._is_probabilistic
+        assert ensemble_mixproba.supports_probabilistic_prediction
         ensemble_mixproba.fit(self.ts_random_walk[:100])
         # probabilistic forecasting is supported
         pred = ensemble_mixproba.predict(5, num_samples=10)
@@ -647,7 +647,7 @@ class TestRegressionEnsembleModels:
         )
 
         assert not ensemble_mixproba2._models_are_probabilistic
-        assert ensemble_mixproba2._is_probabilistic
+        assert ensemble_mixproba2.supports_probabilistic_prediction
         ensemble_mixproba2.fit(self.ts_random_walk[:100])
         pred = ensemble_mixproba2.predict(5, num_samples=10)
         assert pred.n_samples == 10
@@ -663,7 +663,7 @@ class TestRegressionEnsembleModels:
         )
 
         assert not ensemble_proba_reg._models_are_probabilistic
-        assert ensemble_proba_reg._is_probabilistic
+        assert ensemble_proba_reg.supports_probabilistic_prediction
         ensemble_proba_reg.fit(self.ts_random_walk[:100])
         # probabilistic forecasting is supported
         pred = ensemble_proba_reg.predict(5, num_samples=10)
@@ -680,7 +680,7 @@ class TestRegressionEnsembleModels:
         )
 
         assert ensemble_dete_reg._models_are_probabilistic
-        assert not ensemble_dete_reg._is_probabilistic
+        assert not ensemble_dete_reg.supports_probabilistic_prediction
         ensemble_dete_reg.fit(self.ts_random_walk[:100])
         # deterministic forecasting is supported
         ensemble_dete_reg.predict(5, num_samples=1)
@@ -699,7 +699,7 @@ class TestRegressionEnsembleModels:
         )
 
         assert not ensemble_alldete._models_are_probabilistic
-        assert not ensemble_alldete._is_probabilistic
+        assert not ensemble_alldete.supports_probabilistic_prediction
         ensemble_alldete.fit(self.ts_random_walk[:100])
         # deterministic forecasting is supported
         ensemble_alldete.predict(5, num_samples=1)


### PR DESCRIPTION
Implements #2259

### Summary

Renames the private property `ForecastingModel._is_probabilistic` to a public (still non-abstract) property `supports_probabilistic_prediction`.