### PR TITLE
fix MixedCovTorchModels multi TS predictions with n<ocl

### DIFF
--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -830,13 +830,15 @@ class PLMixedCovariatesModule(PLForecastingModule, ABC):
         batch_prediction = [out[:, :roll_size, :]]
         prediction_length = roll_size
 
-        while prediction_length < n:
-            # we want the last prediction to end exactly at `n` into the future.
+        # predict at least `output_chunk_length` points, so that we use the most recent target values
+        min_n = n if n >= self.output_chunk_length else self.output_chunk_length
+        while prediction_length < min_n:
+            # we want the last prediction to end exactly at `min_n` into the future.
             # this means we may have to truncate the previous prediction and step
             # back the roll size for the last chunk
-            if prediction_length + self.output_chunk_length > n:
+            if prediction_length + self.output_chunk_length > min_n:
                 spillover_prediction_length = (
-                    prediction_length + self.output_chunk_length - n
+                    prediction_length + self.output_chunk_length - min_n
                 )
                 roll_size -= spillover_prediction_length
                 prediction_length -= spillover_prediction_length

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -2779,62 +2779,6 @@ class MixedCovariatesTorchModel(TorchForecastingModel, ABC):
             None,
         )
 
-    def predict(
-        self,
-        n: int,
-        series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
-        trainer: Optional[pl.Trainer] = None,
-        batch_size: Optional[int] = None,
-        verbose: Optional[bool] = None,
-        n_jobs: int = 1,
-        roll_size: Optional[int] = None,
-        num_samples: int = 1,
-        num_loader_workers: int = 0,
-        mc_dropout: bool = False,
-        predict_likelihood_parameters: bool = False,
-        show_warnings: bool = True,
-    ) -> Union[TimeSeries, Sequence[TimeSeries]]:
-        # since we have future covariates, the inference dataset for future input must be at least of length
-        # `output_chunk_length`. If not, we would have to step back which causes past input to be shorter than
-        # `input_chunk_length`.
-
-        if n >= self.output_chunk_length:
-            return super().predict(
-                n=n,
-                series=series,
-                past_covariates=past_covariates,
-                future_covariates=future_covariates,
-                trainer=trainer,
-                batch_size=batch_size,
-                verbose=verbose,
-                n_jobs=n_jobs,
-                roll_size=roll_size,
-                num_samples=num_samples,
-                num_loader_workers=num_loader_workers,
-                mc_dropout=mc_dropout,
-                predict_likelihood_parameters=predict_likelihood_parameters,
-                show_warnings=show_warnings,
-            )
-        else:
-            return super().predict(
-                n=self.output_chunk_length,
-                series=series,
-                past_covariates=past_covariates,
-                future_covariates=future_covariates,
-                trainer=trainer,
-                batch_size=batch_size,
-                verbose=verbose,
-                n_jobs=n_jobs,
-                roll_size=roll_size,
-                num_samples=num_samples,
-                num_loader_workers=num_loader_workers,
-                mc_dropout=mc_dropout,
-                predict_likelihood_parameters=predict_likelihood_parameters,
-                show_warnings=show_warnings,
-            )[:n]
-
 
 class SplitCovariatesTorchModel(TorchForecastingModel, ABC):
     def _build_train_dataset(


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- fixes a bug when calling `predict()` with a MixedCovariatesTorchForecastingModel (e.g. TiDE, N/DLinear, ...) `n<output_chunk_length` and a list of `series` with length `len(series) < n`, where the predictions did not return the correct number of series.