### PR TITLE
fix index generation and n steps between

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Improved**
 
 **Fixed**
+- Fixed a bug where `n_steps_between` did not work properly with custom business frequencies. This affected metrics computation. [#2357](https://github.com/unit8co/darts/pull/2357) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 - Improvements to linting via updated pre-commit configurations: [#2324](https://github.com/unit8co/darts/pull/2324) by [Jirka Borovec](https://github.com/borda).

--- a/darts/tests/utils/test_utils.py
+++ b/darts/tests/utils/test_utils.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.tseries.offsets import CustomBusinessDay
 
 from darts import TimeSeries
 from darts.utils import _with_sanity_checks
 from darts.utils.missing_values import extract_subseries
 from darts.utils.ts_utils import retain_period_common_to_all
+from darts.utils.utils import generate_index, n_steps_between
 
 
 class TestUtils:
@@ -94,3 +96,446 @@ class TestUtils:
         assert subseries_any[0] == series[:2]
         assert subseries_any[1] == series[3:5]
         assert subseries_any[2] == series[-1]
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            # regular date offset frequencies
+            # day
+            ("2000-01-02", "2000-01-01", None, None, "D", 0),  # empty time index
+            ("2000-01-01", "2000-01-01", None, None, "D", 1),  # increasing time index
+            ("2000-01-01", "2000-01-02", None, None, "D", 2),
+            ("2000-01-01 01:00:00", "2000-01-02 02:00:00", None, None, "D", 2),
+            # 2 * day
+            ("2000-01-01", "1999-12-31", None, None, "2D", 0),
+            ("2000-01-01", "2000-01-02", None, None, "2D", 1),
+            ("2000-01-01", "2000-01-03", None, None, "2D", 2),
+            # hour
+            ("2000-01-01", "2000-01-01", None, None, "h", 1),
+            ("2000-01-01", "2000-01-02", None, None, "h", 25),
+            ("2000-01-01 01:00:00", "2000-01-02 02:00:00", None, None, "h", 26),
+            ("2000-01-01 01:30:00", "2000-01-02 02:00:00", None, None, "h", 25),
+            # 2 * hour
+            ("2000-01-01", "2000-01-01", None, None, "2h", 1),
+            ("2000-01-01", "2000-01-02", None, None, "2h", 13),
+            ("2000-01-01 01:00:00", "2000-01-02 02:00:00", None, None, "2h", 13),
+            ("2000-01-01 01:30:00", "2000-01-02 02:00:00", None, None, "2h", 13),
+            # ambiguous frequencies
+            # week-monday
+            (
+                "2000-01-01",  # saturday
+                "2000-01-03",  # first monday
+                "2000-01-03",  # first monday
+                None,  # first wednesday
+                "W-MON",
+                1,
+            ),
+            # week-monday, start and end are not part of freq (two mondays)
+            (
+                "2000-01-01",  # saturday
+                "2000-01-12",  # second wednesday
+                "2000-01-03",  # first monday
+                "2000-01-10",  # second monday
+                "W-MON",
+                2,
+            ),
+            # week-monday, start is part of freq (two mondays)
+            (
+                "2000-01-03",  # saturday
+                "2000-01-12",  # second wednesday
+                "2000-01-03",  # first monday
+                "2000-01-10",  # second monday
+                "W-MON",
+                2,
+            ),
+            # week-monday, end is part of freq (one monday, end exclusive)
+            (
+                "2000-01-01",  # saturday
+                "2000-01-10",  # second monday
+                "2000-01-03",  # first monday
+                None,  # second wednesday
+                "W-MON",
+                2,
+            ),
+            # week-monday, start and end are part of freq (one monday, end exclusive)
+            (
+                "2000-01-03",  # saturday
+                "2000-01-10",  # second monday
+                "2000-01-03",  # first monday
+                None,  # second wednesday
+                "W-MON",
+                2,
+            ),
+            # month start
+            ("2000-01-31", "2000-01-31", None, None, "MS", 0),
+            ("2000-01-01", "2000-01-02", None, "2000-01-01", "MS", 1),
+            ("2000-01-01", "2000-01-01", None, None, "MS", 1),
+            ("2000-01-01", "2000-02-01", None, None, "MS", 2),
+            ("2000-01-01", "2000-03-01", None, None, "MS", 3),
+            # month end
+            ("2000-01-01", "2000-01-02", None, None, "ME", 0),
+            ("2000-01-31", "2000-02-29", None, None, "ME", 2),
+            # 2 * months
+            ("2000-01-01", "2000-01-01", None, None, "2MS", 1),
+            ("2000-01-01", "2000-02-11", None, "2000-01-01", "2MS", 1),
+            ("2000-01-01", "2000-03-01", None, None, "2MS", 2),
+            ("2000-01-01", "2000-05-01", None, None, "2MS", 3),
+            # quarter
+            ("2000-01-01", "2000-04-01", None, None, "QS", 2),
+            # year
+            ("2000-01-01", "2001-04-01", None, "2001-01-01", "YS", 2),
+            # 2*year
+            ("2001-01-01", "2010-04-01", None, "2009-01-01", "2YS", 5),
+            (0, -1, None, None, 1, 0),  # empty int index
+            (0, -1, None, None, -1, 2),  # decreasing int index
+            (0, 0, None, None, 1, 1),  # increasing int index
+            (0, 0, None, None, 2, 1),
+            (0, 1, None, None, 1, 2),
+            (0, 1, None, None, 2, 1),
+            (0, 2, None, None, 1, 3),
+            (0, 2, None, None, 2, 2),
+        ],
+    )
+    def test_generate_index_with_start_end(self, config):
+        """Test that generate index returns the expected length, start, and end points
+        using `start`, `end`, and `freq` as input.
+        Also tests the reverse index generation with a negative frequency.
+        """
+        start, end, expected_start, expected_start_rev, freq, expected_n_steps = config
+        if isinstance(start, str):
+            start = pd.Timestamp(start)
+            end = pd.Timestamp(end)
+            expected_start = (
+                pd.Timestamp(expected_start) if expected_start is not None else start
+            )
+            expected_start_rev = (
+                pd.Timestamp(expected_start_rev)
+                if expected_start_rev is not None
+                else end
+            )
+            freq = pd.tseries.frequencies.to_offset(freq)
+        else:
+            expected_start = expected_start if expected_start is not None else start
+            expected_start_rev = (
+                expected_start_rev if expected_start_rev is not None else end
+            )
+
+        idx = generate_index(start=start, end=end, freq=freq)
+
+        if isinstance(freq, int):
+            assert idx.step == freq
+        else:
+            assert idx.freq == freq
+
+        # idx has expected length
+        assert len(idx) == expected_n_steps
+
+        if expected_n_steps == 0:
+            return
+
+        # start and end are as expected
+        assert idx[0] == expected_start
+        assert idx[-1] == expected_start + freq * (expected_n_steps - 1)
+
+        # reversed operations generates expected index
+        idx_rev = generate_index(start=end, end=start, freq=-freq)
+        assert idx_rev[0] == expected_start_rev
+        assert idx_rev[-1] == expected_start_rev - freq * (expected_n_steps - 1)
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            # regular date offset frequencies
+            # day
+            ("2000-01-02", None, "D", 0),  # empty time index
+            ("2000-01-01", "2000-01-01", "D", 1),  # increasing time index
+            ("2000-01-01", "2000-01-02", "D", 2),
+            ("2000-01-01 01:00:00", "2000-01-02 01:00:00", "D", 2),
+            # 2 * day
+            ("2000-01-01", None, "2D", 0),
+            ("2000-01-01", "2000-01-01", "2D", 1),
+            ("2000-01-01", "2000-01-03", "2D", 2),
+            # hour
+            ("2000-01-01", "2000-01-01", "h", 1),
+            ("2000-01-01", "2000-01-02", "h", 25),
+            ("2000-01-01 01:00:00", "2000-01-02 02:00:00", "h", 26),
+            ("2000-01-01 01:30:00", "2000-01-02 01:30:00", "h", 25),
+            # 2 * hour
+            ("2000-01-01", "2000-01-01", "2h", 1),
+            ("2000-01-01", "2000-01-02", "2h", 13),
+            ("2000-01-01 01:00:00", "2000-01-02 01:00:00", "2h", 13),
+            ("2000-01-01 01:30:00", "2000-01-02 01:30:00", "2h", 13),
+            # ambiguous frequencies
+            # week-monday
+            (
+                "2000-01-01",  # saturday
+                "2000-01-03",  # first monday
+                "W-MON",
+                1,
+            ),
+            # week-monday, start is not part of freq (two mondays)
+            (
+                "2000-01-01",  # saturday
+                "2000-01-10",  # second monday
+                "W-MON",
+                2,
+            ),
+            # week-monday, start and end are part of freq (two mondays)
+            (
+                "2000-01-03",  # saturday
+                "2000-01-10",  # second monday
+                "W-MON",
+                2,
+            ),
+            # month start
+            ("2000-01-31", None, "MS", 0),
+            ("2000-01-01", "2000-01-01", "MS", 1),
+            ("2000-01-01", "2000-02-01", "MS", 2),
+            ("2000-01-01", "2000-03-01", "MS", 3),
+            # month end
+            ("2000-01-01", None, "ME", 0),
+            ("2000-01-31", "2000-02-29", "ME", 2),
+            # 2 * months
+            ("2000-01-01", "2000-01-01", "2MS", 1),
+            ("2000-01-01", "2000-03-01", "2MS", 2),
+            ("2000-01-01", "2000-05-01", "2MS", 3),
+            # quarter
+            ("2000-01-01", "2000-04-01", "QS", 2),
+            # year
+            ("2000-01-01", "2001-01-01", "YS", 2),
+            # 2*year
+            ("2001-01-01", "2009-01-01", "2YS", 5),
+            (0, None, 1, 0),  # empty int index
+            (0, -1, -1, 2),  # decreasing int index
+            (0, 0, 1, 1),  # increasing int index
+            (0, 0, 2, 1),
+            (0, 1, 1, 2),
+            (0, 2, 1, 3),
+            (0, 2, 2, 2),
+        ],
+    )
+    def test_generate_index_with_start_length(self, config):
+        """Test that generate index returns the expected length, start, and end points
+        using `start`, `length`, and `freq` as input.
+        """
+        start, expected_end, freq, n_steps = config
+        if isinstance(start, str):
+            freq = pd.tseries.frequencies.to_offset(freq)
+            start = pd.Timestamp(start)
+            expected_end = (
+                pd.Timestamp(expected_end) if expected_end is not None else None
+            )
+        idx = generate_index(start=start, length=n_steps, freq=freq)
+        assert len(idx) == n_steps
+        if n_steps == 0:
+            return
+
+        assert idx[-1] == expected_end
+        assert idx[0] == expected_end - (n_steps - 1) * freq
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            # regular date offset frequencies
+            # day
+            (None, "2000-01-02", "D", 0),  # empty time index
+            ("2000-01-01", "2000-01-01", "D", 1),  # increasing time index
+            ("2000-01-01", "2000-01-02", "D", 2),
+            ("2000-01-01 01:00:00", "2000-01-02 01:00:00", "D", 2),
+            # 2 * day
+            (None, "2000-01-01", "2D", 0),
+            ("2000-01-01", "2000-01-01", "2D", 1),
+            ("2000-01-01", "2000-01-03", "2D", 2),
+            # hour
+            ("2000-01-01", "2000-01-01", "h", 1),
+            ("2000-01-01", "2000-01-02", "h", 25),
+            ("2000-01-01 01:00:00", "2000-01-02 02:00:00", "h", 26),
+            ("2000-01-01 01:30:00", "2000-01-02 01:30:00", "h", 25),
+            # 2 * hour
+            ("2000-01-01", "2000-01-01", "2h", 1),
+            ("2000-01-01", "2000-01-02", "2h", 13),
+            ("2000-01-01 01:00:00", "2000-01-02 01:00:00", "2h", 13),
+            ("2000-01-01 01:30:00", "2000-01-02 01:30:00", "2h", 13),
+            # ambiguous frequencies
+            # week-monday, end is not part of freq
+            (
+                "1999-12-27",  # saturday
+                "2000-01-02",  # first monday
+                "W-MON",
+                1,
+            ),
+            # week-monday, end is part of freq
+            (
+                "2000-01-03",  # saturday
+                "2000-01-10",  # second monday
+                "W-MON",
+                2,
+            ),
+            # month start
+            (None, "2000-01-31", "MS", 0),
+            ("2000-01-01", "2000-01-01", "MS", 1),
+            ("2000-01-01", "2000-02-01", "MS", 2),
+            ("2000-01-01", "2000-03-01", "MS", 3),
+            # month end
+            (None, "2000-01-01", "ME", 0),
+            ("2000-01-31", "2000-02-29", "ME", 2),
+            # 2 * months
+            ("2000-01-01", "2000-01-01", "2MS", 1),
+            ("2000-01-01", "2000-03-01", "2MS", 2),
+            ("2000-01-01", "2000-05-01", "2MS", 3),
+            # quarter
+            ("2000-01-01", "2000-04-01", "QS", 2),
+            # year
+            ("2000-01-01", "2001-01-01", "YS", 2),
+            # 2*year
+            ("2001-01-01", "2009-01-01", "2YS", 5),
+            (None, 0, 1, 0),  # empty int index
+            (0, -1, -1, 2),  # decreasing int index
+            (0, 0, 1, 1),  # increasing int index
+            (0, 0, 2, 1),
+            (0, 1, 1, 2),
+            (0, 2, 1, 3),
+            (0, 2, 2, 2),
+        ],
+    )
+    def test_generate_index_with_end_length(self, config):
+        """Test that generate index returns the expected length, start, and end points
+        using `end`, `length`, and `freq` as input.
+        """
+        expected_start, end, freq, n_steps = config
+
+        if isinstance(end, str):
+            freq = pd.tseries.frequencies.to_offset(freq)
+            expected_start = (
+                pd.Timestamp(expected_start) if expected_start is not None else None
+            )
+            end = pd.Timestamp(end)
+        idx = generate_index(end=end, length=n_steps, freq=freq)
+        assert len(idx) == n_steps
+        if n_steps == 0:
+            return
+
+        assert idx[0] == expected_start
+        assert idx[-1] == expected_start + (n_steps - 1) * freq
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            # regular date offset frequencies
+            # day
+            ("2000-01-01", "2000-01-01", "D", 0),
+            ("2000-01-01", "2000-01-02", "D", 1),
+            ("2000-01-01", "2005-02-05", "D", 1862),
+            # 2*days
+            ("2000-01-01", "2000-01-01", "2D", 0),
+            ("2000-01-01", "2000-01-02", "2D", 0),
+            ("2000-01-01", "2000-01-03", "2D", 1),
+            # hour
+            ("2000-01-01", "2000-01-01", "h", 0),
+            ("2000-01-01", "2000-01-01 06:00:00", "h", 6),
+            ("2000-01-01", "2000-01-02", "h", 24),
+            # ambiguous frequencies
+            # week-monday, start and end are not part of freq (two mondays)
+            (
+                "2000-01-01",  # saturday
+                "2000-01-12",  # second wednesday
+                "W-MON",
+                2,
+            ),
+            # week-monday, start is part of freq (two mondays)
+            (
+                "2000-01-03",  # monday
+                "2000-01-12",  # second wednesday
+                "W-MON",
+                2,
+            ),
+            # week-monday, end is part of freq (one monday, end exclusive)
+            (
+                "2000-01-01",  # saturday
+                "2000-01-10",  # second monday
+                "W-MON",
+                1,
+            ),
+            # week-monday, start and end are part of freq (one monday, end exclusive)
+            (
+                "2000-01-03",  # saturday
+                "2000-01-10",  # second monday
+                "W-MON",
+                1,
+            ),
+            # month
+            ("2000-01-01", "2000-01-02", "ME", 0),
+            ("2000-01-01", "2000-01-01", "ME", 0),
+            ("2000-01-01", "2000-02-01", "ME", 1),
+            ("2000-01-01", "2000-03-01", "ME", 2),
+            # 2 * months
+            ("2000-01-01", "2000-01-01", "2ME", 0),
+            ("2000-01-01", "2000-02-11", "2ME", 0),
+            ("2000-01-01", "2000-03-01", "2ME", 1),
+            ("2000-01-01", "2000-05-01", "2ME", 2),
+            # quarter
+            ("2000-01-01", "2000-04-01", "QE", 1),
+            # year
+            ("2000-01-01", "2001-04-01", "YE", 1),
+            # 2*year
+            ("2000-01-01", "2010-04-01", "2YE", 5),
+            # custom frequencies
+            # business day
+            (
+                "2000-01-01",  # saturday (no business)
+                "2000-01-01",
+                CustomBusinessDay(weekmask="Mon Tue Wed Thu Fri"),
+                0,
+            ),
+            (
+                "2000-01-01",  # saturday (no business)
+                "2000-01-02",  # sunday (no business)
+                CustomBusinessDay(weekmask="Mon Tue Wed Thu Fri"),
+                0,
+            ),
+            (
+                "2000-01-01",  # saturday (no business)
+                "2000-01-03",  # monday (first business day)
+                CustomBusinessDay(weekmask="Mon Tue Wed Thu Fri"),
+                0,
+            ),
+            (
+                "2000-01-01",  # saturday (no business)
+                "2000-01-08",  # second saturday (first business day)
+                CustomBusinessDay(weekmask="Mon Tue Wed Thu Fri"),
+                4,
+            ),
+            (
+                "2000-01-03",  # monday
+                "2000-01-07",  # friday
+                CustomBusinessDay(weekmask="Mon Tue Wed Thu Fri"),
+                4,
+            ),
+            # 2 * business days
+            (
+                "2000-01-01",  # saturday (no business)
+                "2000-01-08",  # second saturday (first business day)
+                2 * CustomBusinessDay(weekmask="Mon Tue Wed Thu Fri"),
+                2,
+            ),
+            # integer steps/frequencies
+            (0, -1, 1, -1),
+            (0, 0, 1, 0),
+            (0, 0, 2, 0),
+            (0, 1, 1, 1),
+            (0, 1, 2, 0),
+            (0, 2, 1, 2),
+            (0, 2, 2, 1),
+        ],
+    )
+    def test_n_steps_between(self, config):
+        """Test the number of frequency steps/periods between two time steps."""
+        start, end, freq, expected_n_steps = config
+        if isinstance(start, str):
+            start = pd.Timestamp(start)
+            end = pd.Timestamp(end)
+            freq = pd.tseries.frequencies.to_offset(freq)
+        n_steps = n_steps_between(end=end, start=start, freq=freq)
+        assert n_steps == expected_n_steps
+        n_steps_reversed = n_steps_between(end=start, start=end, freq=freq)
+        assert n_steps_reversed == -expected_n_steps

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2520,10 +2520,13 @@ class TimeSeries:
             return vals[self.time_index.isin(other.time_index)]
 
     def _slice_intersect_bounds(self, other: Self) -> Tuple[int, int]:
