### PR TITLE
add codecov token to merge and dev ci pipelines

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           fail_ci_if_error: true
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           fail_ci_if_error: true
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   check-examples:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 ### For developers of the library:
 - Fixed failing docs build by adding new dependency `lxml_html_clean` for `nbsphinx`. [#2303](https://github.com/unit8co/darts/pull/2303) by [Dennis Bader](https://github.com/dennisbader).
 - Bumped `black` from 24.1.1 to 24.3.0. [#2308](https://github.com/unit8co/darts/pull/2308) by [Dennis Bader](https://github.com/dennisbader).
+- Added a Codecov token as repository secret for codecov upload authentication in CI pipelines. [#2309](https://github.com/unit8co/darts/pull/2309) by [Dennis Bader](https://github.com/dennisbader).
 
 ## [0.28.0](https://github.com/unit8co/darts/tree/0.28.0) (2024-03-05)
 ### For users of the library:


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). 

### Summary
- Fixes failing CI pipeline at Codecov upload step. 
  - Codecov was added to Github apps since Access tokens (classic) have been disabled
  - Added codecov token secret to repository
  - CI now uses that token to authenticate