### PR TITLE
add progress bar to regression models for hist fc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - Moved functions `retain_period_common_to_all()`, `series2seq()`, `seq2series()`, `get_single_series()` from `darts.utils.utils` to `darts.utils.ts_utils`.
 - Improvements to `ForecastingModel`: [#2269](https://github.com/unit8co/darts/pull/2269) by [Felix Divo](https://github.com/felixdivo).
   - Renamed the private `_is_probabilistic` property to a public `supports_probabilistic_prediction`.
+- Improvements to `RegressionModel`: [#2320](https://github.com/unit8co/darts/pull/2320) by [Felix Divo](https://github.com/felixdivo).
+  - Added a progress bar when performing optimized historical forecasts (`retrain=False` and no autoregression) to display the series-level progress.
 - Improvements to `DataTransformer`: [#2267](https://github.com/unit8co/darts/pull/2267) by [Alicja Krzeminska-Sciga](https://github.com/alicjakrzeminska).
   - `InvertibleDataTransformer` now supports parallelized inverse transformation for `series` being a list of lists of `TimeSeries` (`Sequence[Sequence[TimeSeries]]`). This `series` type represents for example the output from `historical_forecasts()` when using multiple series. 
 

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -1199,6 +1199,7 @@ class RegressionModel(GlobalForecastingModel):
                 stride=stride,
                 overlap_end=overlap_end,
                 show_warnings=show_warnings,
+                verbose=verbose,
                 predict_likelihood_parameters=predict_likelihood_parameters,
                 **kwargs,
             )
@@ -1215,6 +1216,7 @@ class RegressionModel(GlobalForecastingModel):
                 stride=stride,
                 overlap_end=overlap_end,
                 show_warnings=show_warnings,
+                verbose=verbose,
                 predict_likelihood_parameters=predict_likelihood_parameters,
                 **kwargs,
             )

--- a/darts/utils/historical_forecasts/optimized_historical_forecasts_regression.py
+++ b/darts/utils/historical_forecasts/optimized_historical_forecasts_regression.py
@@ -41,7 +41,6 @@ def _optimized_historical_forecasts_last_points_only(
     Rely on _check_optimizable_historical_forecasts() to check that the assumptions are verified.
     """
     forecasts_list = []
-
     iterator = _build_tqdm_iterator(series, verbose)
     for idx, series_ in enumerate(iterator):
         past_covariates_ = past_covariates[idx] if past_covariates is not None else None

--- a/darts/utils/historical_forecasts/optimized_historical_forecasts_regression.py
+++ b/darts/utils/historical_forecasts/optimized_historical_forecasts_regression.py
@@ -11,6 +11,7 @@ from numpy.lib.stride_tricks import sliding_window_view
 
 from darts.logging import get_logger
 from darts.timeseries import TimeSeries
+from darts.utils import _build_tqdm_iterator
 from darts.utils.data.tabularization import create_lagged_prediction_data
 from darts.utils.historical_forecasts.utils import _get_historical_forecast_boundaries
 from darts.utils.utils import generate_index
@@ -30,6 +31,7 @@ def _optimized_historical_forecasts_last_points_only(
     stride: int = 1,
     overlap_end: bool = False,
     show_warnings: bool = True,
+    verbose: bool = False,
     predict_likelihood_parameters: bool = False,
     **kwargs,
 ) -> Union[TimeSeries, Sequence[TimeSeries], Sequence[Sequence[TimeSeries]]]:
@@ -39,7 +41,9 @@ def _optimized_historical_forecasts_last_points_only(
     Rely on _check_optimizable_historical_forecasts() to check that the assumptions are verified.
     """
     forecasts_list = []
-    for idx, series_ in enumerate(series):
+
+    iterator = _build_tqdm_iterator(series, verbose)
+    for idx, series_ in enumerate(iterator):
         past_covariates_ = past_covariates[idx] if past_covariates is not None else None
         future_covariates_ = (
             future_covariates[idx] if future_covariates is not None else None
@@ -185,6 +189,7 @@ def _optimized_historical_forecasts_all_points(
     stride: int = 1,
     overlap_end: bool = False,
     show_warnings: bool = True,
+    verbose: bool = False,
     predict_likelihood_parameters: bool = False,
     **kwargs,
 ) -> Union[TimeSeries, Sequence[TimeSeries], Sequence[Sequence[TimeSeries]]]:
@@ -194,7 +199,8 @@ def _optimized_historical_forecasts_all_points(
     Rely on _check_optimizable_historical_forecasts() to check that the assumptions are verified.
     """
     forecasts_list = []
-    for idx, series_ in enumerate(series):
+    iterator = _build_tqdm_iterator(series, verbose)
+    for idx, series_ in enumerate(iterator):
         past_covariates_ = past_covariates[idx] if past_covariates is not None else None
         future_covariates_ = (
             future_covariates[idx] if future_covariates is not None else None


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). 

<!-- Please mention an issue this pull request addresses. -->
Fixes #2061.

### Summary
- Added a progress bar when performing optimized historical forecasts (`retrain=False` and no autoregression) to display the series-level progress.
- can be activated with `verbose=True` when calling `ForecastingModel.historical forecasts()`
