### PR TITLE
fix lighgbm segmentation fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,9 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `InvertibleDataTransformer` now supports parallelized inverse transformation for `series` being a list of lists of `TimeSeries` (`Sequence[Sequence[TimeSeries]]`). This `series` type represents for example the output from `historical_forecasts()` when using multiple series.
 
 **Fixed**
-- fixed a bug in `quantile_loss`, where the loss was computed on all samples rather than only on the predicted quantiles. [#2284](https://github.com/unit8co/darts/pull/2284) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a bug in `quantile_loss`, where the loss was computed on all samples rather than only on the predicted quantiles. [#2284](https://github.com/unit8co/darts/pull/2284) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed type hint warning "Unexpected argument" when calling `historical_forecasts()` caused by the `_with_sanity_checks` decorator. The type hinting is now properly configured to expect any input arguments and return the output type of the method for which the sanity checks are performed for. [#2286](https://github.com/unit8co/darts/pull/2286) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a segmentation fault that some users were facing when importing a `LightGBMModel`. [#2304](https://github.com/unit8co/darts/pull/2304) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 

--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -7,6 +7,14 @@ from darts.logging import get_logger
 
 logger = get_logger(__name__)
 
+from darts.models.utils import NotImportedModule
+
+try:
+    # `lightgbm` needs to be imported first to avoid segmentation fault
+    from darts.models.forecasting.lgbm import LightGBMModel
+except ModuleNotFoundError:
+    LightGBMModel = NotImportedModule(module_name="LightGBM", warn=False)
+
 # Forecasting
 from darts.models.forecasting.arima import ARIMA
 from darts.models.forecasting.auto_arima import AutoARIMA
@@ -26,7 +34,6 @@ from darts.models.forecasting.regression_model import RegressionModel
 from darts.models.forecasting.tbats_model import BATS, TBATS
 from darts.models.forecasting.theta import FourTheta, Theta
 from darts.models.forecasting.varima import VARIMA
-from darts.models.utils import NotImportedModule
 
 try:
     from darts.models.forecasting.block_rnn_model import BlockRNNModel
@@ -50,11 +57,6 @@ except ModuleNotFoundError:
         'To enable them, install "darts", "u8darts[torch]" or "u8darts[all]" (with pip); '
         'or "u8darts-torch" or "u8darts-all" (with conda).'
     )
-
-try:
-    from darts.models.forecasting.lgbm import LightGBMModel
-except ModuleNotFoundError:
-    LightGBMModel = NotImportedModule(module_name="LightGBM", warn=False)
 
 try:
     from darts.models.forecasting.prophet_model import Prophet

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -1,3 +1,4 @@
+import itertools
 import platform
 
 import numpy as np
@@ -278,81 +279,74 @@ class TestProbabilisticModels:
             mae_err = new_mae
 
     @pytest.mark.slow
-    def test_predict_likelihood_parameters_regression_models(self):
+    @pytest.mark.parametrize(
+        "config",
+        itertools.product(
+            [(LinearRegressionModel, False), (XGBModel, False)]
+            + ([(LightGBMModel, False)] if lgbm_available else [])
+            + ([(CatBoostModel, True)] if cb_available else []),
+            [1, 3],
+            [
+                "quantile",
+                "poisson",
+                "gaussian",
+            ],
+        ),
+    )
+    def test_predict_likelihood_parameters_regression_models(self, config):
         """
         Check that the shape of the predicted likelihood parameters match expectations, for both
         univariate and multivariate series.
 
         Note: values are not tested as it would be too time consuming
         """
+        (model_cls, supports_gaussian), n_comp, likelihood = config
+
         seed = 142857
         n_times, n_samples = 100, 1
-        model_classes = [LinearRegressionModel, XGBModel]
-        if lgbm_available:
-            model_classes.append(LightGBMModel)
-        if cb_available:
-            model_classes.append(CatBoostModel)
+        lkl = {"kwargs": {"likelihood": likelihood}}
 
