### PR TITLE
Fix/mc dropout

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        if_ci_failed: ignore
+    patch:
+      default:
+        if_ci_failed: error

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,8 +1,5 @@
+comment: false
 coverage:
   status:
-    project:
-      default:
-        if_ci_failed: success
-    patch:
-      default:
-        if_ci_failed: error
+    project: off
+    patch: off

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        if_ci_failed: ignore
+        if_ci_failed: success
     patch:
       default:
         if_ci_failed: error

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -85,10 +85,9 @@ jobs:
 
       - name: "8. Codecov upload"
         if: ${{ matrix.flavour == 'all' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   docs:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: "8. Codecov upload"
         if: ${{ matrix.flavour == 'all' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -78,10 +78,9 @@ jobs:
 
       - name: "7. Codecov upload"
         if: ${{ matrix.flavour == 'all' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   check-examples:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "7. Codecov upload"
         if: ${{ matrix.flavour == 'all' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug in `quantile_loss`, where the loss was computed on all samples rather than only on the predicted quantiles. [#2284](https://github.com/unit8co/darts/pull/2284) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed type hint warning "Unexpected argument" when calling `historical_forecasts()` caused by the `_with_sanity_checks` decorator. The type hinting is now properly configured to expect any input arguments and return the output type of the method for which the sanity checks are performed for. [#2286](https://github.com/unit8co/darts/pull/2286) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a segmentation fault that some users were facing when importing a `LightGBMModel`. [#2304](https://github.com/unit8co/darts/pull/2304) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a bug when using a dropout with a `TorchForecasting` and pytorch lightning versions >= 2.2.0, where the dropout was not properly activated during training. [#2312](https://github.com/unit8co/darts/pull/2312) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -475,8 +475,9 @@ class PLForecastingModule(pl.LightningModule, ABC):
         return recurse_children(self.children(), set())
 
     def set_mc_dropout(self, active: bool):
+        # optionally, activate dropout in all MonteCarloDropout modules
         for module in self._get_mc_dropout_modules():
-            module.mc_dropout_enabled = active
+            module._mc_dropout_enabled = active
 
     @property
     def supports_probabilistic_prediction(self) -> bool:

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -29,7 +29,7 @@ class _ResidualBlock(nn.Module):
         num_filters: int,
         kernel_size: int,
         dilation_base: int,
-        dropout_fn,
+        dropout: float,
         weight_norm: bool,
         nr_blocks_below: int,
         num_layers: int,
@@ -46,8 +46,8 @@ class _ResidualBlock(nn.Module):
             The size of every kernel in a convolutional layer.
         dilation_base
             The base of the exponent that will determine the dilation on every level.
-        dropout_fn
-            The dropout function to be applied to every convolutional layer.
+        dropout
+            The dropout to be applied to every convolutional layer.
         weight_norm
             Boolean value indicating whether to use weight normalization.
         nr_blocks_below
@@ -77,7 +77,8 @@ class _ResidualBlock(nn.Module):
 
         self.dilation_base = dilation_base
         self.kernel_size = kernel_size
-        self.dropout_fn = dropout_fn
+        self.dropout1 = MonteCarloDropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
         self.num_layers = num_layers
         self.nr_blocks_below = nr_blocks_below
 
@@ -111,14 +112,14 @@ class _ResidualBlock(nn.Module):
             self.kernel_size - 1
         )
         x = F.pad(x, (left_padding, 0))
-        x = self.dropout_fn(F.relu(self.conv1(x)))
+        x = self.dropout1(F.relu(self.conv1(x)))
 
         # second step
         x = F.pad(x, (left_padding, 0))
         x = self.conv2(x)
         if self.nr_blocks_below < self.num_layers - 1:
             x = F.relu(x)
-        x = self.dropout_fn(x)
+        x = self.dropout2(x)
 
         # add residual
         if self.conv1.in_channels != self.conv2.out_channels:
@@ -195,7 +196,6 @@ class _TCNModule(PLPastCovariatesModule):
         self.target_size = target_size
         self.nr_params = nr_params
         self.dilation_base = dilation_base
-        self.dropout = MonteCarloDropout(p=dropout)
 
         # If num_layers is not passed, compute number of layers needed for full history coverage
         if num_layers is None and dilation_base > 1:
@@ -221,15 +221,15 @@ class _TCNModule(PLPastCovariatesModule):
         self.res_blocks_list = []
         for i in range(num_layers):
             res_block = _ResidualBlock(
-                num_filters,
-                kernel_size,
-                dilation_base,
-                self.dropout,
-                weight_norm,
-                i,
-                num_layers,
-                self.input_size,
-                target_size * nr_params,
+                num_filters=num_filters,
+                kernel_size=kernel_size,
+                dilation_base=dilation_base,
+                dropout=dropout,
+                weight_norm=weight_norm,
+                nr_blocks_below=i,
+                num_layers=num_layers,
+                input_size=self.input_size,
+                target_size=target_size * nr_params,
             )
             self.res_blocks_list.append(res_block)
         self.res_blocks = nn.ModuleList(self.res_blocks_list)

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -78,7 +78,7 @@ class _ResidualBlock(nn.Module):
         self.dilation_base = dilation_base
         self.kernel_size = kernel_size
         self.dropout1 = MonteCarloDropout(dropout)
-        self.dropout2 = nn.Dropout(dropout)
+        self.dropout2 = MonteCarloDropout(dropout)
         self.num_layers = num_layers
         self.nr_blocks_below = nr_blocks_below
 

--- a/darts/models/forecasting/tide_model.py
+++ b/darts/models/forecasting/tide_model.py
@@ -14,6 +14,7 @@ from darts.models.forecasting.pl_forecasting_module import (
     io_processor,
 )
 from darts.models.forecasting.torch_forecasting_model import MixedCovariatesTorchModel
+from darts.utils.torch import MonteCarloDropout
 
 MixedCovariatesTrainTensorType = Tuple[
     torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
@@ -40,7 +41,7 @@ class _ResidualBlock(nn.Module):
             nn.Linear(input_dim, hidden_size),
             nn.ReLU(),
             nn.Linear(hidden_size, output_dim),
-            nn.Dropout(dropout),
+            MonteCarloDropout(dropout),
         )
 
         # linear skip connection from input to output of self.dense

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1522,6 +1522,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             batch_size=batch_size,
             n_jobs=n_jobs,
             predict_likelihood_parameters=predict_likelihood_parameters,
+            mc_dropout=mc_dropout,
         )
 
         pred_loader = DataLoader(
@@ -1533,9 +1534,6 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             drop_last=False,
             collate_fn=self._batch_collate_fn,
         )
-
-        # set mc_dropout rate
-        self.model.set_mc_dropout(mc_dropout)
 
         # set up trainer. use user supplied trainer or create a new trainer from scratch
         self.trainer = self._setup_trainer(

--- a/darts/models/forecasting/transformer_model.py
+++ b/darts/models/forecasting/transformer_model.py
@@ -21,6 +21,7 @@ from darts.models.forecasting.pl_forecasting_module import (
     io_processor,
 )
 from darts.models.forecasting.torch_forecasting_model import PastCovariatesTorchModel
+from darts.utils.torch import MonteCarloDropout
 
 logger = get_logger(__name__)
 
@@ -99,7 +100,7 @@ class _PositionalEncoding(nn.Module):
             Tensor containing the embedded time series enhanced with positional encoding.
         """
         super().__init__()
-        self.dropout = nn.Dropout(p=dropout)
+        self.dropout = MonteCarloDropout(p=dropout)
 
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)

--- a/darts/utils/torch.py
+++ b/darts/utils/torch.py
@@ -37,29 +37,17 @@ class MonteCarloDropout(nn.Dropout):
     often improves its performance.
     """
 
-    # We need to init it to False as some models may start by
-    # a validation round, in which case MC dropout is disabled.
-    mc_dropout_enabled: bool = False
-
-    def train(self, mode: bool = True):
-        # NOTE: we could use the line below if self.mc_dropout_rate represented
-        # a rate to be applied at inference time, and self.applied_rate the
-        # actual rate to be used in self.forward(). However, the original paper
-        # considers the same rate for training and inference; we also stick to this.
-
-        # self.applied_rate = self.p if mode else self.mc_dropout_rate
-
-        if mode:  # in train mode, keep dropout as is
-            self.mc_dropout_enabled = True
-        # in eval mode, bank on the mc_dropout_enabled flag
-        # mc_dropout_enabled is set equal to "mc_dropout" param given to predict()
+    # mc dropout is only activated on `PLForecastingModule.on_predict_start()`
+    # otherwise, it is activated based on the `model.training` flag.
+    mc_dropout_enabled = False
 
     def forward(self, input: Tensor) -> Tensor:
         # NOTE: we could use the following line in case a different rate
         # is used for inference:
         # return F.dropout(input, self.applied_rate, True, self.inplace)
-
-        return F.dropout(input, self.p, self.mc_dropout_enabled, self.inplace)
+        return F.dropout(
+            input, self.p, self.mc_dropout_enabled or self.training, self.inplace
+        )
 
 
 def _is_method(func: Callable[..., Any]) -> bool:

--- a/darts/utils/torch.py
+++ b/darts/utils/torch.py
@@ -37,17 +37,20 @@ class MonteCarloDropout(nn.Dropout):
     often improves its performance.
     """
 
-    # mc dropout is only activated on `PLForecastingModule.on_predict_start()`
-    # otherwise, it is activated based on the `model.training` flag.
-    mc_dropout_enabled = False
+    # mc dropout is deactivated at init; see `MonteCarloDropout.mc_dropout_enabled` for more info
+    _mc_dropout_enabled = False
 
     def forward(self, input: Tensor) -> Tensor:
         # NOTE: we could use the following line in case a different rate
         # is used for inference:
         # return F.dropout(input, self.applied_rate, True, self.inplace)
-        return F.dropout(
-            input, self.p, self.mc_dropout_enabled or self.training, self.inplace
-        )
+        return F.dropout(input, self.p, self.mc_dropout_enabled, self.inplace)
+
+    @property
+    def mc_dropout_enabled(self) -> bool:
+        # mc dropout is only activated on `PLForecastingModule.on_predict_start()`
+        # otherwise, it is activated based on the `model.training` flag.
+        return self._mc_dropout_enabled or self.training
 
 
 def _is_method(func: Callable[..., Any]) -> bool:


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). 

<!-- Please mention an issue this pull request addresses. -->
Fixes #2300.

### Summary
- fixes Monte Carlo Dropout for all TorchForecastingModels. MC dropout training mode was not getting activated properly in the different model training/val/pred/.. stages.
- add `MonteCarloDropout` to all TorchForecastingModels that were not using them before.


## Additional Information

Below an example that it works properly now.

```
import numpy as np
import matplotlib.pyplot as plt

from darts import concatenate
from darts.models import TCNModel, TSMixerModel
from darts.datasets import AirPassengersDataset

series = AirPassengersDataset().load().astype(np.float32)
preds = []

dropouts = [0., 0.5, 0.99]
for dropout in dropouts:
    model = TCNModel(13, 12, dropout=dropout, random_state=42)
    model.fit(series, epochs=100)
    preds.append(
        concatenate(
            model.historical_forecasts(
                series=series,
                retrain=False,
                forecast_horizon=12,
                stride=12,
                last_points_only=False,
            ),
            axis=0
        )
    )

series.plot()
for pred, dropout in zip(preds, dropouts):
    pred.plot(label=f"d={dropout}")
plt.show()
```

<img width="630" alt="image" src="https://github.com/unit8co/darts/assets/84317528/73e8152b-c46a-4da9-88a2-4353481fc40e">
