### PR TITLE
Fix/historical forecasts torch models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,14 +90,18 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Improvements to `RegressionModel`: [#2320](https://github.com/unit8co/darts/pull/2320) by [Felix Divo](https://github.com/felixdivo).
   - Added a progress bar when performing optimized historical forecasts (`retrain=False` and no autoregression) to display the series-level progress.
 - Improvements to `DataTransformer`: [#2267](https://github.com/unit8co/darts/pull/2267) by [Alicja Krzeminska-Sciga](https://github.com/alicjakrzeminska).
-  - `InvertibleDataTransformer` now supports parallelized inverse transformation for `series` being a list of lists of `TimeSeries` (`Sequence[Sequence[TimeSeries]]`). This `series` type represents for example the output from `historical_forecasts()` when using multiple series. 
+  - `InvertibleDataTransformer` now supports parallelized inverse transformation for `series` being a list of lists of `TimeSeries` (`Sequence[Sequence[TimeSeries]]`). This `series` type represents for example the output from `historical_forecasts()` when using multiple series.
+- Improvements to `RNNModel`: [#2329](https://github.com/unit8co/darts/pull/2329) by [Dennis Bader](https://github.com/dennisbader).
+  - 🔴 Enforce `training_length>input_chunk_length` since otherwise, during training the model is never run for as many iterations as it will during prediction.
+  - Historical forecasts now correctly infer all possible prediction start points for untrained and pre-trained `RNNModel`.
 
 **Fixed**
 - Fixed a bug in `quantile_loss`, where the loss was computed on all samples rather than only on the predicted quantiles. [#2284](https://github.com/unit8co/darts/pull/2284) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed type hint warning "Unexpected argument" when calling `historical_forecasts()` caused by the `_with_sanity_checks` decorator. The type hinting is now properly configured to expect any input arguments and return the output type of the method for which the sanity checks are performed for. [#2286](https://github.com/unit8co/darts/pull/2286) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed the order of the features when using component-wise lags so that they are grouped by values, then by components (before, were grouped by components, then by values). [#2272](https://github.com/unit8co/darts/pull/2272) by [Antoine Madrona](https://github.com/madtoinou).
 - Fixed a segmentation fault that some users were facing when importing a `LightGBMModel`. [#2304](https://github.com/unit8co/darts/pull/2304) by [Dennis Bader](https://github.com/dennisbader).
-- Fixed a bug when using a dropout with a `TorchForecasting` and pytorch lightning versions >= 2.2.0, where the dropout was not properly activated during training. [#2312](https://github.com/unit8co/darts/pull/2312) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a bug when using a dropout with a `TorchForecastingModel` and pytorch lightning versions >= 2.2.0, where the dropout was not properly activated during training. [#2312](https://github.com/unit8co/darts/pull/2312) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a bug when performing historical forecasts with an untrained `TorchForecastingModel` and using covariates, where the historical forecastable time index generation did not take the covariates into account. [#2329](https://github.com/unit8co/darts/pull/2329) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -402,6 +402,7 @@ class EnsembleModel(GlobalForecastingModel):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         def find_max_lag_or_none(lag_id, aggregator) -> Optional[int]:
             max_lag = None
@@ -413,7 +414,7 @@ class EnsembleModel(GlobalForecastingModel):
                     max_lag = aggregator(max_lag, curr_lag)
             return max_lag
 
-        lag_aggregators = (min, max, min, max, min, max, max)
+        lag_aggregators = (min, max, min, max, min, max, max, max)
         return tuple(
             find_max_lag_or_none(i, agg) for i, agg in enumerate(lag_aggregators)
         )

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -446,12 +446,13 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         """
-        A 7-tuple containing in order:
+        A 8-tuple containing in order:
         (min target lag, max target lag, min past covariate lag, max past covariate lag, min future covariate
-        lag, max future covariate lag, output shift). If 0 is the index of the first prediction, then all lags are
-        relative to this index.
+        lag, max future covariate lag, output shift, max target lag train (only for RNNModel)). If 0 is the index of the
+        first prediction, then all lags are relative to this index.
 
         See examples below.
 
@@ -474,27 +475,27 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         >>> model = LinearRegressionModel(lags=3, output_chunk_length=2)
         >>> model.fit(train_series)
         >>> model.extreme_lags
-        (-3, 1, None, None, None, None, 0)
+        (-3, 1, None, None, None, None, 0, None)
         >>> model = LinearRegressionModel(lags=3, output_chunk_length=2, output_chunk_shift=2)
         >>> model.fit(train_series)
         >>> model.extreme_lags
-        (-3, 1, None, None, None, None, 2)
+        (-3, 1, None, None, None, None, 2, None)
         >>> model = LinearRegressionModel(lags=[-3, -5], lags_past_covariates = 4, output_chunk_length=7)
         >>> model.fit(train_series, past_covariates=past_covariates)
         >>> model.extreme_lags
-        (-5, 6, -4, -1,  None, None, 0)
+        (-5, 6, -4, -1,  None, None, 0, None)
         >>> model = LinearRegressionModel(lags=[3, 5], lags_future_covariates = [4, 6], output_chunk_length=7)
         >>> model.fit(train_series, future_covariates=future_covariates)
         >>> model.extreme_lags
-        (-5, 6, None, None, 4, 6, 0)
+        (-5, 6, None, None, 4, 6, 0, None)
         >>> model = NBEATSModel(input_chunk_length=10, output_chunk_length=7)
         >>> model.fit(train_series)
         >>> model.extreme_lags
-        (-10, 6, None, None, None, None, 0)
+        (-10, 6, None, None, None, None, 0, None)
         >>> model = NBEATSModel(input_chunk_length=10, output_chunk_length=7, lags_future_covariates=[4, 6])
         >>> model.fit(train_series, future_covariates)
         >>> model.extreme_lags
-        (-10, 6, None, None, 4, 6, 0)
+        (-10, 6, None, None, 4, 6, 0, None)
         """
 
     @property
@@ -510,10 +511,13 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
             min_future_cov_lag,
             max_future_cov_lag,
             output_chunk_shift,
+            max_target_lag_train,
         ) = self.extreme_lags
 
+        # some models can have different output chunks for training and prediction (e.g. `RNNModel`)
+        output_lag = max_target_lag_train or max_target_lag
         return max(
-            max_target_lag + 1,
+            output_lag + 1,
             max_future_cov_lag + 1 if max_future_cov_lag else 0,
         ) - min(
             min_target_lag if min_target_lag else 0,
@@ -2452,12 +2456,13 @@ class LocalForecastingModel(ForecastingModel, ABC):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         # TODO: LocalForecastingModels do not yet handle extreme lags properly. Especially
         #  TransferableFutureCovariatesLocalForecastingModel, where there is a difference between fit and predict mode)
         #  do not yet. In general, Local models train on the entire series (input=output), different to Global models
         #  that use an input to predict an output.
-        return -self.min_train_series_length, -1, None, None, None, None, 0
+        return -self.min_train_series_length, -1, None, None, None, None, 0, None
 
     @property
     def supports_transferrable_series_prediction(self) -> bool:
@@ -2927,12 +2932,13 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         # TODO: LocalForecastingModels do not yet handle extreme lags properly. Especially
         #  TransferableFutureCovariatesLocalForecastingModel, where there is a difference between fit and predict mode)
         #  do not yet. In general, Local models train on the entire series (input=output), different to Global models
         #  that use an input to predict an output.
-        return -self.min_train_series_length, -1, None, None, 0, 0, 0
+        return -self.min_train_series_length, -1, None, None, 0, 0, 0, None
 
 
 class TransferableFutureCovariatesLocalForecastingModel(

--- a/darts/models/forecasting/global_baseline_models.py
+++ b/darts/models/forecasting/global_baseline_models.py
@@ -229,9 +229,6 @@ class _GlobalNaiveModel(MixedCovariatesTorchModel, ABC):
         # have to match the training sample
         pass
 
-    def min_train_series_length(self) -> int:
-        return self.input_chunk_length
-
     def supports_likelihood_parameter_prediction(self) -> bool:
         return False
 

--- a/darts/models/forecasting/regression_ensemble_model.py
+++ b/darts/models/forecasting/regression_ensemble_model.py
@@ -316,9 +316,9 @@ class RegressionEnsembleModel(EnsembleModel):
             # shift by the forecasting models' largest input length
             all_shifts = []
             # when it's not clearly defined, extreme_lags returns
-            # min_train_serie_length for the LocalForecastingModels
+            # `min_train_series_length` for the LocalForecastingModels
             for model in self.forecasting_models:
-                min_target_lag, _, _, _, _, _, _ = model.extreme_lags
+                min_target_lag, _, _, _, _, _, _, _ = model.extreme_lags
                 if min_target_lag is not None:
                     all_shifts.append(-min_target_lag)
 
@@ -459,6 +459,7 @@ class RegressionEnsembleModel(EnsembleModel):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         extreme_lags_ = super().extreme_lags
         # shift min_target_lag in the past to account for the regression model training set

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -449,6 +449,7 @@ class RegressionModel(GlobalForecastingModel):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         min_target_lag = self.lags["target"][0] if "target" in self.lags else None
         max_target_lag = self.output_chunk_length - 1 + self.output_chunk_shift
@@ -464,6 +465,7 @@ class RegressionModel(GlobalForecastingModel):
             min_future_cov_lag,
             max_future_cov_lag,
             self.output_chunk_shift,
+            None,
         )
 
     @property

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -606,6 +606,14 @@ class RNNModel(DualCovariatesTorchModel):
         Optional[int],
         int,
     ]:
-        lags = super().extreme_lags
-        # max_target_lag for training is given by `training_length - icl`
-        return lags[:1] + (self.training_length - self.input_chunk_length,) + lags[2:]
+        # output window for training is given by `training_length - icl`
+        output_window = self.training_length - self.input_chunk_length
+        return (
+            -self.input_chunk_length,
+            output_window,
+            None,
+            None,
+            -self.input_chunk_length,
+            output_window,
+            self.output_chunk_shift,
+        )

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -321,9 +321,9 @@ class RNNModel(DualCovariatesTorchModel):
             Fraction of neurons afected by Dropout.
         training_length
             The length of both input (target and covariates) and output (target) time series used during
-            training. Generally speaking, `training_length` should have a higher value than `input_chunk_length`
-            because otherwise during training the RNN is never run for as many iterations as it will during
-            inference. For more information on this parameter, please see `darts.utils.data.ShiftedDataset`
+            training. Must have a larger value than `input_chunk_length`, because otherwise during training
+            the RNN is never run for as many iterations as it will during inference. For more information on
+            this parameter, please see `darts.utils.data.ShiftedDataset`.
         **kwargs
             Optional arguments to initialize the pytorch_lightning.Module, pytorch_lightning.Trainer, and
             Darts' :class:`TorchForecastingModel`.
@@ -485,6 +485,14 @@ class RNNModel(DualCovariatesTorchModel):
             `RNN example notebook <https://unit8co.github.io/darts/examples/04-RNN-examples.html>`_ presents techniques
             that can be used to improve the forecasts quality compared to this simple usage example.
         """
+        if training_length <= input_chunk_length:
+            raise_log(
+                ValueError(
+                    f"`training_length` ({training_length}) must be larger than "
+                    f"`input_chunk_length` ({input_chunk_length})."
+                ),
+                logger=logger,
+            )
         # create copy of model parameters
         model_kwargs = {key: val for key, val in self.model_params.items()}
 
@@ -585,3 +593,19 @@ class RNNModel(DualCovariatesTorchModel):
     @property
     def min_train_series_length(self) -> int:
         return self.training_length + 1
+
+    @property
+    def extreme_lags(
+        self,
+    ) -> Tuple[
+        Optional[int],
+        Optional[int],
+        Optional[int],
+        Optional[int],
+        Optional[int],
+        Optional[int],
+        int,
+    ]:
+        lags = super().extreme_lags
+        # max_target_lag for training is given by `training_length - icl`
+        return lags[:1] + (self.training_length - self.input_chunk_length,) + lags[2:]

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -605,15 +605,15 @@ class RNNModel(DualCovariatesTorchModel):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
-        # output window for training is given by `training_length - icl`
-        output_window = self.training_length - self.input_chunk_length
         return (
             -self.input_chunk_length,
-            output_window,
+            self.output_chunk_length - 1,
             None,
             None,
             -self.input_chunk_length,
-            output_window,
+            self.output_chunk_length - 1,
             self.output_chunk_shift,
+            self.training_length - self.input_chunk_length,
         )

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -485,11 +485,10 @@ class RNNModel(DualCovariatesTorchModel):
             `RNN example notebook <https://unit8co.github.io/darts/examples/04-RNN-examples.html>`_ presents techniques
             that can be used to improve the forecasts quality compared to this simple usage example.
         """
-        if training_length <= input_chunk_length:
+        if training_length < input_chunk_length:
             raise_log(
                 ValueError(
-                    f"`training_length` ({training_length}) must be larger than "
-                    f"`input_chunk_length` ({input_chunk_length})."
+                    f"`training_length` ({training_length}) must be `>=input_chunk_length` ({input_chunk_length})."
                 ),
                 logger=logger,
             )

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -2494,6 +2494,7 @@ class PastCovariatesTorchModel(TorchForecastingModel, ABC):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         return (
             -self.input_chunk_length,
@@ -2503,6 +2504,7 @@ class PastCovariatesTorchModel(TorchForecastingModel, ABC):
             None,
             None,
             self.output_chunk_shift,
+            None,
         )
 
 
@@ -2583,6 +2585,7 @@ class FutureCovariatesTorchModel(TorchForecastingModel, ABC):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         return (
             -self.input_chunk_length,
@@ -2592,6 +2595,7 @@ class FutureCovariatesTorchModel(TorchForecastingModel, ABC):
             self.output_chunk_shift,
             self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
+            None,
         )
 
 
@@ -2673,6 +2677,7 @@ class DualCovariatesTorchModel(TorchForecastingModel, ABC):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         return (
             -self.input_chunk_length,
@@ -2682,6 +2687,7 @@ class DualCovariatesTorchModel(TorchForecastingModel, ABC):
             -self.input_chunk_length,
             self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
+            None,
         )
 
 
@@ -2763,6 +2769,7 @@ class MixedCovariatesTorchModel(TorchForecastingModel, ABC):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         return (
             -self.input_chunk_length,
@@ -2772,6 +2779,7 @@ class MixedCovariatesTorchModel(TorchForecastingModel, ABC):
             -self.input_chunk_length,
             self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
+            None,
         )
 
     def predict(
@@ -2910,6 +2918,7 @@ class SplitCovariatesTorchModel(TorchForecastingModel, ABC):
         Optional[int],
         Optional[int],
         int,
+        Optional[int],
     ]:
         return (
             -self.input_chunk_length,
@@ -2919,4 +2928,5 @@ class SplitCovariatesTorchModel(TorchForecastingModel, ABC):
             self.output_chunk_shift,
             self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
+            None,
         )

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -2498,8 +2498,8 @@ class PastCovariatesTorchModel(TorchForecastingModel, ABC):
         return (
             -self.input_chunk_length,
             self.output_chunk_length - 1 + self.output_chunk_shift,
-            -self.input_chunk_length if self.uses_past_covariates else None,
-            -1 if self.uses_past_covariates else None,
+            -self.input_chunk_length,
+            -1,
             None,
             None,
             self.output_chunk_shift,
@@ -2589,12 +2589,8 @@ class FutureCovariatesTorchModel(TorchForecastingModel, ABC):
             self.output_chunk_length - 1 + self.output_chunk_shift,
             None,
             None,
-            self.output_chunk_shift if self.uses_future_covariates else None,
-            (
-                self.output_chunk_length - 1 + self.output_chunk_shift
-                if self.uses_future_covariates
-                else None
-            ),
+            self.output_chunk_shift,
+            self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
         )
 
@@ -2683,12 +2679,8 @@ class DualCovariatesTorchModel(TorchForecastingModel, ABC):
             self.output_chunk_length - 1 + self.output_chunk_shift,
             None,
             None,
-            -self.input_chunk_length if self.uses_future_covariates else None,
-            (
-                self.output_chunk_length - 1 + self.output_chunk_shift
-                if self.uses_future_covariates
-                else None
-            ),
+            -self.input_chunk_length,
+            self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
         )
 
@@ -2775,14 +2767,10 @@ class MixedCovariatesTorchModel(TorchForecastingModel, ABC):
         return (
             -self.input_chunk_length,
             self.output_chunk_length - 1 + self.output_chunk_shift,
-            -self.input_chunk_length if self.uses_past_covariates else None,
-            -1 if self.uses_past_covariates else None,
-            -self.input_chunk_length if self.uses_future_covariates else None,
-            (
-                self.output_chunk_length - 1 + self.output_chunk_shift
-                if self.uses_future_covariates
-                else None
-            ),
+            -self.input_chunk_length,
+            -1,
+            -self.input_chunk_length,
+            self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
         )
 
@@ -2926,13 +2914,9 @@ class SplitCovariatesTorchModel(TorchForecastingModel, ABC):
         return (
             -self.input_chunk_length,
             self.output_chunk_length - 1 + self.output_chunk_shift,
-            -self.input_chunk_length if self.uses_past_covariates else None,
-            -1 if self.uses_past_covariates else None,
-            self.output_chunk_shift if self.uses_future_covariates else None,
-            (
-                self.output_chunk_length - 1 + self.output_chunk_shift
-                if self.uses_future_covariates
-                else None
-            ),
+            -self.input_chunk_length,
+            -1,
+            self.output_chunk_shift,
+            self.output_chunk_length - 1 + self.output_chunk_shift,
             self.output_chunk_shift,
         )

--- a/darts/tests/models/forecasting/test_RNN.py
+++ b/darts/tests/models/forecasting/test_RNN.py
@@ -55,6 +55,25 @@ class TestRNNModel:
         dropout=0,
     )
 
+    def test_training_length_input(self):
+        # too small training length
+        with pytest.raises(ValueError) as msg:
+            RNNModel(input_chunk_length=2, training_length=1)
+        assert (
+            str(msg.value)
+            == "`training_length` (1) must be `>=input_chunk_length` (2)."
+        )
+
+        # training_length >= input_chunk_length works
+        model = RNNModel(
+            input_chunk_length=2,
+            training_length=2,
+            n_epochs=1,
+            random_state=42,
+            **tfm_kwargs,
+        )
+        model.fit(self.series[:3])
+
     def test_creation(self):
         # cannot choose any string
         with pytest.raises(ValueError) as msg:

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -111,6 +111,7 @@ class TestEnsembleModels:
             None,
             None,
             0,
+            None,
         )  # test if default is okay
 
         model1 = LinearRegressionModel(
@@ -123,7 +124,19 @@ class TestEnsembleModels:
         ensemble = NaiveEnsembleModel(
             [model1, model2]
         )  # test if infers extreme lags is okay
-        expected = (-5, 0, -6, -1, 6, 9, 0)
+        expected = (-5, 0, -6, -1, 6, 9, 0, None)
+        assert expected == ensemble.extreme_lags
+
+    @pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
+    def test_extreme_lags_rnn(self):
+        # RNNModel has the 8th element in `extreme_lags` for the `max_target_lag_train`.
+        # it is given by `training_length - input_chunk_length`.
+        # for the ensemble model we want the max lag of all forecasting models.
+        model1 = RNNModel(input_chunk_length=14, training_length=24)
+        model2 = RNNModel(input_chunk_length=12, training_length=37)
+
+        ensemble = NaiveEnsembleModel([model1, model2])
+        expected = (-14, 0, None, None, -14, 0, 0, 37 - 12)
         assert expected == ensemble.extreme_lags
 
     def test_input_models_local_models(self):
@@ -152,7 +165,7 @@ class TestEnsembleModels:
     def test_call_backtest_naive_ensemble_local_models(self):
         ensemble = NaiveEnsembleModel([NaiveSeasonal(5), Theta(2, 5)])
         ensemble.fit(self.series1)
-        assert ensemble.extreme_lags == (-10, -1, None, None, None, None, 0)
+        assert ensemble.extreme_lags == (-10, -1, None, None, None, None, 0, None)
         ensemble.backtest(self.series1)
 
     def test_predict_univariate_ensemble_local_models(self):

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -67,6 +67,7 @@ models_cls_kwargs_errs = [
         RNNModel,
         {
             "model": "RNN",
+            "training_length": IN_LEN + OUT_LEN,
             "hidden_dim": 10,
             "batch_size": 32,
             "n_epochs": 10,
@@ -77,7 +78,7 @@ models_cls_kwargs_errs = [
     (
         RNNModel,
         {
-            "training_length": 12,
+            "training_length": IN_LEN + OUT_LEN,
             "n_epochs": 10,
             "likelihood": GaussianLikelihood(),
             "pl_trainer_kwargs": tfm_kwargs["pl_trainer_kwargs"],

--- a/darts/tests/models/forecasting/test_historical_forecasts.py
+++ b/darts/tests/models/forecasting/test_historical_forecasts.py
@@ -1779,7 +1779,7 @@ class TestHistoricalforecast:
         # `pc_end_before` has required length but end one step before `pc`
         pc_end_before = pc[:-1].prepend_values([0.0])
 
-        # `overlap_end=True`
+        # checks for long enough and shorter covariates
         forecasts = model.historical_forecasts(
             series=[series] * 4,
             past_covariates=[
@@ -1916,7 +1916,7 @@ class TestHistoricalforecast:
         # `fc_end_before` has required length but end one step before `fc`
         fc_end_before = fc[:-1].prepend_values([0.0])
 
-        # `overlap_end=True`
+        # checks for long enough and shorter covariates
         forecasts = model.historical_forecasts(
             series=[series] * 4,
             future_covariates=[
@@ -2076,7 +2076,7 @@ class TestHistoricalforecast:
         # `fc_end_before` has required length but end one step before `fc`
         fc_end_before = fc[:-1].prepend_values([0.0])
 
-        # `overlap_end=True`
+        # checks for long enough and shorter covariates
         forecasts = model.historical_forecasts(
             series=[series] * 4,
             past_covariates=[

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -70,17 +70,19 @@ class TestRegressionEnsembleModels:
         return [NaiveDrift(), NaiveSeasonal(5), NaiveSeasonal(10)]
 
     @pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
-    def get_global_models(self, output_chunk_length=5):
+    def get_global_models(
+        self, output_chunk_length=5, input_chunk_length=20, training_length=24
+    ):
         return [
             RNNModel(
-                input_chunk_length=20,
-                output_chunk_length=output_chunk_length,
+                input_chunk_length=input_chunk_length,
+                training_length=training_length,
                 n_epochs=1,
                 random_state=42,
                 **tfm_kwargs,
             ),
             BlockRNNModel(
-                input_chunk_length=20,
+                input_chunk_length=input_chunk_length,
                 output_chunk_length=output_chunk_length,
                 n_epochs=1,
                 random_state=42,
@@ -559,6 +561,7 @@ class TestRegressionEnsembleModels:
             None,
             None,
             0,
+            None,
         )
         ensemble.backtest(self.sine_series)
 
@@ -574,7 +577,7 @@ class TestRegressionEnsembleModels:
             regression_train_n_points=train_n_points,
         )
 
-        assert model.extreme_lags == (-train_n_points, 0, -3, -1, 0, 0, 0)
+        assert model.extreme_lags == (-train_n_points, 0, -3, -1, 0, 0, 0, None)
 
         # mix of all the lags
         model3 = RandomForest(
@@ -586,7 +589,26 @@ class TestRegressionEnsembleModels:
             regression_train_n_points=train_n_points,
         )
 
-        assert model.extreme_lags == (-7 - train_n_points, 0, -3, -1, -2, 5, 0)
+        assert model.extreme_lags == (-7 - train_n_points, 0, -3, -1, -2, 5, 0, None)
+
+        # test RNN case which has the 8th extreme lags element (max_target_lag_train)
+        icl = 20
+        ocl = 5
+        training_length = 24
+        model = RegressionEnsembleModel(
+            forecasting_models=self.get_global_models(ocl, training_length),
+            regression_train_n_points=train_n_points,
+        )
+        assert model.extreme_lags == (
+            -icl - train_n_points,
+            ocl - 1,
+            -icl,  # past covs from BlockRNN
+            -1,  # past covs from BlockRNN
+            -icl,  # future covs from RNN
+            0,  # future covs from RNN
+            0,
+            training_length - icl,  # training length from RNN
+        )
 
     def test_stochastic_regression_ensemble_model(self):
         quantiles = [0.25, 0.5, 0.75]

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -596,7 +596,7 @@ class TestRegressionEnsembleModels:
         ocl = 5
         training_length = 24
         model = RegressionEnsembleModel(
-            forecasting_models=self.get_global_models(ocl, training_length),
+            forecasting_models=self.get_global_models(ocl, icl, training_length),
             regression_train_n_points=train_n_points,
         )
         assert model.extreme_lags == (

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -64,7 +64,7 @@ try:
         (NBEATSModel, kwargs),
         (NHiTSModel, kwargs),
         (NLinearModel, kwargs),
-        (RNNModel, {"training_length": 2, **kwargs}),
+        (RNNModel, {"training_length": 10, **kwargs}),
         (TCNModel, kwargs),
         (TFTModel, {"add_relative_index": 2, **kwargs}),
         (TiDEModel, kwargs),

--- a/darts/utils/historical_forecasts/utils.py
+++ b/darts/utils/historical_forecasts/utils.py
@@ -403,6 +403,7 @@ def _get_historical_forecastable_time_index(
         min_future_cov_lag,
         max_future_cov_lag,
         output_chunk_shift,
+        max_target_lag_train,
     ) = model.extreme_lags
 
     # max_target_lag < 0 are local models which can predict for n (horizon) -> infinity (no auto-regression)
@@ -414,11 +415,17 @@ def _get_historical_forecastable_time_index(
     if min_target_lag is None:
         min_target_lag = 0
 
+    if is_training and max_target_lag_train is not None:
+        # the output lag/window can be different for train and predict modes
+        output_lag = max_target_lag_train
+    else:
+        output_lag = max_target_lag
+
     # longest possible time index for target
     if is_training:
         start = (
             series.start_time()
-            + (max_target_lag - output_chunk_shift - min_target_lag + 1) * series.freq
+            + (output_lag - output_chunk_shift - min_target_lag + 1) * series.freq
         )
     else:
         start = series.start_time() - min_target_lag * series.freq
@@ -431,7 +438,7 @@ def _get_historical_forecastable_time_index(
         if is_training:
             start_pc = (
                 past_covariates.start_time()
-                + (max_target_lag - output_chunk_shift - min_past_cov_lag + 1)
+                + (output_lag - output_chunk_shift - min_past_cov_lag + 1)
                 * past_covariates.freq
             )
         else:
@@ -455,7 +462,7 @@ def _get_historical_forecastable_time_index(
         if is_training:
             start_fc = (
                 future_covariates.start_time()
-                + (max_target_lag - output_chunk_shift - min_future_cov_lag + 1)
+                + (output_lag - output_chunk_shift - min_future_cov_lag + 1)
                 * future_covariates.freq
             )
         else:
@@ -475,7 +482,7 @@ def _get_historical_forecastable_time_index(
             min([intersect_[1], end_fc]),
         )
 
-    # overlap_end = True -> predictions must not go beyond end of target series
+    # overlap_end = False -> predictions must not go beyond end of target series
     if (
         not overlap_end
         and intersect_[1] + (forecast_horizon + output_chunk_shift - 1) * series.freq
@@ -723,6 +730,7 @@ def _get_historical_forecast_boundaries(
     )
 
     # re-adjust the slicing indexes to account for the lags
+    # `max_target_lag_train` is redundant, since optimized hist fc is running in predict mode only
     (
         min_target_lag,
         _,
@@ -731,6 +739,7 @@ def _get_historical_forecast_boundaries(
         min_future_cov_lag,
         max_future_cov_lag,
         output_chunk_shift,
+        max_target_lag_train,
     ) = model.extreme_lags
 
     # target lags are <= 0


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). 

### Summary
- simplifies and improves historical forecast tests for torch models, by reducing input series length and checking for minimum length requirements. Speeds up tests from 2min to 1min 15 seconds
- Improvements to `RNNModel`:
  - 🔴 enforce `training_length>input_chunk_length`
  - the historical forecastable time index is now properly computed for RNNModels
- `ForecastingModel.exteme_lags()` now has an additional return element indicating the `max_target_lag` used during training (specific to `RNNModel`) 
- simplifies and improves historical forecast tests for torch models, by reducing input series length and checking for minimum length requirements. Speeds up tests from 2min to 1min 15 seconds
- fixes a bug when using historical forecasts with untrained torch models and using covariates, where the historical forecastable time index computation did not take the covariates into account
