### PR TITLE
Lint/e402

### DIFF
--- a/darts/__init__.py
+++ b/darts/__init__.py
@@ -8,7 +8,7 @@ import os
 import matplotlib as mpl
 from matplotlib import cycler
 
-from .timeseries import TimeSeries, concatenate
+from darts.timeseries import TimeSeries, concatenate
 
 __version__ = "0.29.0"
 
@@ -41,3 +41,5 @@ u8plots_mplstyle = {
 
 if os.getenv("DARTS_CONFIGURE_MATPLOTLIB", "1") != "0":
     mpl.rcParams.update(u8plots_mplstyle)
+
+__all__ = ["TimeSeries", "concatenate"]

--- a/darts/ad/__init__.py
+++ b/darts/ad/__init__.py
@@ -27,16 +27,16 @@ on time series.
 """
 
 # anomaly aggregators
-from .aggregators import AndAggregator, EnsembleSklearnAggregator, OrAggregator
+from darts.ad.aggregators import AndAggregator, EnsembleSklearnAggregator, OrAggregator
 
 # anomaly models
-from .anomaly_model import FilteringAnomalyModel, ForecastingAnomalyModel
+from darts.ad.anomaly_model import FilteringAnomalyModel, ForecastingAnomalyModel
 
 # anomaly detectors
-from .detectors import QuantileDetector, ThresholdDetector
+from darts.ad.detectors import QuantileDetector, ThresholdDetector
 
 # anomaly scorers
-from .scorers import (
+from darts.ad.scorers import (
     CauchyNLLScorer,
     DifferenceScorer,
     ExponentialNLLScorer,
@@ -49,3 +49,24 @@ from .scorers import (
     PyODScorer,
     WassersteinScorer,
 )
+
+__all__ = [
+    "AndAggregator",
+    "EnsembleSklearnAggregator",
+    "OrAggregator",
+    "FilteringAnomalyModel",
+    "ForecastingAnomalyModel",
+    "QuantileDetector",
+    "ThresholdDetector",
+    "CauchyNLLScorer",
+    "DifferenceScorer",
+    "ExponentialNLLScorer",
+    "GammaNLLScorer",
+    "GaussianNLLScorer",
+    "KMeansScorer",
+    "LaplaceNLLScorer",
+    "NormScorer",
+    "PoissonNLLScorer",
+    "PyODScorer",
+    "WassersteinScorer",
+]

--- a/darts/ad/aggregators/__init__.py
+++ b/darts/ad/aggregators/__init__.py
@@ -13,6 +13,12 @@ detection of a single model, and returns one (or multiple) univariate
 binary TimeSeries representing the final detection.
 """
 
-from .and_aggregator import AndAggregator
-from .ensemble_sklearn_aggregator import EnsembleSklearnAggregator
-from .or_aggregator import OrAggregator
+from darts.ad.aggregators.and_aggregator import AndAggregator
+from darts.ad.aggregators.ensemble_sklearn_aggregator import EnsembleSklearnAggregator
+from darts.ad.aggregators.or_aggregator import OrAggregator
+
+__all__ = [
+    "AndAggregator",
+    "EnsembleSklearnAggregator",
+    "OrAggregator",
+]

--- a/darts/ad/anomaly_model/__init__.py
+++ b/darts/ad/anomaly_model/__init__.py
@@ -25,5 +25,10 @@ Finally, the function :func:`show_anomalies()` can also be used to visualize the
 (in-sample predictions and anomaly scores) of the anomaly model.
 """
 
-from .filtering_am import FilteringAnomalyModel
-from .forecasting_am import ForecastingAnomalyModel
+from darts.ad.anomaly_model.filtering_am import FilteringAnomalyModel
+from darts.ad.anomaly_model.forecasting_am import ForecastingAnomalyModel
+
+__all__ = [
+    "FilteringAnomalyModel",
+    "ForecastingAnomalyModel",
+]

--- a/darts/ad/detectors/__init__.py
+++ b/darts/ad/detectors/__init__.py
@@ -19,5 +19,10 @@ to obtain binary predictions. The function ``eval_accuracy()`` returns the accur
 binary ground truth time series indicating the presence of anomalies.
 """
 
-from .quantile_detector import QuantileDetector
-from .threshold_detector import ThresholdDetector
+from darts.ad.detectors.quantile_detector import QuantileDetector
+from darts.ad.detectors.threshold_detector import ThresholdDetector
+
+__all__ = [
+    "QuantileDetector",
+    "ThresholdDetector",
+]

--- a/darts/ad/scorers/__init__.py
+++ b/darts/ad/scorers/__init__.py
@@ -65,15 +65,31 @@ Other useful functions are:
 More details can be found in the API documentation of each scorer.
 """
 
-from .difference_scorer import DifferenceScorer
-from .kmeans_scorer import KMeansScorer
-from .nll_cauchy_scorer import CauchyNLLScorer
-from .nll_exponential_scorer import ExponentialNLLScorer
-from .nll_gamma_scorer import GammaNLLScorer
-from .nll_gaussian_scorer import GaussianNLLScorer
-from .nll_laplace_scorer import LaplaceNLLScorer
-from .nll_poisson_scorer import PoissonNLLScorer
-from .norm_scorer import NormScorer
-from .pyod_scorer import PyODScorer
-from .scorers import FittableAnomalyScorer, NonFittableAnomalyScorer
-from .wasserstein_scorer import WassersteinScorer
+from darts.ad.scorers.difference_scorer import DifferenceScorer
+from darts.ad.scorers.kmeans_scorer import KMeansScorer
+from darts.ad.scorers.nll_cauchy_scorer import CauchyNLLScorer
+from darts.ad.scorers.nll_exponential_scorer import ExponentialNLLScorer
+from darts.ad.scorers.nll_gamma_scorer import GammaNLLScorer
+from darts.ad.scorers.nll_gaussian_scorer import GaussianNLLScorer
+from darts.ad.scorers.nll_laplace_scorer import LaplaceNLLScorer
+from darts.ad.scorers.nll_poisson_scorer import PoissonNLLScorer
+from darts.ad.scorers.norm_scorer import NormScorer
+from darts.ad.scorers.pyod_scorer import PyODScorer
+from darts.ad.scorers.scorers import FittableAnomalyScorer, NonFittableAnomalyScorer
+from darts.ad.scorers.wasserstein_scorer import WassersteinScorer
+
+__all__ = [
+    "DifferenceScorer",
+    "KMeansScorer",
+    "CauchyNLLScorer",
+    "ExponentialNLLScorer",
+    "GammaNLLScorer",
+    "GaussianNLLScorer",
+    "LaplaceNLLScorer",
+    "PoissonNLLScorer",
+    "NormScorer",
+    "PyODScorer",
+    "FittableAnomalyScorer",
+    "NonFittableAnomalyScorer",
+    "WassersteinScorer",
+]

--- a/darts/dataprocessing/__init__.py
+++ b/darts/dataprocessing/__init__.py
@@ -3,4 +3,6 @@ Data Processing
 ---------------
 """
 
-from .pipeline import Pipeline
+from darts.dataprocessing.pipeline import Pipeline
+
+__all__ = ["Pipeline"]

--- a/darts/dataprocessing/dtw/__init__.py
+++ b/darts/dataprocessing/dtw/__init__.py
@@ -3,6 +3,23 @@ Dynamic Time Warping (DTW)
 --------------------------
 """
 
-from .cost_matrix import CostMatrix
-from .dtw import DTWAlignment, dtw
-from .window import CRWindow, Itakura, NoWindow, SakoeChiba, Window
+from darts.dataprocessing.dtw.cost_matrix import CostMatrix
+from darts.dataprocessing.dtw.dtw import DTWAlignment, dtw
+from darts.dataprocessing.dtw.window import (
+    CRWindow,
+    Itakura,
+    NoWindow,
+    SakoeChiba,
+    Window,
+)
+
+__all__ = [
+    "CostMatrix",
+    "DTWAlignment",
+    "dtw",
+    "CRWindow",
+    "Itakura",
+    "NoWindow",
+    "SakoeChiba",
+    "Window",
+]

--- a/darts/dataprocessing/dtw/cost_matrix.py
+++ b/darts/dataprocessing/dtw/cost_matrix.py
@@ -5,7 +5,7 @@ from typing import Tuple
 
 import numpy as np
 
-from .window import CRWindow, Window
+from darts.dataprocessing.dtw.window import CRWindow, Window
 
 Elem = Tuple[int, int]
 

--- a/darts/dataprocessing/dtw/dtw.py
+++ b/darts/dataprocessing/dtw/dtw.py
@@ -11,11 +11,10 @@ import pandas as pd
 import xarray as xr
 
 from darts import TimeSeries
+from darts.dataprocessing.dtw.cost_matrix import CostMatrix
+from darts.dataprocessing.dtw.window import CRWindow, NoWindow, Window
 from darts.logging import get_logger, raise_if, raise_if_not
 from darts.timeseries import DIMS
-
-from .cost_matrix import CostMatrix
-from .window import CRWindow, NoWindow, Window
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/encoders/__init__.py
+++ b/darts/dataprocessing/encoders/__init__.py
@@ -3,7 +3,7 @@ Time Axis Encoders
 ------------------
 """
 
-from .encoders import (
+from darts.dataprocessing.encoders.encoders import (
     FutureCallableIndexEncoder,
     FutureCyclicEncoder,
     FutureDatetimeAttributeEncoder,
@@ -14,3 +14,15 @@ from .encoders import (
     PastIntegerIndexEncoder,
     SequentialEncoder,
 )
+
+__all__ = [
+    "FutureCallableIndexEncoder",
+    "FutureCyclicEncoder",
+    "FutureDatetimeAttributeEncoder",
+    "FutureIntegerIndexEncoder",
+    "PastCallableIndexEncoder",
+    "PastCyclicEncoder",
+    "PastDatetimeAttributeEncoder",
+    "PastIntegerIndexEncoder",
+    "SequentialEncoder",
+]

--- a/darts/dataprocessing/transformers/__init__.py
+++ b/darts/dataprocessing/transformers/__init__.py
@@ -3,19 +3,43 @@ Data Transformers
 -----------------
 """
 
-from .base_data_transformer import BaseDataTransformer
-from .boxcox import BoxCox
-from .diff import Diff
-from .fittable_data_transformer import FittableDataTransformer
-from .invertible_data_transformer import InvertibleDataTransformer
-from .mappers import InvertibleMapper, Mapper
-from .midas import MIDAS
-from .missing_values_filler import MissingValuesFiller
-from .reconciliation import (
+from darts.dataprocessing.transformers.base_data_transformer import BaseDataTransformer
+from darts.dataprocessing.transformers.boxcox import BoxCox
+from darts.dataprocessing.transformers.diff import Diff
+from darts.dataprocessing.transformers.fittable_data_transformer import (
+    FittableDataTransformer,
+)
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    InvertibleDataTransformer,
+)
+from darts.dataprocessing.transformers.mappers import InvertibleMapper, Mapper
+from darts.dataprocessing.transformers.midas import MIDAS
+from darts.dataprocessing.transformers.missing_values_filler import MissingValuesFiller
+from darts.dataprocessing.transformers.reconciliation import (
     BottomUpReconciliator,
     MinTReconciliator,
     TopDownReconciliator,
 )
-from .scaler import Scaler
-from .static_covariates_transformer import StaticCovariatesTransformer
-from .window_transformer import WindowTransformer
+from darts.dataprocessing.transformers.scaler import Scaler
+from darts.dataprocessing.transformers.static_covariates_transformer import (
+    StaticCovariatesTransformer,
+)
+from darts.dataprocessing.transformers.window_transformer import WindowTransformer
+
+__all__ = [
+    "BaseDataTransformer",
+    "BoxCox",
+    "Diff",
+    "FittableDataTransformer",
+    "InvertibleDataTransformer",
+    "InvertibleMapper",
+    "Mapper",
+    "MIDAS",
+    "MissingValuesFiller",
+    "BottomUpReconciliator",
+    "MinTReconciliator",
+    "TopDownReconciliator",
+    "Scaler",
+    "StaticCovariatesTransformer",
+    "WindowTransformer",
+]

--- a/darts/dataprocessing/transformers/boxcox.py
+++ b/darts/dataprocessing/transformers/boxcox.py
@@ -15,11 +15,14 @@ import pandas as pd
 from scipy.special import inv_boxcox
 from scipy.stats import boxcox, boxcox_normmax
 
+from darts.dataprocessing.transformers.fittable_data_transformer import (
+    FittableDataTransformer,
+)
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    InvertibleDataTransformer,
+)
 from darts.logging import get_logger, raise_if
 from darts.timeseries import TimeSeries
-
-from .fittable_data_transformer import FittableDataTransformer
-from .invertible_data_transformer import InvertibleDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/transformers/diff.py
+++ b/darts/dataprocessing/transformers/diff.py
@@ -7,11 +7,14 @@ from typing import Any, Mapping, Sequence, Union
 
 import numpy as np
 
+from darts.dataprocessing.transformers.fittable_data_transformer import (
+    FittableDataTransformer,
+)
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    InvertibleDataTransformer,
+)
 from darts.logging import get_logger, raise_if, raise_if_not
 from darts.timeseries import TimeSeries
-
-from .fittable_data_transformer import FittableDataTransformer
-from .invertible_data_transformer import InvertibleDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/transformers/fittable_data_transformer.py
+++ b/darts/dataprocessing/transformers/fittable_data_transformer.py
@@ -9,10 +9,9 @@ from typing import Any, Generator, Iterable, List, Mapping, Optional, Sequence, 
 import numpy as np
 
 from darts import TimeSeries
+from darts.dataprocessing.transformers.base_data_transformer import BaseDataTransformer
 from darts.logging import get_logger, raise_log
 from darts.utils import _build_tqdm_iterator, _parallel_apply
-
-from .base_data_transformer import BaseDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/transformers/invertible_data_transformer.py
+++ b/darts/dataprocessing/transformers/invertible_data_transformer.py
@@ -9,10 +9,9 @@ from typing import Any, List, Mapping, Optional, Sequence, Union
 import numpy as np
 
 from darts import TimeSeries
+from darts.dataprocessing.transformers.base_data_transformer import BaseDataTransformer
 from darts.logging import get_logger, raise_log
 from darts.utils import _build_tqdm_iterator, _parallel_apply
-
-from .base_data_transformer import BaseDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/transformers/mappers.py
+++ b/darts/dataprocessing/transformers/mappers.py
@@ -8,11 +8,12 @@ from typing import Any, Callable, Mapping, Union
 import numpy as np
 import pandas as pd
 
+from darts.dataprocessing.transformers.base_data_transformer import BaseDataTransformer
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    InvertibleDataTransformer,
+)
 from darts.logging import get_logger
 from darts.timeseries import TimeSeries
-
-from .base_data_transformer import BaseDataTransformer
-from .invertible_data_transformer import InvertibleDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/transformers/missing_values_filler.py
+++ b/darts/dataprocessing/transformers/missing_values_filler.py
@@ -6,10 +6,9 @@ Missing Values Filler
 from typing import Any, Mapping, Union
 
 from darts import TimeSeries
+from darts.dataprocessing.transformers.base_data_transformer import BaseDataTransformer
 from darts.logging import get_logger, raise_if, raise_if_not
 from darts.utils.missing_values import fill_missing_values
-
-from .base_data_transformer import BaseDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/transformers/scaler.py
+++ b/darts/dataprocessing/transformers/scaler.py
@@ -9,11 +9,14 @@ from typing import Any, Mapping, Sequence, Union
 import numpy as np
 from sklearn.preprocessing import MinMaxScaler
 
+from darts.dataprocessing.transformers.fittable_data_transformer import (
+    FittableDataTransformer,
+)
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    InvertibleDataTransformer,
+)
 from darts.logging import get_logger, raise_log
 from darts.timeseries import TimeSeries
-
-from .fittable_data_transformer import FittableDataTransformer
-from .invertible_data_transformer import InvertibleDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/dataprocessing/transformers/static_covariates_transformer.py
+++ b/darts/dataprocessing/transformers/static_covariates_transformer.py
@@ -16,11 +16,14 @@ import pandas as pd
 from scipy.sparse import csr_matrix
 from sklearn.preprocessing import MinMaxScaler, OrdinalEncoder
 
+from darts.dataprocessing.transformers.fittable_data_transformer import (
+    FittableDataTransformer,
+)
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    InvertibleDataTransformer,
+)
 from darts.logging import get_logger, raise_log
 from darts.timeseries import TimeSeries
-
-from .fittable_data_transformer import FittableDataTransformer
-from .invertible_data_transformer import InvertibleDataTransformer
 
 logger = get_logger(__name__)
 

--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -5,18 +5,16 @@ Datasets
 A few popular time series datasets
 """
 
-import os
 from pathlib import Path
-from typing import List, Literal, Optional
+from typing import List
 
 import numpy as np
 import pandas as pd
 
 from darts import TimeSeries
+from darts.datasets.dataset_loaders import DatasetLoaderCSV, DatasetLoaderMetadata
 from darts.logging import get_logger, raise_if_not
 from darts.utils.utils import _build_tqdm_iterator
-
-from .dataset_loaders import DatasetLoaderCSV, DatasetLoaderMetadata
 
 """
     Overall usage of this package:

--- a/darts/explainability/__init__.py
+++ b/darts/explainability/__init__.py
@@ -3,17 +3,16 @@ Explainability
 --------------
 """
 
-from darts.logging import get_logger
-
-logger = get_logger(__name__)
-
 from darts.explainability.explainability_result import (
     ShapExplainabilityResult,
     TFTExplainabilityResult,
     _ExplainabilityResult,
 )
 from darts.explainability.shap_explainer import ShapExplainer
+from darts.logging import get_logger
+from darts.models.utils import NotImportedModule
 
+logger = get_logger(__name__)
 try:
     from darts.explainability.tft_explainer import TFTExplainer
 except ModuleNotFoundError:
@@ -22,3 +21,12 @@ except ModuleNotFoundError:
         'To enable them, install "darts", "u8darts[torch]" or "u8darts[all]" (with pip); '
         'or "u8darts-torch" or "u8darts-all" (with conda).'
     )
+    TFTExplainer = NotImportedModule(module_name="(Py)Torch", warn=False)
+
+__all__ = [
+    "ShapExplainabilityResult",
+    "TFTExplainabilityResult",
+    "_ExplainabilityResult",
+    "ShapExplainer",
+    "TFTExplainer",
+]

--- a/darts/metrics/__init__.py
+++ b/darts/metrics/__init__.py
@@ -49,7 +49,7 @@ For Dynamic Time Warping (DTW) (aggregated over time):
     - :func:`DTW <darts.metrics.metrics.dtw_metric>`: Dynamic Time Warping Metric
 """
 
-from .metrics import (
+from darts.metrics.metrics import (
     ae,
     ape,
     arre,
@@ -78,3 +78,33 @@ from .metrics import (
     smape,
     sse,
 )
+
+__all__ = [
+    "ae",
+    "ape",
+    "arre",
+    "ase",
+    "coefficient_of_variation",
+    "dtw_metric",
+    "err",
+    "mae",
+    "mape",
+    "marre",
+    "mase",
+    "merr",
+    "mql",
+    "mse",
+    "msse",
+    "ope",
+    "ql",
+    "qr",
+    "r2_score",
+    "rmse",
+    "rmsle",
+    "rmsse",
+    "sape",
+    "se",
+    "sle",
+    "smape",
+    "sse",
+]

--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -58,6 +58,20 @@ except ModuleNotFoundError:
         'To enable them, install "darts", "u8darts[torch]" or "u8darts[all]" (with pip); '
         'or "u8darts-torch" or "u8darts-all" (with conda).'
     )
+    BlockRNNModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    DLinearModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    GlobalNaiveAggregate = NotImportedModule(module_name="(Py)Torch", warn=False)
+    GlobalNaiveDrift = NotImportedModule(module_name="(Py)Torch", warn=False)
+    GlobalNaiveSeasonal = NotImportedModule(module_name="(Py)Torch", warn=False)
+    NBEATSModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    NHiTSModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    NLinearModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    RNNModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    TCNModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    TFTModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    TiDEModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    TransformerModel = NotImportedModule(module_name="(Py)Torch", warn=False)
+    TSMixerModel = NotImportedModule(module_name="(Py)Torch", warn=False)
 
 try:
     from darts.models.forecasting.prophet_model import Prophet
@@ -103,3 +117,52 @@ from darts.models.forecasting.baselines import NaiveEnsembleModel
 
 # Ensembling
 from darts.models.forecasting.ensemble_model import EnsembleModel
+
+__all__ = [
+    "LightGBMModel",
+    "ARIMA",
+    "AutoARIMA",
+    "NaiveDrift",
+    "NaiveMean",
+    "NaiveMovingAverage",
+    "NaiveSeasonal",
+    "ExponentialSmoothing",
+    "FFT",
+    "KalmanForecaster",
+    "LinearRegressionModel",
+    "RandomForest",
+    "RegressionEnsembleModel",
+    "RegressionModel",
+    "BATS",
+    "TBATS",
+    "FourTheta",
+    "Theta",
+    "VARIMA",
+    "BlockRNNModel",
+    "DLinearModel",
+    "GlobalNaiveDrift",
+    "GlobalNaiveDrift",
+    "GlobalNaiveSeasonal",
+    "NBEATSModel",
+    "NHiTSModel",
+    "NLinearModel",
+    "RNNModel",
+    "TCNModel",
+    "TFTModel",
+    "TiDEModel",
+    "TransformerModel",
+    "TSMixerModel",
+    "Prophet",
+    "CatBoostModel",
+    "Croston",
+    "StatsForecastAutoARIMA",
+    "StatsForecastAutoCES",
+    "StatsForecastAutoETS",
+    "StatsForecastAutoTheta",
+    "XGBModel",
+    "GaussianProcessFilter",
+    "KalmanFilter",
+    "MovingAverageFilter",
+    "NaiveEnsembleModel",
+    "EnsembleModel",
+]

--- a/darts/tests/conftest.py
+++ b/darts/tests/conftest.py
@@ -4,6 +4,18 @@ import tempfile
 
 import pytest
 
+from darts.logging import get_logger
+
+logger = get_logger(__name__)
+
+try:
+    import torch  # noqa: F401
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    logger.warning("Torch not installed - Some tests will be skipped.")
+    TORCH_AVAILABLE = False
+
 tfm_kwargs = {
     "pl_trainer_kwargs": {
         "accelerator": "cpu",

--- a/darts/tests/dataprocessing/encoders/test_encoders.py
+++ b/darts/tests/dataprocessing/encoders/test_encoders.py
@@ -29,18 +29,14 @@ from darts.dataprocessing.encoders.encoders import (
 )
 from darts.dataprocessing.transformers import Scaler
 from darts.logging import get_logger, raise_log
+from darts.tests.conftest import TORCH_AVAILABLE
 from darts.utils import timeseries_generation as tg
 from darts.utils.utils import generate_index
 
 logger = get_logger(__name__)
 
-try:
+if TORCH_AVAILABLE:
     from darts.models import TFTModel
-
-    TORCH_AVAILABLE = True
-except ImportError:
-    logger.warning("Torch not installed - will be skipping Torch models tests")
-    TORCH_AVAILABLE = False
 
 
 class TestEncoder:

--- a/darts/tests/datasets/test_datasets.py
+++ b/darts/tests/datasets/test_datasets.py
@@ -5,35 +5,33 @@ import pandas as pd
 import pytest
 
 from darts import TimeSeries
-from darts.logging import get_logger
+from darts.tests.conftest import TORCH_AVAILABLE
 from darts.utils.timeseries_generation import gaussian_timeseries
 
-logger = get_logger(__name__)
-
-try:
-    from darts.utils.data import (  # noqa: F401
-        DualCovariatesInferenceDataset,
-        DualCovariatesSequentialDataset,
-        DualCovariatesShiftedDataset,
-        FutureCovariatesInferenceDataset,
-        FutureCovariatesSequentialDataset,
-        FutureCovariatesShiftedDataset,
-        HorizonBasedDataset,
-        MixedCovariatesInferenceDataset,
-        MixedCovariatesSequentialDataset,
-        MixedCovariatesShiftedDataset,
-        PastCovariatesInferenceDataset,
-        PastCovariatesSequentialDataset,
-        PastCovariatesShiftedDataset,
-        SplitCovariatesInferenceDataset,
-        SplitCovariatesSequentialDataset,
-        SplitCovariatesShiftedDataset,
-    )
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+
+from darts.utils.data import (  # noqa: F401
+    DualCovariatesInferenceDataset,
+    DualCovariatesSequentialDataset,
+    DualCovariatesShiftedDataset,
+    FutureCovariatesInferenceDataset,
+    FutureCovariatesSequentialDataset,
+    FutureCovariatesShiftedDataset,
+    HorizonBasedDataset,
+    MixedCovariatesInferenceDataset,
+    MixedCovariatesSequentialDataset,
+    MixedCovariatesShiftedDataset,
+    PastCovariatesInferenceDataset,
+    PastCovariatesSequentialDataset,
+    PastCovariatesShiftedDataset,
+    SplitCovariatesInferenceDataset,
+    SplitCovariatesSequentialDataset,
+    SplitCovariatesShiftedDataset,
+)
 
 
 class TestDataset:

--- a/darts/tests/explainability/test_tft_explainer.py
+++ b/darts/tests/explainability/test_tft_explainer.py
@@ -7,20 +7,16 @@ import pandas as pd
 import pytest
 
 from darts import TimeSeries
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
-    from darts.explainability import TFTExplainabilityResult, TFTExplainer
-    from darts.models import TFTModel
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+from darts.explainability import TFTExplainabilityResult, TFTExplainer
+from darts.models import TFTModel
 
 
 def helper_create_test_cases(series_options: list):

--- a/darts/tests/models/components/glu_variants.py
+++ b/darts/tests/models/components/glu_variants.py
@@ -1,19 +1,16 @@
 import pytest
 
-from darts.logging import get_logger
+from darts.tests.conftest import TORCH_AVAILABLE
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.models.components import glu_variants
-    from darts.models.components.glu_variants import GLU_FFN
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
+
+from darts.models.components import glu_variants
+from darts.models.components.glu_variants import GLU_FFN
 
 
 class TestFFN:

--- a/darts/tests/models/components/test_layer_norm_variants.py
+++ b/darts/tests/models/components/test_layer_norm_variants.py
@@ -1,24 +1,21 @@
 import numpy as np
 import pytest
 
-from darts.logging import get_logger
+from darts.tests.conftest import TORCH_AVAILABLE
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.models.components.layer_norm_variants import (
-        LayerNorm,
-        LayerNormNoBias,
-        RINorm,
-        RMSNorm,
-    )
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
+
+from darts.models.components.layer_norm_variants import (
+    LayerNorm,
+    LayerNormNoBias,
+    RINorm,
+    RMSNorm,
+)
 
 
 class TestLayerNormVariants:

--- a/darts/tests/models/forecasting/test_RNN.py
+++ b/darts/tests/models/forecasting/test_RNN.py
@@ -3,20 +3,16 @@ import pandas as pd
 import pytest
 
 from darts import TimeSeries
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 
-logger = get_logger(__name__)
-
-try:
-    import torch.nn as nn
-
-    from darts.models.forecasting.rnn_model import CustomRNNModule, RNNModel, _RNNModule
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch.nn as nn
+
+from darts.models.forecasting.rnn_model import CustomRNNModule, RNNModel, _RNNModule
 
 
 class ModuleValid1(_RNNModule):

--- a/darts/tests/models/forecasting/test_TCN.py
+++ b/darts/tests/models/forecasting/test_TCN.py
@@ -1,21 +1,17 @@
 import pytest
 
-from darts.logging import get_logger
 from darts.metrics import mae
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.models.forecasting.tcn_model import TCNModel
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
+
+from darts.models.forecasting.tcn_model import TCNModel
 
 
 class TestTCNModel:

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -4,24 +4,20 @@ import pytest
 
 from darts import TimeSeries, concatenate
 from darts.dataprocessing.transformers import Scaler
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
-    import torch.nn as nn
-    from torch.nn import MSELoss
-
-    from darts.models.forecasting.tft_model import TFTModel
-    from darts.models.forecasting.tft_submodels import get_embedding_size
-    from darts.utils.likelihood_models import QuantileRegression
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch.nn as nn
+from torch.nn import MSELoss
+
+from darts.models.forecasting.tft_model import TFTModel
+from darts.models.forecasting.tft_submodels import get_embedding_size
+from darts.utils.likelihood_models import QuantileRegression
 
 
 class TestTFTModel:

--- a/darts/tests/models/forecasting/test_backtesting.py
+++ b/darts/tests/models/forecasting/test_backtesting.py
@@ -18,7 +18,7 @@ from darts.models import (
     NaiveSeasonal,
     Theta,
 )
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils.timeseries_generation import constant_timeseries as ct
 from darts.utils.timeseries_generation import gaussian_timeseries as gt
 from darts.utils.timeseries_generation import linear_timeseries as lt
@@ -28,20 +28,13 @@ from darts.utils.timeseries_generation import sine_timeseries as st
 logger = get_logger(__name__)
 
 
-try:
+if TORCH_AVAILABLE:
     from darts.models import (
         BlockRNNModel,
         LinearRegressionModel,
         RandomForest,
         TCNModel,
     )
-
-    TORCH_AVAILABLE = True
-except ImportError:
-    logger.warning(
-        "Torch models are not installed - will not be tested for backtesting"
-    )
-    TORCH_AVAILABLE = False
 
 
 def get_dummy_series(

--- a/darts/tests/models/forecasting/test_baseline_models.py
+++ b/darts/tests/models/forecasting/test_baseline_models.py
@@ -10,7 +10,7 @@ from darts.models.forecasting.forecasting_model import (
     GlobalForecastingModel,
     LocalForecastingModel,
 )
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
@@ -26,12 +26,10 @@ local_models = [
 global_models = []
 
 
-try:
+if TORCH_AVAILABLE:
     import torch
 
     from darts.models import GlobalNaiveAggregate, GlobalNaiveDrift, GlobalNaiveSeasonal
-
-    TORCH_AVAILABLE = True
 
     global_models += [
         (
@@ -72,10 +70,7 @@ try:
     def custom_mean_invalid_output_type(x, dim):
         return torch.mean(x, dim=1).detach().numpy()
 
-except ImportError:
-    logger.warning("Torch not installed - will be skipping Torch models tests")
-    TORCH_AVAILABLE = False
-
+else:
     custom_mean_valid = None
     custom_mean_invalid_out_shape = None
     custom_mean_invalid_signature = None

--- a/darts/tests/models/forecasting/test_block_RNN.py
+++ b/darts/tests/models/forecasting/test_block_RNN.py
@@ -3,24 +3,20 @@ import pandas as pd
 import pytest
 
 from darts import TimeSeries
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 
-logger = get_logger(__name__)
-
-try:
-    import torch.nn as nn
-
-    from darts.models.forecasting.block_rnn_model import (
-        BlockRNNModel,
-        CustomBlockRNNModule,
-        _BlockRNNModule,
-    )
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch.nn as nn
+
+from darts.models.forecasting.block_rnn_model import (
+    BlockRNNModel,
+    CustomBlockRNNModule,
+    _BlockRNNModule,
+)
 
 
 class ModuleValid1(_BlockRNNModule):

--- a/darts/tests/models/forecasting/test_dlinear_nlinear.py
+++ b/darts/tests/models/forecasting/test_dlinear_nlinear.py
@@ -5,24 +5,20 @@ import pandas as pd
 import pytest
 
 from darts import concatenate
-from darts.logging import get_logger
 from darts.metrics import rmse
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.models.forecasting.dlinear import DLinearModel
-    from darts.models.forecasting.nlinear import NLinearModel
-    from darts.utils.likelihood_models import GaussianLikelihood
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
+
+from darts.models.forecasting.dlinear import DLinearModel
+from darts.models.forecasting.nlinear import NLinearModel
+from darts.utils.likelihood_models import GaussianLikelihood
 
 
 class TestDlinearNlinearModels:

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -13,19 +13,14 @@ from darts.models import (
     StatsForecastAutoARIMA,
     Theta,
 )
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
 
-try:
+if TORCH_AVAILABLE:
     from darts.models import DLinearModel, NBEATSModel, RNNModel, TCNModel
     from darts.utils.likelihood_models import QuantileRegression
-
-    TORCH_AVAILABLE = True
-except ImportError:
-    logger.warning("Torch not installed - Some ensemble models tests will be skipped.")
-    TORCH_AVAILABLE = False
 
 
 def _make_ts(start_value=0, n=100):

--- a/darts/tests/models/forecasting/test_global_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_global_forecasting_models.py
@@ -9,44 +9,39 @@ import pytest
 
 from darts.dataprocessing.transformers import Scaler
 from darts.datasets import AirPassengersDataset
-from darts.logging import get_logger
 from darts.metrics import mape
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 from darts.utils.timeseries_generation import linear_timeseries
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.models import (
-        BlockRNNModel,
-        DLinearModel,
-        GlobalNaiveAggregate,
-        GlobalNaiveDrift,
-        GlobalNaiveSeasonal,
-        NBEATSModel,
-        NLinearModel,
-        RNNModel,
-        TCNModel,
-        TFTModel,
-        TiDEModel,
-        TransformerModel,
-        TSMixerModel,
-    )
-    from darts.models.forecasting.torch_forecasting_model import (
-        DualCovariatesTorchModel,
-        MixedCovariatesTorchModel,
-        PastCovariatesTorchModel,
-    )
-    from darts.utils.likelihood_models import GaussianLikelihood
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
 
+from darts.models import (
+    BlockRNNModel,
+    DLinearModel,
+    GlobalNaiveAggregate,
+    GlobalNaiveDrift,
+    GlobalNaiveSeasonal,
+    NBEATSModel,
+    NLinearModel,
+    RNNModel,
+    TCNModel,
+    TFTModel,
+    TiDEModel,
+    TransformerModel,
+    TSMixerModel,
+)
+from darts.models.forecasting.torch_forecasting_model import (
+    DualCovariatesTorchModel,
+    MixedCovariatesTorchModel,
+    PastCovariatesTorchModel,
+)
+from darts.utils.likelihood_models import GaussianLikelihood
 
 IN_LEN = 24
 OUT_LEN = 12

--- a/darts/tests/models/forecasting/test_historical_forecasts.py
+++ b/darts/tests/models/forecasting/test_historical_forecasts.py
@@ -9,7 +9,6 @@ import darts
 from darts import TimeSeries, concatenate
 from darts.dataprocessing.transformers import Scaler
 from darts.datasets import AirPassengersDataset
-from darts.logging import get_logger
 from darts.models import (
     ARIMA,
     AutoARIMA,
@@ -20,10 +19,10 @@ from darts.models import (
     NaiveSeasonal,
     NotImportedModule,
 )
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-try:
+if TORCH_AVAILABLE:
     import torch
 
     from darts.models import (
@@ -41,14 +40,6 @@ try:
         TSMixerModel,
     )
     from darts.utils.likelihood_models import GaussianLikelihood, QuantileRegression
-
-    TORCH_AVAILABLE = True
-except ImportError:
-    logger = get_logger(__name__)
-    logger.warning(
-        "Torch not installed - will be skipping historical forecasts tests for torch models"
-    )
-    TORCH_AVAILABLE = False
 
 models_reg_no_cov_cls_kwargs = [(LinearRegressionModel, {"lags": 8}, {}, (8, 1))]
 if not isinstance(CatBoostModel, NotImportedModule):

--- a/darts/tests/models/forecasting/test_nbeats_nhits.py
+++ b/darts/tests/models/forecasting/test_nbeats_nhits.py
@@ -1,20 +1,16 @@
 import numpy as np
 import pytest
 
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
-    from darts.models.forecasting.nbeats import NBEATSModel
-    from darts.models.forecasting.nhits import NHiTSModel
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+from darts.models.forecasting.nbeats import NBEATSModel
+from darts.models.forecasting.nhits import NHiTSModel
 
 
 class TestNbeatsNhitsModel:

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -18,12 +18,12 @@ from darts.models import (
     NotImportedModule,
     XGBModel,
 )
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
 logger = get_logger(__name__)
 
-try:
+if TORCH_AVAILABLE:
     import torch
 
     from darts.models import (
@@ -57,13 +57,6 @@ try:
         QuantileRegression,
         WeibullLikelihood,
     )
-
-    TORCH_AVAILABLE = True
-except ImportError:
-    logger.warning(
-        "Torch not available. Tests related to torch-based models will be skipped."
-    )
-    TORCH_AVAILABLE = False
 
 lgbm_available = not isinstance(LightGBMModel, NotImportedModule)
 cb_available = not isinstance(CatBoostModel, NotImportedModule)

--- a/darts/tests/models/forecasting/test_ptl_trainer.py
+++ b/darts/tests/models/forecasting/test_ptl_trainer.py
@@ -1,21 +1,17 @@
 import numpy as np
 import pytest
 
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils.timeseries_generation import linear_timeseries
 
-logger = get_logger(__name__)
-
-try:
-    import pytorch_lightning as pl
-
-    from darts.models.forecasting.rnn_model import RNNModel
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import pytorch_lightning as pl
+
+from darts.models.forecasting.rnn_model import RNNModel
 
 
 class TestPTLTrainer:

--- a/darts/tests/models/forecasting/test_regression_ensemble_model.py
+++ b/darts/tests/models/forecasting/test_regression_ensemble_model.py
@@ -7,7 +7,6 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression
 
 from darts import TimeSeries
-from darts.logging import get_logger
 from darts.metrics import mape, rmse
 from darts.models import (
     LinearRegressionModel,
@@ -18,22 +17,15 @@ from darts.models import (
     RegressionModel,
     Theta,
 )
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.tests.models.forecasting.test_ensemble_models import _make_ts
 from darts.tests.models.forecasting.test_regression_models import train_test_split
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
+if TORCH_AVAILABLE:
     import torch
 
     from darts.models import BlockRNNModel, RNNModel
-
-    TORCH_AVAILABLE = True
-except ImportError:
-    logger.warning("Torch not available. Some tests will be skipped.")
-    TORCH_AVAILABLE = False
 
 
 class TestRegressionEnsembleModels:

--- a/darts/tests/models/forecasting/test_tide_model.py
+++ b/darts/tests/models/forecasting/test_tide_model.py
@@ -3,22 +3,18 @@ import pandas as pd
 import pytest
 
 from darts import concatenate
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.models.forecasting.tide_model import TiDEModel
-    from darts.utils.likelihood_models import GaussianLikelihood
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
+
+from darts.models.forecasting.tide_model import TiDEModel
+from darts.utils.likelihood_models import GaussianLikelihood
 
 
 class TestTiDEModel:

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -12,73 +12,69 @@ import darts.utils.timeseries_generation as tg
 from darts import TimeSeries
 from darts.dataprocessing.encoders import SequentialEncoder
 from darts.dataprocessing.transformers import BoxCox, Scaler
-from darts.logging import get_logger
 from darts.metrics import mape
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-    from pytorch_lightning.callbacks import Callback
-    from pytorch_lightning.loggers.logger import DummyLogger
-    from pytorch_lightning.tuner.lr_finder import _LRFinder
-    from torchmetrics import (
-        MeanAbsoluteError,
-        MeanAbsolutePercentageError,
-        MetricCollection,
-    )
-
-    from darts.models import (
-        BlockRNNModel,
-        DLinearModel,
-        GlobalNaiveAggregate,
-        GlobalNaiveDrift,
-        GlobalNaiveSeasonal,
-        NBEATSModel,
-        NHiTSModel,
-        NLinearModel,
-        RNNModel,
-        TCNModel,
-        TFTModel,
-        TiDEModel,
-        TransformerModel,
-        TSMixerModel,
-    )
-    from darts.models.components.layer_norm_variants import RINorm
-    from darts.utils.likelihood_models import (
-        GaussianLikelihood,
-        LaplaceLikelihood,
-        Likelihood,
-    )
-
-    kwargs = {
-        "input_chunk_length": 10,
-        "output_chunk_length": 1,
-        "n_epochs": 1,
-        "pl_trainer_kwargs": {"fast_dev_run": True, **tfm_kwargs["pl_trainer_kwargs"]},
-    }
-    models = [
-        (BlockRNNModel, kwargs),
-        (DLinearModel, kwargs),
-        (NBEATSModel, kwargs),
-        (NHiTSModel, kwargs),
-        (NLinearModel, kwargs),
-        (RNNModel, {"training_length": 10, **kwargs}),
-        (TCNModel, kwargs),
-        (TFTModel, {"add_relative_index": 2, **kwargs}),
-        (TiDEModel, kwargs),
-        (TransformerModel, kwargs),
-        (TSMixerModel, kwargs),
-        (GlobalNaiveSeasonal, kwargs),
-        (GlobalNaiveAggregate, kwargs),
-        (GlobalNaiveDrift, kwargs),
-    ]
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
+from pytorch_lightning.callbacks import Callback
+from pytorch_lightning.loggers.logger import DummyLogger
+from pytorch_lightning.tuner.lr_finder import _LRFinder
+from torchmetrics import (
+    MeanAbsoluteError,
+    MeanAbsolutePercentageError,
+    MetricCollection,
+)
+
+from darts.models import (
+    BlockRNNModel,
+    DLinearModel,
+    GlobalNaiveAggregate,
+    GlobalNaiveDrift,
+    GlobalNaiveSeasonal,
+    NBEATSModel,
+    NHiTSModel,
+    NLinearModel,
+    RNNModel,
+    TCNModel,
+    TFTModel,
+    TiDEModel,
+    TransformerModel,
+    TSMixerModel,
+)
+from darts.models.components.layer_norm_variants import RINorm
+from darts.utils.likelihood_models import (
+    GaussianLikelihood,
+    LaplaceLikelihood,
+    Likelihood,
+)
+
+kwargs = {
+    "input_chunk_length": 10,
+    "output_chunk_length": 1,
+    "n_epochs": 1,
+    "pl_trainer_kwargs": {"fast_dev_run": True, **tfm_kwargs["pl_trainer_kwargs"]},
+}
+models = [
+    (BlockRNNModel, kwargs),
+    (DLinearModel, kwargs),
+    (NBEATSModel, kwargs),
+    (NHiTSModel, kwargs),
+    (NLinearModel, kwargs),
+    (RNNModel, {"training_length": 10, **kwargs}),
+    (TCNModel, kwargs),
+    (TFTModel, {"add_relative_index": 2, **kwargs}),
+    (TiDEModel, kwargs),
+    (TransformerModel, kwargs),
+    (TSMixerModel, kwargs),
+    (GlobalNaiveSeasonal, kwargs),
+    (GlobalNaiveAggregate, kwargs),
+    (GlobalNaiveDrift, kwargs),
+]
 
 
 class TestTorchForecastingModel:

--- a/darts/tests/models/forecasting/test_transformer_model.py
+++ b/darts/tests/models/forecasting/test_transformer_model.py
@@ -3,28 +3,24 @@ import pandas as pd
 import pytest
 
 from darts import TimeSeries
-from darts.logging import get_logger
-from darts.tests.conftest import tfm_kwargs
+from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
 from darts.utils import timeseries_generation as tg
 
-logger = get_logger(__name__)
-
-try:
-    import torch.nn as nn
-
-    from darts.models.components.transformer import (
-        CustomFeedForwardDecoderLayer,
-        CustomFeedForwardEncoderLayer,
-    )
-    from darts.models.forecasting.transformer_model import (
-        TransformerModel,
-        _TransformerModule,
-    )
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch.nn as nn
+
+from darts.models.components.transformer import (
+    CustomFeedForwardDecoderLayer,
+    CustomFeedForwardEncoderLayer,
+)
+from darts.models.forecasting.transformer_model import (
+    TransformerModel,
+    _TransformerModule,
+)
 
 
 class TestTransformerModel:

--- a/darts/tests/models/forecasting/test_tsmixer.py
+++ b/darts/tests/models/forecasting/test_tsmixer.py
@@ -1,24 +1,22 @@
-from darts.logging import get_logger
+import pytest
 
-logger = get_logger(__name__)
+from darts.tests.conftest import TORCH_AVAILABLE
 
-try:
-    import numpy as np
-    import pandas as pd
-    import pytest
-    import torch
-    from torch import nn
-
-    from darts import concatenate
-    from darts.models.forecasting.tsmixer_model import TimeBatchNorm2d, TSMixerModel
-    from darts.tests.conftest import tfm_kwargs
-    from darts.utils import timeseries_generation as tg
-    from darts.utils.likelihood_models import GaussianLikelihood
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import numpy as np
+import pandas as pd
+import torch
+from torch import nn
+
+from darts import concatenate
+from darts.models.forecasting.tsmixer_model import TimeBatchNorm2d, TSMixerModel
+from darts.tests.conftest import tfm_kwargs
+from darts.utils import timeseries_generation as tg
+from darts.utils.likelihood_models import GaussianLikelihood
 
 
 class TestTSMixerModel:

--- a/darts/tests/utils/test_likelihood_models.py
+++ b/darts/tests/utils/test_likelihood_models.py
@@ -2,53 +2,50 @@ from itertools import combinations
 
 import pytest
 
-from darts.logging import get_logger
+from darts.tests.conftest import TORCH_AVAILABLE
 
-logger = get_logger(__name__)
-
-try:
-    from darts.utils.likelihood_models import (
-        BetaLikelihood,
-        CauchyLikelihood,
-        ExponentialLikelihood,
-        GaussianLikelihood,
-        PoissonLikelihood,
-        QuantileRegression,
-        WeibullLikelihood,
-    )
-
-    likelihood_models = {
-        "quantile": [QuantileRegression(), QuantileRegression([0.25, 0.5, 0.75])],
-        "gaussian": [
-            GaussianLikelihood(prior_mu=0, prior_sigma=1),
-            GaussianLikelihood(prior_mu=10, prior_sigma=1),
-        ],
-        "exponential": [
-            ExponentialLikelihood(prior_lambda=0.1),
-            ExponentialLikelihood(prior_lambda=0.5),
-        ],
-        "poisson": [
-            PoissonLikelihood(prior_lambda=2),
-            PoissonLikelihood(prior_lambda=5),
-        ],
-        "cauchy": [
-            CauchyLikelihood(prior_xzero=-0.4, prior_gamma=2),
-            CauchyLikelihood(prior_xzero=3, prior_gamma=2),
-        ],
-        "weibull": [
-            WeibullLikelihood(prior_strength=1.0),
-            WeibullLikelihood(prior_strength=0.8),
-        ],
-        "beta": [
-            BetaLikelihood(prior_alpha=0.2, prior_beta=0.4, prior_strength=0.3),
-            BetaLikelihood(prior_alpha=0.2, prior_beta=0.4, prior_strength=0.6),
-        ],
-    }
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+from darts.utils.likelihood_models import (
+    BetaLikelihood,
+    CauchyLikelihood,
+    ExponentialLikelihood,
+    GaussianLikelihood,
+    PoissonLikelihood,
+    QuantileRegression,
+    WeibullLikelihood,
+)
+
+likelihood_models = {
+    "quantile": [QuantileRegression(), QuantileRegression([0.25, 0.5, 0.75])],
+    "gaussian": [
+        GaussianLikelihood(prior_mu=0, prior_sigma=1),
+        GaussianLikelihood(prior_mu=10, prior_sigma=1),
+    ],
+    "exponential": [
+        ExponentialLikelihood(prior_lambda=0.1),
+        ExponentialLikelihood(prior_lambda=0.5),
+    ],
+    "poisson": [
+        PoissonLikelihood(prior_lambda=2),
+        PoissonLikelihood(prior_lambda=5),
+    ],
+    "cauchy": [
+        CauchyLikelihood(prior_xzero=-0.4, prior_gamma=2),
+        CauchyLikelihood(prior_xzero=3, prior_gamma=2),
+    ],
+    "weibull": [
+        WeibullLikelihood(prior_strength=1.0),
+        WeibullLikelihood(prior_strength=0.8),
+    ],
+    "beta": [
+        BetaLikelihood(prior_alpha=0.2, prior_beta=0.4, prior_strength=0.3),
+        BetaLikelihood(prior_alpha=0.2, prior_beta=0.4, prior_strength=0.6),
+    ],
+}
 
 
 class TestLikelihoodModel:

--- a/darts/tests/utils/test_losses.py
+++ b/darts/tests/utils/test_losses.py
@@ -1,18 +1,16 @@
 import pytest
 
-from darts.logging import get_logger
+from darts.tests.conftest import TORCH_AVAILABLE
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.utils.losses import MAELoss, MapeLoss, SmapeLoss
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+
+import torch
+
+from darts.utils.losses import MAELoss, MapeLoss, SmapeLoss
 
 
 class TestLosses:

--- a/darts/tests/utils/test_utils_torch.py
+++ b/darts/tests/utils/test_utils_torch.py
@@ -1,19 +1,16 @@
 import pytest
 from numpy.random import RandomState
 
-from darts.logging import get_logger
+from darts.tests.conftest import TORCH_AVAILABLE
 
-logger = get_logger(__name__)
-
-try:
-    import torch
-
-    from darts.utils.torch import random_method
-except ImportError:
+if not TORCH_AVAILABLE:
     pytest.skip(
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
+
+from darts.utils.torch import random_method
 
 
 # use a simple torch model mock

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -50,10 +50,9 @@ import xarray as xr
 from pandas.tseries.frequencies import to_offset
 from scipy.stats import kurtosis, skew
 
+from darts.logging import get_logger, raise_if, raise_if_not, raise_log
+from darts.utils import _build_tqdm_iterator, _parallel_apply
 from darts.utils.utils import generate_index, n_steps_between
-
-from .logging import get_logger, raise_if, raise_if_not, raise_log
-from .utils import _build_tqdm_iterator, _parallel_apply
 
 try:
     from typing import Literal
@@ -3173,7 +3172,7 @@ class TimeSeries:
             New TimeSeries instance enhanced by `attribute`.
         """
         self._assert_deterministic()
-        from .utils import timeseries_generation as tg
+        from darts.utils import timeseries_generation as tg
 
         return self.stack(
             tg.datetime_attribute_timeseries(
@@ -3219,7 +3218,7 @@ class TimeSeries:
             A new TimeSeries instance, enhanced with binary holiday component.
         """
         self._assert_deterministic()
-        from .utils import timeseries_generation as tg
+        from darts.utils import timeseries_generation as tg
 
         return self.stack(
             tg.holidays_timeseries(

--- a/darts/utils/__init__.py
+++ b/darts/utils/__init__.py
@@ -3,9 +3,16 @@ Utils
 -----
 """
 
-from .utils import (
+from darts.utils.utils import (
     _build_tqdm_iterator,
     _parallel_apply,
     _with_sanity_checks,
     n_steps_between,
 )
+
+__all__ = [
+    "_build_tqdm_iterator",
+    "_parallel_apply",
+    "_with_sanity_checks",
+    "n_steps_between",
+]

--- a/darts/utils/data/__init__.py
+++ b/darts/utils/data/__init__.py
@@ -6,10 +6,10 @@ TimeSeries Datasets
 try:
     # Base classes for training datasets:
     # Implementation (horizon-based)
-    from .horizon_based_dataset import HorizonBasedDataset
+    from darts.utils.data.horizon_based_dataset import HorizonBasedDataset
 
     # Base class and implementations for inference datasets:
-    from .inference_dataset import (
+    from darts.utils.data.inference_dataset import (
         DualCovariatesInferenceDataset,
         FutureCovariatesInferenceDataset,
         InferenceDataset,
@@ -19,7 +19,7 @@ try:
     )
 
     # Implementations (sequential)
-    from .sequential_dataset import (
+    from darts.utils.data.sequential_dataset import (
         DualCovariatesSequentialDataset,
         FutureCovariatesSequentialDataset,
         MixedCovariatesSequentialDataset,
@@ -28,14 +28,14 @@ try:
     )
 
     # Implementations (shifted)
-    from .shifted_dataset import (
+    from darts.utils.data.shifted_dataset import (
         DualCovariatesShiftedDataset,
         FutureCovariatesShiftedDataset,
         MixedCovariatesShiftedDataset,
         PastCovariatesShiftedDataset,
         SplitCovariatesShiftedDataset,
     )
-    from .training_dataset import (
+    from darts.utils.data.training_dataset import (
         DualCovariatesTrainingDataset,
         FutureCovariatesTrainingDataset,
         MixedCovariatesTrainingDataset,
@@ -43,7 +43,95 @@ try:
         SplitCovariatesTrainingDataset,
         TrainingDataset,
     )
+except ImportError:  # Torch is not available
+    from darts.models.utils import NotImportedModule
 
-except ImportError:
-    # Torch is not available
-    pass
+    HorizonBasedDataset = NotImportedModule(module_name="(Py)Torch", warn=False)
+    DualCovariatesInferenceDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    FutureCovariatesInferenceDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    InferenceDataset = NotImportedModule(module_name="(Py)Torch", warn=False)
+    MixedCovariatesInferenceDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    PastCovariatesInferenceDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    SplitCovariatesInferenceDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    DualCovariatesSequentialDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    FutureCovariatesSequentialDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    MixedCovariatesSequentialDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    PastCovariatesSequentialDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    SplitCovariatesSequentialDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    DualCovariatesShiftedDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    FutureCovariatesShiftedDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    MixedCovariatesShiftedDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    PastCovariatesShiftedDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    SplitCovariatesShiftedDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    DualCovariatesTrainingDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    FutureCovariatesTrainingDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    MixedCovariatesTrainingDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    PastCovariatesTrainingDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    SplitCovariatesTrainingDataset = NotImportedModule(
+        module_name="(Py)Torch", warn=False
+    )
+    TrainingDataset = NotImportedModule(module_name="(Py)Torch", warn=False)
+
+__all__ = [
+    "HorizonBasedDataset",
+    "DualCovariatesInferenceDataset",
+    "FutureCovariatesInferenceDataset",
+    "InferenceDataset",
+    "MixedCovariatesInferenceDataset",
+    "PastCovariatesInferenceDataset",
+    "SplitCovariatesInferenceDataset",
+    "DualCovariatesSequentialDataset",
+    "FutureCovariatesSequentialDataset",
+    "MixedCovariatesSequentialDataset",
+    "PastCovariatesSequentialDataset",
+    "SplitCovariatesSequentialDataset",
+    "DualCovariatesShiftedDataset",
+    "FutureCovariatesShiftedDataset",
+    "MixedCovariatesShiftedDataset",
+    "PastCovariatesShiftedDataset",
+    "SplitCovariatesShiftedDataset",
+    "DualCovariatesTrainingDataset",
+    "FutureCovariatesTrainingDataset",
+    "MixedCovariatesTrainingDataset",
+    "PastCovariatesTrainingDataset",
+    "SplitCovariatesTrainingDataset",
+    "TrainingDataset",
+]

--- a/darts/utils/data/horizon_based_dataset.py
+++ b/darts/utils/data/horizon_based_dataset.py
@@ -9,9 +9,8 @@ import numpy as np
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_if_not
-
-from .training_dataset import PastCovariatesTrainingDataset
-from .utils import CovariateType
+from darts.utils.data.training_dataset import PastCovariatesTrainingDataset
+from darts.utils.data.utils import CovariateType
 
 logger = get_logger(__name__)
 

--- a/darts/utils/data/inference_dataset.py
+++ b/darts/utils/data/inference_dataset.py
@@ -13,9 +13,8 @@ from torch.utils.data import Dataset
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_log
+from darts.utils.data.utils import CovariateType
 from darts.utils.historical_forecasts.utils import _process_predict_start_points_bounds
-
-from .utils import CovariateType
 
 logger = get_logger(__name__)
 

--- a/darts/utils/data/sequential_dataset.py
+++ b/darts/utils/data/sequential_dataset.py
@@ -8,16 +8,15 @@ from typing import Optional, Sequence, Tuple, Union
 import numpy as np
 
 from darts import TimeSeries
-
-from .shifted_dataset import GenericShiftedDataset
-from .training_dataset import (
+from darts.utils.data.shifted_dataset import GenericShiftedDataset
+from darts.utils.data.training_dataset import (
     DualCovariatesTrainingDataset,
     FutureCovariatesTrainingDataset,
     MixedCovariatesTrainingDataset,
     PastCovariatesTrainingDataset,
     SplitCovariatesTrainingDataset,
 )
-from .utils import CovariateType
+from darts.utils.data.utils import CovariateType
 
 
 class PastCovariatesSequentialDataset(PastCovariatesTrainingDataset):

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -9,8 +9,7 @@ import numpy as np
 
 from darts import TimeSeries
 from darts.logging import raise_if_not
-
-from .training_dataset import (
+from darts.utils.data.training_dataset import (
     DualCovariatesTrainingDataset,
     FutureCovariatesTrainingDataset,
     MixedCovariatesTrainingDataset,
@@ -18,7 +17,7 @@ from .training_dataset import (
     SplitCovariatesTrainingDataset,
     TrainingDataset,
 )
-from .utils import CovariateType
+from darts.utils.data.utils import CovariateType
 
 
 class PastCovariatesShiftedDataset(PastCovariatesTrainingDataset):

--- a/darts/utils/data/training_dataset.py
+++ b/darts/utils/data/training_dataset.py
@@ -11,8 +11,7 @@ from torch.utils.data import Dataset
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_if_not
-
-from .utils import CovariateType
+from darts.utils.data.utils import CovariateType
 
 logger = get_logger(__name__)
 SampleIndexType = Tuple[int, int, int, int, int, int]

--- a/darts/utils/historical_forecasts/__init__.py
+++ b/darts/utils/historical_forecasts/__init__.py
@@ -1,11 +1,21 @@
-from .optimized_historical_forecasts_regression import (
+from darts.utils.historical_forecasts.optimized_historical_forecasts_regression import (
     _optimized_historical_forecasts_all_points,
     _optimized_historical_forecasts_last_points_only,
 )
-from .utils import (
+from darts.utils.historical_forecasts.utils import (
     _check_optimizable_historical_forecasts_global_models,
     _get_historical_forecast_boundaries,
     _historical_forecasts_general_checks,
     _historical_forecasts_start_warnings,
     _process_historical_forecast_input,
 )
+
+__all__ = [
+    "_optimized_historical_forecasts_all_points",
+    "_optimized_historical_forecasts_last_points_only",
+    "_check_optimizable_historical_forecasts_global_models",
+    "_get_historical_forecast_boundaries",
+    "_historical_forecasts_general_checks",
+    "_historical_forecasts_start_warnings",
+    "_process_historical_forecast_input",
+]

--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -23,9 +23,8 @@ from statsmodels.tsa.stattools import (
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_if, raise_if_not, raise_log
-
-from .missing_values import fill_missing_values
-from .utils import ModelMode, SeasonalityMode
+from darts.utils.missing_values import fill_missing_values
+from darts.utils.utils import ModelMode, SeasonalityMode
 
 logger = get_logger(__name__)
 

--- a/examples/utils/__init__.py
+++ b/examples/utils/__init__.py
@@ -1,1 +1,3 @@
-from .utils import fix_pythonpath_if_working_locally
+from examples.utils.utils import fix_pythonpath_if_working_locally
+
+__all__ = ["fix_pythonpath_if_working_locally"]

--- a/examples/utils/__init__.py
+++ b/examples/utils/__init__.py
@@ -1,3 +1,3 @@
-from examples.utils.utils import fix_pythonpath_if_working_locally
+from .utils import fix_pythonpath_if_working_locally
 
 __all__ = ["fix_pythonpath_if_working_locally"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ select = [
 ]
 ignore = [
     "E203",
-    "F401",  # todo: add imports to `__all__`
     "E402",  # todo: use noqa per line
 ]
 ignore-init-module-imports = true


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). (not required)

### Summary
- Activates `F401` checks to Ruff (import unused). When switching from `flake8` to Ruff in #2323 we ignored "F401" as a TODO.
- For these checks to pass, all imports in `__init__.py` must be added to `__all__`
- Additionally, changed all relative imports to absolute imports.