### PR TITLE
TimeInstanceNorm2d normalization for TSMixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,14 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
       - renamed method `eval_accuracy_from_prediction()` to `eval_metric_from_prediction()`
       - renamed params `actual_series` to `series`, and `actual_anomalies` to `anomalies`
     - `darts.ad.utils.eval_accuracy_from_scores` :
-      - renamed function to `eval_metric_from_scores`
+      - renamed function to `eval_metric_from_scores`\
       - renamed params `actual_anoamlies` to `anomalies`, and `anomaly_score` to `pred_scores`
     - `darts.ad.utils.eval_accuracy_from_binary_prediction` :
       - renamed function to `eval_metric_from_binary_prediction`
       - renamed params `actual_anoamlies` to `anomalies`, and `binary_pred_anomalies` to `pred_anomalies`
     - `darts.ad.utils.show_anomalies_from_scores`:
       - renamed params `series` to `actual_series`, `actual_anomalies` to `anomalies`, `model_output` to `pred_series`, and `anomaly_scores` to `pred_scores`
+- Added new TSMixer normalization layer TimeInstanceNorm2d. [#2386](https://github.com/unit8co/darts/pull/2386) by [Tim Rosenflanz](https://github.com/trosenflanz).
 - Improvements to `TimeSeries` : [#1477](https://github.com/unit8co/darts/pull/1477) by [Dennis Bader](https://github.com/dennisbader).
   - New method `with_times_and_values()`, which returns a new series with a new time index and new values but with identical columns and metadata as the series called from (static covariates, hierarchy).
   - New method `slice_intersect_times()`, which returns the sliced time index of a series, where the index has been intersected with another series.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
       - renamed method `eval_accuracy_from_prediction()` to `eval_metric_from_prediction()`
       - renamed params `actual_series` to `series`, and `actual_anomalies` to `anomalies`
     - `darts.ad.utils.eval_accuracy_from_scores` :
-      - renamed function to `eval_metric_from_scores`\
+      - renamed function to `eval_metric_from_scores`
       - renamed params `actual_anoamlies` to `anomalies`, and `anomaly_score` to `pred_scores`
     - `darts.ad.utils.eval_accuracy_from_binary_prediction` :
       - renamed function to `eval_metric_from_binary_prediction`

--- a/darts/tests/models/forecasting/test_tsmixer.py
+++ b/darts/tests/models/forecasting/test_tsmixer.py
@@ -267,6 +267,7 @@ class TestTSMixerModel:
             ("LayerNormNoBias", False),
             (nn.LayerNorm, False),
             ("TimeBatchNorm2d", False),
+            ("TimeInstanceNorm2d", False),
             ("invalid", True),
         ],
     )


### PR DESCRIPTION
### Summary
Addresses https://github.com/unit8co/darts/issues/2384

Adds a new normalization type for TSMixer TimeInstanceNorm2d

### Other Information

To avoid duplicating code, used an abstract class to define the reshape logic and inherited from specific normalization layers in children classes. Let me know if you want it replaced with simpler code that just copypastes the logic. 