+        """Find the start (absolute index) and end (index relative to the end) indices that represent the time
+        intersection from `self` and `other`."""
         shift_start = n_steps_between(
             other.start_time(), self.start_time(), freq=self.freq
         )
-        shift_end = n_steps_between(other.end_time(), self.end_time(), freq=self.freq)
+        shift_end = len(other) - (len(self) - shift_start)
+
         shift_start = shift_start if shift_start >= 0 else 0
         shift_end = shift_end if shift_end < 0 else None
         return shift_start, shift_end

--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -10,7 +10,6 @@ from typing import Callable, Iterator, List, Optional, Tuple, TypeVar, Union
 
 import pandas as pd
 from joblib import Parallel, delayed
-from pandas._libs.tslibs.offsets import BusinessMixin
 from tqdm import tqdm
 from tqdm.notebook import tqdm as tqdm_notebook
 
@@ -377,11 +376,12 @@ def n_steps_between(
     else:
         period_alias = pd.tseries.frequencies.get_period_alias(freq.name)
         if period_alias is not None:
-            # Create a temporary DatetimeIndex to extract the actual start index.
+            # get the number of base periods ("2MS" has base freq "MS") between the two time steps
             diff = (end.to_period(period_alias) - start.to_period(period_alias)).n
             if abs(diff) != diff:
                 # similar case as with (A)
                 diff += diff % freq.n
+            # floor division by the frequency multiplier ("2MS" has multiplier 2)
             n_steps = diff // freq.n
         else:
             # in the worst case for special frequencies (e.g "C*"), we must generate the index

--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -10,6 +10,7 @@ from typing import Callable, Iterator, List, Optional, Tuple, TypeVar, Union
 
 import pandas as pd
 from joblib import Parallel, delayed
+from pandas._libs.tslibs.offsets import BusinessMixin
 from tqdm import tqdm
 from tqdm.notebook import tqdm as tqdm_notebook
 
@@ -342,6 +343,12 @@ def n_steps_between(
     1
     """
     freq = pd.tseries.frequencies.to_offset(freq) if isinstance(freq, str) else freq
+    valid_freq = freq >= 0 if isinstance(freq, int) else freq.n >= 0
+    if not valid_freq:
+        raise_log(
+            ValueError(f"`freq` must be positive/increasing, received freq={freq}."),
+            logger=logger,
+        )
     valid_int = (
         isinstance(start, int) and isinstance(end, int) and isinstance(freq, int)
     )
@@ -358,21 +365,38 @@ def n_steps_between(
             ),
             logger=logger,
         )
-    # Series frequency represents a non-ambiguous timedelta value (not ‘M’, ‘Y’ or ‘y’)
+    # Series frequency represents a non-ambiguous timedelta value (not ‘M’, ‘Y’ or ‘y’, 'W')
     if pd.to_timedelta(freq, errors="coerce") is not pd.NaT:
-        n_steps = (end - start) // freq
+        diff = end - start
+        if abs(diff) != diff:
+            # (A) when diff is negative, not perfectly divisible by freq, and freq is a multiple of a base frequency
+            # (e.g., "2D" or step=2), then computing `diff // freq` can be one off
+            # Example: `end=1, start=2, freq=2` -> then `diff // freq` gives `-1`, but should be `0`.
+            diff += diff % freq
+        n_steps = diff // freq
     else:
-        period_alias = pd.tseries.frequencies.get_period_alias(freq.freqstr)
-        if period_alias is None:
-            raise_log(
-                ValueError(
-                    f"Cannot infer period alias for `freq={freq}`. "
-                    f"Is it a valid pandas offset/frequency alias?"
-                ),
-                logger=logger,
-            )
-        # Create a temporary DatetimeIndex to extract the actual start index.
-        n_steps = (end.to_period(period_alias) - start.to_period(period_alias)).n
+        period_alias = pd.tseries.frequencies.get_period_alias(freq.name)
+        if period_alias is not None:
+            # Create a temporary DatetimeIndex to extract the actual start index.
+            diff = (end.to_period(period_alias) - start.to_period(period_alias)).n
+            if abs(diff) != diff:
+                # similar case as with (A)
+                diff += diff % freq.n
+            n_steps = diff // freq.n
+        else:
+            # in the worst case for special frequencies (e.g "C*"), we must generate the index
+            is_reversed = end < start
+            if is_reversed:
+                # always generate an increasing index, since pandas (v2.2.1) gives inconsistent result for
+                # negative/decreasing frequencies. Then reverse the index in case of negative/decreasing
+                # input frequency
+                start, end = end, start
+            n_steps = len(generate_index(start=start, end=end, freq=freq))
+            if n_steps:
+                # index includes end, take away for difference
+                n_steps -= 1
+            if is_reversed:
+                n_steps *= -1
     return n_steps
 
 
@@ -426,18 +450,39 @@ def generate_index(
     )
 
     if isinstance(start, pd.Timestamp) or isinstance(end, pd.Timestamp):
+        freq = "D" if freq is None else freq
+        freq = pd.tseries.frequencies.to_offset(freq) if isinstance(freq, str) else freq
         index = pd.date_range(
             start=start,
             end=end,
             periods=length,
-            freq="D" if freq is None else freq,
+            freq=freq,
             name=name,
         )
+        if freq.n < 0:
+            if start is not None and not freq.is_on_offset(start):
+                # for anchored negative frequencies, and `start` does not intersect with `freq`:
+                # pandas (v2.2.1) generates an index that starts one step before `start` -> remove this step
+                index = index[1:]
+            elif end is not None and not freq.is_on_offset(end):
+                # if `start` intersects with `freq`, then the same can happen for `end` -> remove this step
+                index = index[:-1]
     else:  # int
         step = 1 if freq is None else freq
+        if start is None:
+            start_ = end - step * length + step
+        else:
+            start_ = start
+
+        if end is None:
+            end_ = start + step * length
+        else:
+            # make end inclusive
+            end_ = end + 1 if step >= 0 else end - 1
+
         index = pd.RangeIndex(
-            start=start if start is not None else end - step * length + step,
-            stop=end + step if end is not None else start + step * length,
+            start=start_,
+            stop=end_,
             step=step,
             name=name,
         )


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2352.

### Summary
- fixes a bug where `n_steps_between` did not work properly with custom business frequencies
- fixes a bug where `generate_index()` with a negative frequencies and either `start` or `end` not intersecting with the frequency, did not return the correct index.
- fixes other edge cases with `generate_index()` and `n_steps_between`