### PR TITLE
Fix deprecated usage of torch.nn.utils.weight_norm

### DIFF
--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -98,8 +98,8 @@ class _ResidualBlock(nn.Module):
         )
         if weight_norm:
             self.conv1, self.conv2 = (
-                nn.utils.weight_norm(self.conv1),
-                nn.utils.weight_norm(self.conv2),
+                nn.utils.parametrizations.weight_norm(self.conv1),
+                nn.utils.parametrizations.weight_norm(self.conv2),
             )
 
         if input_dim != output_dim:

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1579,7 +1579,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             torch.save(self, f_out)
 
         # save the LightningModule checkpoint
-        path_ptl_ckpt = path + ".ckpt"
+        path_ptl_ckpt = path.replace(".pt", "") + ".ckpt"
         if self.trainer is not None:
             self.trainer.save_checkpoint(path_ptl_ckpt)
         # TODO: keep track of PyTorch Lightning to see if they implement model checkpoint saving


### PR DESCRIPTION
42ef14a1e3fadc4398d8c0077b150a5703b78f16: The previous implementation in darts.darts.models.forecasting.tcn_mode was using `torch.nn.utils.weight_norm`, which is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`. This commit replaces two occurrences of `torch.nn.utils.weight_norm` with the recommended `torch.nn.utils.parametrizations.weight_norm` to resolve the deprecation warning.

8cc12c846d2b26d5da9b15ac7c5c7a5a21d5b874: The .pt string is yet existed in the checkpoint file .ckpt. I filtered it out. 

Change Made:
- Replaced torch.nn.utils.weight_norm with torch.nn.utils.parametrizations.weight_norm, and filtering out the .pt string.

Testing:
- Tested the changes by using the TCN (Temporal Convolutional Network) model in darts.
- Confirmed that the deprecation warning related to the usage of `torch.nn.utils.weight_norm` no longer appears when utilizing the TCN model.
- Ran existing test suites to ensure that the functionality of the package is not affected by the changes.
- Tested backward compatibility to verify that existing codebases relying on the TCN model continue to function as expected after the update.