-        for n_comp in [1, 3]:
-            list_lkl = [
-                {
-                    "kwargs": {
-                        "likelihood": "quantile",
-                        "quantiles": [0.05, 0.50, 0.95],
-                    },
-                    "ts": TimeSeries.from_values(
-                        np.random.normal(
-                            loc=0, scale=1, size=(n_times, n_comp, n_samples)
-                        )
-                    ),
-                    "expected": np.array([-1.67, 0, 1.67]),
-                },
-                {
-                    "kwargs": {"likelihood": "poisson"},
-                    "ts": TimeSeries.from_values(
-                        np.random.poisson(lam=4, size=(n_times, n_comp, n_samples))
-                    ),
-                    "expected": np.array([4]),
-                },
-            ]
+        if likelihood == "quantile":
+            lkl["kwargs"]["quantiles"] = [0.05, 0.50, 0.95]
+            lkl["ts"] = TimeSeries.from_values(
+                np.random.normal(loc=0, scale=1, size=(n_times, n_comp, n_samples))
+            )
+            lkl["expected"] = np.array([-1.67, 0, 1.67])
+        elif likelihood == "poisson":
+            lkl["ts"] = TimeSeries.from_values(
+                np.random.poisson(lam=4, size=(n_times, n_comp, n_samples))
+            )
+            lkl["expected"] = np.array([4])
+        elif likelihood == "gaussian":
+            if not supports_gaussian:
+                return
 
-            for model_cls in model_classes:
-                # Catboost is the only regression model supporting the GaussianLikelihood
-                if cb_available and issubclass(model_cls, CatBoostModel):
-                    list_lkl.append(
-                        {
-                            "kwargs": {"likelihood": "gaussian"},
-                            "ts": TimeSeries.from_values(
-                                np.random.normal(
-                                    loc=10, scale=3, size=(n_times, n_comp, n_samples)
-                                )
-                            ),
-                            "expected": np.array([10, 3]),
-                        }
-                    )
+            lkl["ts"] = TimeSeries.from_values(
+                np.random.normal(loc=10, scale=3, size=(n_times, n_comp, n_samples))
+            )
+            lkl["expected"] = np.array([10, 3])
+        else:
+            assert False, f"unknown likelihood {likelihood}"
 
-                for lkl in list_lkl:
-                    model = model_cls(lags=3, random_state=seed, **lkl["kwargs"])
-                    model.fit(lkl["ts"])
-                    pred_lkl_params = model.predict(
-                        n=1, num_samples=1, predict_likelihood_parameters=True
-                    )
-                    if n_comp == 1:
-                        assert (
-                            lkl["expected"].shape == pred_lkl_params.values()[0].shape
-                        ), (
-                            "The shape of the predicted likelihood parameters do not match expectation "
-                            "for univariate series."
-                        )
-                    else:
-                        assert (
-                            1,
-                            len(lkl["expected"]) * n_comp,
-                            1,
-                        ) == pred_lkl_params.all_values().shape, (
-                            "The shape of the predicted likelihood parameters do not match expectation "
-                            "for multivariate series."
-                        )
+        model = model_cls(lags=3, random_state=seed, **lkl["kwargs"])
+        model.fit(lkl["ts"])
+        pred_lkl_params = model.predict(
+            n=1, num_samples=1, predict_likelihood_parameters=True
+        )
+        if n_comp == 1:
+            assert lkl["expected"].shape == pred_lkl_params.values()[0].shape, (
+                "The shape of the predicted likelihood parameters do not match expectation "
+                "for univariate series."
+            )
+        else:
+            assert (
+                1,
+                len(lkl["expected"]) * n_comp,
+                1,
+            ) == pred_lkl_params.all_values().shape, (
+                "The shape of the predicted likelihood parameters do not match expectation "
+                "for multivariate series."
+            )
 
     """ More likelihood tests
     """


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). 

<!-- Please mention an issue this pull request addresses. -->
Fixes a segmentation fault when important LightGBMModel.

### Summary
- Some Mac users faced segmentation faults when importing `LightGBMModel`. For some reason importing `lightgbm` at the wrong place (relative to other dependency imports) can cause this segmentation fault. A fix for this was to import `lightgbm` at the top in the module/script where the model was used.  
  - To fix this generally in `Darts`, I moved the `LightGBMModel` import to the top of `darts/models/__init__.py` (see also https://github.com/shap/shap/issues/3092 which had a similar issue).