### PR TITLE
Feat/sample weight torch

### DIFF
--- a/darts/models/forecasting/global_baseline_models.py
+++ b/darts/models/forecasting/global_baseline_models.py
@@ -253,6 +253,7 @@ class _GlobalNaiveModel(MixedCovariatesTorchModel, ABC):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> MixedCovariatesTrainingDataset:
         return MixedCovariatesSequentialDataset(
@@ -264,6 +265,7 @@ class _GlobalNaiveModel(MixedCovariatesTorchModel, ABC):
             output_chunk_shift=self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
 

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -212,10 +212,10 @@ class PLForecastingModule(pl.LightningModule, ABC):
 
     def training_step(self, train_batch, batch_idx) -> torch.Tensor:
         """performs the training step"""
-        output = self._produce_train_output(train_batch[:-1])
-        target = train_batch[
-            -1
-        ]  # By convention target is always the last element returned by datasets
+        # by convention, the last two elements are sample weights and future target
+        output = self._produce_train_output(train_batch[:-2])
+        # sample_weight = train_batch[-2]
+        target = train_batch[-1]
         loss = self._compute_loss(output, target)
         self.log(
             "train_loss",
@@ -229,7 +229,9 @@ class PLForecastingModule(pl.LightningModule, ABC):
 
     def validation_step(self, val_batch, batch_idx) -> torch.Tensor:
         """performs the validation step"""
-        output = self._produce_train_output(val_batch[:-1])
+        # the last two elements are sample weights and future target
+        output = self._produce_train_output(val_batch[:-2])
+        # sample_weight = val_batch[-2]
         target = val_batch[-1]
         loss = self._compute_loss(output, target)
         self.log(

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -370,12 +370,14 @@ class PLForecastingModule(pl.LightningModule, ABC):
     def _compute_loss(self, output, target, sample_weight):
         # output is of shape (batch_size, n_timesteps, n_components, n_params)
         if self.likelihood:
-            return self.likelihood.compute_loss(output, target)
+            loss = self.likelihood.compute_loss(output, target, sample_weight)
         else:
             # If there's no likelihood, nr_params=1, and we need to squeeze out the
             # last dimension of model output, for properly computing the loss.
             loss = self.criterion(output.squeeze(dim=-1), target)
-            return loss if sample_weight is None else (loss * sample_weight).mean()
+            if sample_weight is not None:
+                loss = (loss * sample_weight).mean()
+        return loss
 
     def _update_metrics(self, output, target, metrics):
         if not len(metrics):

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -563,6 +563,7 @@ class RNNModel(DualCovariatesTorchModel):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> DualCovariatesShiftedDataset:
         return DualCovariatesShiftedDataset(
@@ -572,6 +573,7 @@ class RNNModel(DualCovariatesTorchModel):
             shift=1,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def _verify_train_dataset_type(self, train_dataset: TrainingDataset):

--- a/darts/models/forecasting/tcn_model.py
+++ b/darts/models/forecasting/tcn_model.py
@@ -535,6 +535,7 @@ class TCNModel(PastCovariatesTorchModel):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> PastCovariatesShiftedDataset:
         return PastCovariatesShiftedDataset(
@@ -544,4 +545,5 @@ class TCNModel(PastCovariatesTorchModel):
             shift=self.output_chunk_length + self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -1159,6 +1159,7 @@ class TFTModel(MixedCovariatesTorchModel):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> MixedCovariatesSequentialDataset:
         raise_if(
@@ -1179,6 +1180,7 @@ class TFTModel(MixedCovariatesTorchModel):
             output_chunk_shift=self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def _verify_train_dataset_type(self, train_dataset: TrainingDataset):

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1037,7 +1037,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             (train_sample_weight, model.train_criterion, "train"),
             (val_sample_weight, model.val_criterion, "val"),
         ]:
-            if sample_weight is None:
+            if criterion is None or sample_weight is None:
                 continue
 
             # we need to check that loss has a reduction param that we can change when calling

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -572,6 +572,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> TrainingDataset:
         """
@@ -661,6 +662,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         epochs: int = 0,
         max_samples_per_ts: Optional[int] = None,
         dataloader_kwargs: Optional[Dict[str, Any]] = None,
+        sample_weight: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        val_sample_weight: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
     ) -> "TorchForecastingModel":
         """Fit/train the model on one or multiple series.
 
@@ -699,6 +702,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             Optionally, the past covariates corresponding to the validation series (must match ``covariates``)
         val_future_covariates
             Optionally, the future covariates corresponding to the validation series (must match ``covariates``)
+        val_sample_weight
+            Same as for `sample_weight` but for the evaluation dataset.
         trainer
             Optionally, a custom PyTorch-Lightning Trainer object to perform training. Using a custom ``trainer`` will
             override Darts' default trainer.
@@ -720,6 +725,19 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             <https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader>`_.
             By default, Darts configures parameters ("batch_size", "shuffle", "drop_last", "collate_fn", "pin_memory")
             for seamless forecasting. Changing them should be done with care to avoid unexpected behavior.
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
+        val_sample_weight
+            Same as for `sample_weight` but for the evaluation dataset.
 
         Returns
         -------
@@ -737,9 +755,11 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             series=series,
             past_covariates=past_covariates,
             future_covariates=future_covariates,
+            sample_weight=sample_weight,
             val_series=val_series,
             val_past_covariates=val_past_covariates,
             val_future_covariates=val_future_covariates,
+            val_sample_weight=val_sample_weight,
             trainer=trainer,
             verbose=verbose,
             epochs=epochs,
@@ -759,9 +779,11 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         series: Union[TimeSeries, Sequence[TimeSeries]],
         past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        sample_weight: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         val_series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         val_past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         val_future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        val_sample_weight: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         trainer: Optional[pl.Trainer] = None,
         verbose: Optional[bool] = None,
         epochs: int = 0,
@@ -792,6 +814,10 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         val_series = series2seq(val_series)
         val_past_covariates = series2seq(val_past_covariates)
         val_future_covariates = series2seq(val_future_covariates)
+        if not isinstance(sample_weight, str):
+            sample_weight = series2seq(sample_weight)
+        if not isinstance(val_sample_weight, str):
+            val_sample_weight = series2seq(val_sample_weight)
 
         self.encoders = self.initialize_encoders()
         if self.encoders.encoding_available:
@@ -831,6 +857,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             target=series,
             past_covariates=past_covariates,
             future_covariates=future_covariates,
+            sample_weight=sample_weight,
             max_samples_per_ts=max_samples_per_ts,
         )
 
@@ -839,6 +866,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                 target=val_series,
                 past_covariates=val_past_covariates,
                 future_covariates=val_future_covariates,
+                sample_weight=val_sample_weight,
                 max_samples_per_ts=max_samples_per_ts,
             )
         else:
@@ -974,7 +1002,9 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         train_sample = train_dataset[0]
         if self.model is None:
             # Build model, based on the dimensions of the first series in the train set.
-            self.train_sample, self.output_dim = train_sample, train_sample[-1].shape[1]
+            # the last two elements are sample weights and future target
+            self.train_sample = train_sample[:-2] + train_sample[-1:]
+            self.output_dim = train_sample[-1].shape[1]
             model = self._init_model(trainer)
         else:
             model = self.model
@@ -1082,6 +1112,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         val_series: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         val_past_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         val_future_covariates: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        sample_weight: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
+        val_sample_weight: Optional[Union[TimeSeries, Sequence[TimeSeries]]] = None,
         trainer: Optional[pl.Trainer] = None,
         verbose: Optional[bool] = None,
         epochs: int = 0,
@@ -1143,6 +1175,19 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             Optionally, the past covariates corresponding to the validation series (must match ``covariates``)
         val_future_covariates
             Optionally, the future covariates corresponding to the validation series (must match ``covariates``)
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
+        val_sample_weight
+            Same as for `sample_weight` but for the evaluation dataset.
         trainer
             Optionally, a custom PyTorch-Lightning Trainer object to perform training. Using a custom ``trainer`` will
             override Darts' default trainer.
@@ -1188,9 +1233,11 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             series=series,
             past_covariates=past_covariates,
             future_covariates=future_covariates,
+            sample_weight=sample_weight,
             val_series=val_series,
             val_past_covariates=val_past_covariates,
             val_future_covariates=val_future_covariates,
+            val_sample_weight=val_sample_weight,
             trainer=trainer,
             verbose=verbose,
             epochs=epochs,
@@ -2395,6 +2442,7 @@ class PastCovariatesTorchModel(TorchForecastingModel, ABC):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> PastCovariatesTrainingDataset:
         return PastCovariatesSequentialDataset(
@@ -2405,6 +2453,7 @@ class PastCovariatesTorchModel(TorchForecastingModel, ABC):
             output_chunk_shift=self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def _build_inference_dataset(
@@ -2487,6 +2536,7 @@ class FutureCovariatesTorchModel(TorchForecastingModel, ABC):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> FutureCovariatesTrainingDataset:
         return FutureCovariatesSequentialDataset(
@@ -2497,6 +2547,7 @@ class FutureCovariatesTorchModel(TorchForecastingModel, ABC):
             output_chunk_shift=self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def _build_inference_dataset(
@@ -2578,6 +2629,7 @@ class DualCovariatesTorchModel(TorchForecastingModel, ABC):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> DualCovariatesTrainingDataset:
         return DualCovariatesSequentialDataset(
@@ -2588,6 +2640,7 @@ class DualCovariatesTorchModel(TorchForecastingModel, ABC):
             output_chunk_shift=self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def _build_inference_dataset(
@@ -2668,6 +2721,7 @@ class MixedCovariatesTorchModel(TorchForecastingModel, ABC):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> MixedCovariatesTrainingDataset:
         return MixedCovariatesSequentialDataset(
@@ -2679,6 +2733,7 @@ class MixedCovariatesTorchModel(TorchForecastingModel, ABC):
             output_chunk_shift=self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def _build_inference_dataset(
@@ -2760,6 +2815,7 @@ class SplitCovariatesTorchModel(TorchForecastingModel, ABC):
         target: Sequence[TimeSeries],
         past_covariates: Optional[Sequence[TimeSeries]],
         future_covariates: Optional[Sequence[TimeSeries]],
+        sample_weight: Optional[Sequence[TimeSeries]],
         max_samples_per_ts: Optional[int],
     ) -> SplitCovariatesTrainingDataset:
         return SplitCovariatesSequentialDataset(
@@ -2771,6 +2827,7 @@ class SplitCovariatesTorchModel(TorchForecastingModel, ABC):
             output_chunk_shift=self.output_chunk_shift,
             max_samples_per_ts=max_samples_per_ts,
             use_static_covariates=self.uses_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def _build_inference_dataset(

--- a/darts/tests/datasets/test_datasets.py
+++ b/darts/tests/datasets/test_datasets.py
@@ -1,4 +1,5 @@
 import inspect
+import itertools
 
 import numpy as np
 import pandas as pd
@@ -1319,33 +1320,52 @@ class TestDataset:
         with pytest.raises(ValueError):
             _ = ds[0]
 
-    def test_horizon_based_dataset(self):
+    @pytest.mark.parametrize("use_weight", [False, True])
+    def test_horizon_based_dataset(self, use_weight):
+        weight1 = self.target1 + 1
+        weight2 = self.target2 + 1
+
+        weight = weight1 if use_weight else None
+        weight_exp = weight1[85:95] if use_weight else None
         # one target series
         ds = HorizonBasedDataset(
             target_series=self.target1,
             output_chunk_length=10,
             lh=(1, 3),
             lookback=2,
+            sample_weight=weight,
         )
         assert len(ds) == 20
         self._assert_eq(
-            ds[5], (self.target1[65:85], None, self.cov_st1, None, self.target1[85:95])
+            ds[5],
+            (self.target1[65:85], None, self.cov_st1, weight_exp, self.target1[85:95]),
         )
 
         # two target series
+        weight = [weight1, weight2] if use_weight else None
+        weight_exp1 = weight1[85:95] if use_weight else None
+        weight_exp2 = weight2[135:145] if use_weight else None
         ds = HorizonBasedDataset(
             target_series=[self.target1, self.target2],
             output_chunk_length=10,
             lh=(1, 3),
             lookback=2,
+            sample_weight=weight,
         )
         assert len(ds) == 40
         self._assert_eq(
-            ds[5], (self.target1[65:85], None, self.cov_st1, None, self.target1[85:95])
+            ds[5],
+            (self.target1[65:85], None, self.cov_st1, weight_exp1, self.target1[85:95]),
         )
         self._assert_eq(
             ds[25],
-            (self.target2[115:135], None, self.cov_st2, None, self.target2[135:145]),
+            (
+                self.target2[115:135],
+                None,
+                self.cov_st2,
+                weight_exp2,
+                self.target2[135:145],
+            ),
         )
 
         # two targets and one covariate
@@ -1355,12 +1375,16 @@ class TestDataset:
             )
 
         # two targets and two covariates
+        weight = [weight1, weight2] if use_weight else None
+        weight_exp1 = weight1[85:95] if use_weight else None
+        weight_exp2 = weight2[135:145] if use_weight else None
         ds = HorizonBasedDataset(
             target_series=[self.target1, self.target2],
             covariates=[self.cov1, self.cov2],
             output_chunk_length=10,
             lh=(1, 3),
             lookback=2,
+            sample_weight=weight,
         )
         self._assert_eq(
             ds[5],
@@ -1368,7 +1392,7 @@ class TestDataset:
                 self.target1[65:85],
                 self.cov1[65:85],
                 self.cov_st1,
-                None,
+                weight_exp1,
                 self.target1[85:95],
             ),
         )
@@ -1378,7 +1402,7 @@ class TestDataset:
                 self.target2[115:135],
                 self.cov2[115:135],
                 self.cov_st2,
-                None,
+                weight_exp2,
                 self.target2[135:145],
             ),
         )
@@ -1399,6 +1423,7 @@ class TestDataset:
         ocl = 1
         ocs = 2
         target = self.target1[: -(ocl + ocs)]
+        sample_weight = target + 1
 
         ds_covs = {}
         ds_init_params = set(inspect.signature(ds_cls.__init__).parameters)
@@ -1413,6 +1438,7 @@ class TestDataset:
             input_chunk_length=1,
             output_chunk_length=3,
             output_chunk_shift=0,
+            sample_weight=sample_weight,
             **ds_covs,
         )
 
@@ -1421,6 +1447,7 @@ class TestDataset:
             input_chunk_length=1,
             output_chunk_length=1,
             output_chunk_shift=ocs,
+            sample_weight=sample_weight,
             **ds_covs,
         )
 
@@ -1434,15 +1461,250 @@ class TestDataset:
             batch_reg = batch_reg[:future_idx] + batch_reg[future_idx + 1 :]
             batch_shift = batch_shift[:future_idx] + batch_shift[future_idx + 1 :]
 
-        # last element is the output chunk of the target series.
+        # last two elements are (sample weight, output chunk of the target series).
         # 3rd future values of regular ds must be identical to the 1st future values of shifted dataset
-        batch_reg = batch_reg[:-1] + (batch_reg[-1][ocs:],)
+        batch_reg = batch_reg[:-2] + (batch_reg[-2][ocs:], batch_reg[-1][ocs:])
 
         # without future part, the input will be identical between regular, and shifted dataset
         assert all([
             np.all(el_reg == el_shift)
             for el_reg, el_shift in zip(batch_reg[:-1], batch_shift[:-1])
         ])
+
+    @pytest.mark.parametrize(
+        "config",
+        itertools.product(
+            [
+                PastCovariatesSequentialDataset,
+                FutureCovariatesSequentialDataset,
+                DualCovariatesSequentialDataset,
+                MixedCovariatesSequentialDataset,
+                SplitCovariatesSequentialDataset,
+            ],
+            [True, False],
+        ),
+    )
+    def test_sequential_training_dataset_weight(self, config):
+        ds_cls, manual_weight = config
+
+        def get_built_in_weigths(targets):
+            if isinstance(targets, list):
+                max_steps = max([len(ts) for ts in targets])
+            else:
+                max_steps = len(targets)
+            weight_expected = np.linspace(0, 1, max_steps)[-3:]
+            return np.expand_dims(weight_expected, -1)
+
+        target1 = self.target1
+        target2 = self.target2
+        weight1 = target1 + 1
+        weight2 = target2 + 1
+        built_in_weight = "linear_decay"
+
+        ds_covs = {}
+        ds_init_params = set(inspect.signature(ds_cls.__init__).parameters)
+        for cov_type in ["covariates", "past_covariates", "future_covariates"]:
+            if cov_type in ds_init_params:
+                ds_covs[cov_type] = self.cov1
+
+        # no sample weight
+        ds = ds_cls(
+            target_series=target1,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=None,
+            **ds_covs,
+        )
+        assert ds[0][-2] is None
+
+        # whenever we use sample weight, the weight are extracted from the same time frame as the target labels
+        # since we set the weight to be `target + 1`, the returned batch weight must also be `batch_target_label + 1`
+
+        # single univariate
+        target = target1
+        weight = weight1 if manual_weight else built_in_weight
+        ds = ds_cls(
+            target_series=target,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=weight,
+            **ds_covs,
+        )
+        weight_exp = ds[0][-1] + 1 if manual_weight else get_built_in_weigths(target)
+        assert np.all(ds[0][-2] == weight_exp)
+
+        # single univariate with longer weight
+        target = target1
+        weight = (
+            weight1.prepend_values([0.0]).append_values([0.0])
+            if manual_weight
+            else built_in_weight
+        )
+        ds = ds_cls(
+            target_series=target,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=weight,
+            **ds_covs,
+        )
+        weight_exp = ds[0][-1] + 1 if manual_weight else get_built_in_weigths(target)
+        assert np.all(ds[0][-2] == weight_exp)
+
+        # single multivariate with multivariate weight
+        target = target1.stack(target1 + 1)
+        weight = weight1.stack(weight1 + 1) if manual_weight else built_in_weight
+        ds = ds_cls(
+            target_series=target,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=weight,
+            **ds_covs,
+        )
+        weight_exp = ds[0][-1] + 1 if manual_weight else get_built_in_weigths(target)
+        assert np.all(ds[0][-2] == weight_exp)
+
+        # single multivariate with univariate (global) weight
+        target = target1.stack(target1 + 1)
+        weight = weight1 if manual_weight else built_in_weight
+        ds = ds_cls(
+            target_series=target,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=weight,
+            **ds_covs,
+        )
+        # output weight corresponds to first target component + 1 (e.g. weight1)
+        weight_exp = (
+            ds[0][-1][:, 0:1] + 1 if manual_weight else get_built_in_weigths(target)
+        )
+        assert np.all(ds[0][-2] == weight_exp)
+
+        # single univariate and list of single weight
+        target = target1
+        weight = [weight1] if manual_weight else built_in_weight
+        ds = ds_cls(
+            target_series=target,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=weight,
+            **ds_covs,
+        )
+        weight_exp = ds[0][-1] + 1 if manual_weight else get_built_in_weigths(target)
+        assert np.all(ds[0][-2] == weight_exp)
+
+        # multiple univariate
+        target = [target1, target2]
+        weight = [weight1, weight2] if manual_weight else built_in_weight
+        ds = ds_cls(
+            target_series=target,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=weight,
+            **{k: [v] * 2 for k, v in ds_covs.items()},
+        )
+        weight_exp = ds[0][-1] + 1 if manual_weight else get_built_in_weigths(target)
+        assert np.all(ds[0][-2] == weight_exp)
+
+        # multiple multivariate
+        target = [target1.stack(target1 + 1), target2.stack(target2 + 1)]
+        weight = (
+            [weight1.stack(weight1 + 1), weight2.stack(weight2 + 1)]
+            if manual_weight
+            else built_in_weight
+        )
+        ds = ds_cls(
+            target_series=target,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=weight,
+            **{k: [v] * 2 for k, v in ds_covs.items()},
+        )
+        weight_exp = ds[0][-1] + 1 if manual_weight else get_built_in_weigths(target)
+        assert np.all(ds[0][-2] == weight_exp)
+
+    @pytest.mark.parametrize(
+        "ds_cls",
+        [
+            PastCovariatesSequentialDataset,
+            FutureCovariatesSequentialDataset,
+            DualCovariatesSequentialDataset,
+            MixedCovariatesSequentialDataset,
+            SplitCovariatesSequentialDataset,
+        ],
+    )
+    def test_sequential_training_dataset_invalid_weight(self, ds_cls):
+        ts = self.target1
+
+        # invalid built-in weight
+        with pytest.raises(ValueError) as err:
+            _ = ds_cls(
+                target_series=[ts, ts],
+                input_chunk_length=1,
+                output_chunk_length=3,
+                sample_weight="invalid",
+            )
+        assert str(err.value).startswith(
+            "Invalid `sample_weight` value: `'invalid'`. If a string, must be one of: "
+        )
+
+        # mismatch number of target and weight series
+        with pytest.raises(ValueError) as err:
+            _ = ds_cls(
+                target_series=[ts, ts],
+                input_chunk_length=1,
+                output_chunk_length=3,
+                sample_weight=[ts],
+            )
+        assert (
+            str(err.value)
+            == "The provided sequence of target series must have the same "
+            "length as the provided sequence of sample weights."
+        )
+
+        # too many weight components
+        ds = ds_cls(
+            target_series=ts,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=ts.stack(ts + 1),
+        )
+        with pytest.raises(ValueError) as err:
+            _ = ds[0]
+        assert (
+            str(err.value)
+            == "The number of components in `sample_weight` must either be `1` or match "
+            "the number of target series components `1`. (0-th series)"
+        )
+
+        # weight too short end
+        ds = ds_cls(
+            target_series=ts,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=ts[:-1],
+        )
+        with pytest.raises(ValueError) as err:
+            _ = ds[0]
+        assert (
+            str(err.value)
+            == "Missing sample weights; could not find sample weights in index value range: "
+            "2000-04-07 00:00:00 - 2000-04-09 00:00:00."
+        )
+
+        # weight too short start
+        ds = ds_cls(
+            target_series=ts,
+            input_chunk_length=1,
+            output_chunk_length=3,
+            sample_weight=ts[2:],
+        )
+        with pytest.raises(ValueError) as err:
+            _ = ds[len(ds) - 1]
+        assert (
+            str(err.value)
+            == "Missing sample weights; could not find sample weights in index value range: "
+            "2000-01-02 00:00:00 - 2000-01-04 00:00:00."
+        )
 
     def test_get_matching_index(self):
         from darts.utils.data.utils import _get_matching_index

--- a/darts/tests/datasets/test_datasets.py
+++ b/darts/tests/datasets/test_datasets.py
@@ -569,7 +569,7 @@ class TestDataset:
         )
         assert len(ds) == 81
         self._assert_eq(
-            ds[5], (self.target1[75:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[75:85], None, self.cov_st1, None, self.target1[85:95])
         )
 
         # two target series
@@ -580,11 +580,11 @@ class TestDataset:
         )
         assert len(ds) == 262
         self._assert_eq(
-            ds[5], (self.target1[75:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[75:85], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[136],
-            (self.target2[125:135], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[125:135], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two target series with custom max_nr_samples
@@ -596,11 +596,11 @@ class TestDataset:
         )
         assert len(ds) == 100
         self._assert_eq(
-            ds[5], (self.target1[75:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[75:85], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[55],
-            (self.target2[125:135], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[125:135], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two targets and one covariate
@@ -622,6 +622,7 @@ class TestDataset:
                 self.target1[75:85],
                 self.cov1[75:85],
                 self.cov_st1,
+                None,
                 self.target1[85:95],
             ),
         )
@@ -631,6 +632,7 @@ class TestDataset:
                 self.target2[125:135],
                 self.cov2[125:135],
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -710,7 +712,7 @@ class TestDataset:
         )
         assert len(ds) == 81
         self._assert_eq(
-            ds[5], (self.target1[75:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[75:85], None, self.cov_st1, None, self.target1[85:95])
         )
 
         # two target series
@@ -721,11 +723,11 @@ class TestDataset:
         )
         assert len(ds) == 262
         self._assert_eq(
-            ds[5], (self.target1[75:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[75:85], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[136],
-            (self.target2[125:135], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[125:135], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two target series with custom max_nr_samples
@@ -737,11 +739,11 @@ class TestDataset:
         )
         assert len(ds) == 100
         self._assert_eq(
-            ds[5], (self.target1[75:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[75:85], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[55],
-            (self.target2[125:135], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[125:135], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two targets and one covariate
@@ -770,12 +772,14 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][0], target1.values()[-20:-10])
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-30:-20])
         np.testing.assert_almost_equal(ds[0][2], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][3], target1.values()[-10:])
+        assert ds[0][3] is None
+        np.testing.assert_almost_equal(ds[0][4], target1.values()[-10:])
 
         np.testing.assert_almost_equal(ds[101][0], target2.values()[-40:-30])
         np.testing.assert_almost_equal(ds[101][1], cov2.values()[-60:-50])
         np.testing.assert_almost_equal(ds[101][2], self.cov_st2)
-        np.testing.assert_almost_equal(ds[101][3], target2.values()[-30:-20])
+        assert ds[0][3] is None
+        np.testing.assert_almost_equal(ds[101][4], target2.values()[-30:-20])
 
         # Should also contain correct values when time-indexed with covariates not aligned
         times1 = pd.date_range(start="20090201", end="20090220", freq="D")
@@ -795,7 +799,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][0], target1.values()[-4:-2])
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-4:-2])
         np.testing.assert_almost_equal(ds[0][2], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][3], target1.values()[-2:])
+        assert ds[0][3] is None
+        np.testing.assert_almost_equal(ds[0][4], target1.values()[-2:])
 
         # Should fail if covariates are not long enough
         target1 = TimeSeries.from_values(np.random.randn(8)).with_static_covariates(
@@ -814,7 +819,8 @@ class TestDataset:
             _ = ds[0]
 
     def test_dual_covariates_sequential_dataset(self):
-        # Must contain (past_target, historic_future_covariates, future_covariates, future_target)
+        # Must contain (past_target, historic_future_covariates, future_covariates, static covariates,
+        # sample weight, future_target)
 
         # one target series
         ds = DualCovariatesSequentialDataset(
@@ -825,7 +831,7 @@ class TestDataset:
         assert len(ds) == 81
         self._assert_eq(
             ds[5],
-            (self.target1[75:85], None, None, self.cov_st1, self.target1[85:95]),
+            (self.target1[75:85], None, None, self.cov_st1, None, self.target1[85:95]),
         )
 
         # two target series
@@ -837,7 +843,7 @@ class TestDataset:
         assert len(ds) == 262
         self._assert_eq(
             ds[5],
-            (self.target1[75:85], None, None, self.cov_st1, self.target1[85:95]),
+            (self.target1[75:85], None, None, self.cov_st1, None, self.target1[85:95]),
         )
         self._assert_eq(
             ds[136],
@@ -846,6 +852,7 @@ class TestDataset:
                 None,
                 None,
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -860,7 +867,7 @@ class TestDataset:
         assert len(ds) == 100
         self._assert_eq(
             ds[5],
-            (self.target1[75:85], None, None, self.cov_st1, self.target1[85:95]),
+            (self.target1[75:85], None, None, self.cov_st1, None, self.target1[85:95]),
         )
         self._assert_eq(
             ds[55],
@@ -869,6 +876,7 @@ class TestDataset:
                 None,
                 None,
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -900,13 +908,15 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-40:-30])
         np.testing.assert_almost_equal(ds[0][2], cov1.values()[-30:-20])
         np.testing.assert_almost_equal(ds[0][3], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][4], target1.values()[-10:])
+        assert ds[0][4] is None
+        np.testing.assert_almost_equal(ds[0][5], target1.values()[-10:])
 
         np.testing.assert_almost_equal(ds[101][0], target2.values()[-40:-30])
         np.testing.assert_almost_equal(ds[101][1], cov2.values()[-70:-60])
         np.testing.assert_almost_equal(ds[101][2], cov2.values()[-60:-50])
         np.testing.assert_almost_equal(ds[101][3], self.cov_st2)
-        np.testing.assert_almost_equal(ds[101][4], target2.values()[-30:-20])
+        assert ds[101][4] is None
+        np.testing.assert_almost_equal(ds[101][5], target2.values()[-30:-20])
 
         # Should also contain correct values when time-indexed with covariates not aligned
         times1 = pd.date_range(start="20090201", end="20090220", freq="D")
@@ -927,7 +937,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-6:-4])
         np.testing.assert_almost_equal(ds[0][2], cov1.values()[-4:-2])
         np.testing.assert_almost_equal(ds[0][3], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][4], target1.values()[-2:])
+        assert ds[0][4] is None
+        np.testing.assert_almost_equal(ds[0][5], target1.values()[-2:])
 
         # Should fail if covariates are not long enough
         target1 = TimeSeries.from_values(np.random.randn(8)).with_static_covariates(
@@ -952,7 +963,7 @@ class TestDataset:
         )
         assert len(ds) == 86
         self._assert_eq(
-            ds[5], (self.target1[80:90], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[80:90], None, self.cov_st1, None, self.target1[85:95])
         )
 
         # two target series
@@ -961,11 +972,11 @@ class TestDataset:
         )
         assert len(ds) == 272
         self._assert_eq(
-            ds[5], (self.target1[80:90], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[80:90], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[141],
-            (self.target2[130:140], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[130:140], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two target series with custom max_nr_samples
@@ -977,11 +988,11 @@ class TestDataset:
         )
         assert len(ds) == 100
         self._assert_eq(
-            ds[5], (self.target1[80:90], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[80:90], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[55],
-            (self.target2[130:140], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[130:140], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two targets and one covariate
@@ -1003,6 +1014,7 @@ class TestDataset:
                 self.target1[80:90],
                 self.cov1[80:90],
                 self.cov_st1,
+                None,
                 self.target1[85:95],
             ),
         )
@@ -1012,6 +1024,7 @@ class TestDataset:
                 self.target2[130:140],
                 self.cov2[130:140],
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -1027,7 +1040,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][0], target1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-7:-4])
         np.testing.assert_almost_equal(ds[0][2], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][3], target1.values()[-3:])
+        assert ds[0][3] is None
+        np.testing.assert_almost_equal(ds[0][4], target1.values()[-3:])
 
         # Should also contain correct values when time-indexed with covariates not aligned
         times1 = pd.date_range(start="20090201", end="20090220", freq="D")
@@ -1042,7 +1056,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][0], target1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-7:-4])
         np.testing.assert_almost_equal(ds[0][2], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][3], target1.values()[-3:])
+        assert ds[0][3] is None
+        np.testing.assert_almost_equal(ds[0][4], target1.values()[-3:])
 
         # Should fail if covariates are too short
         target1 = TimeSeries.from_values(np.random.randn(8)).with_static_covariates(
@@ -1062,7 +1077,7 @@ class TestDataset:
         )
         assert len(ds) == 86
         self._assert_eq(
-            ds[5], (self.target1[80:90], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[80:90], None, self.cov_st1, None, self.target1[85:95])
         )
 
         # two target series
@@ -1071,11 +1086,11 @@ class TestDataset:
         )
         assert len(ds) == 272
         self._assert_eq(
-            ds[5], (self.target1[80:90], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[80:90], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[141],
-            (self.target2[130:140], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[130:140], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two target series with custom max_nr_samples
@@ -1087,11 +1102,11 @@ class TestDataset:
         )
         assert len(ds) == 100
         self._assert_eq(
-            ds[5], (self.target1[80:90], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[80:90], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[55],
-            (self.target2[130:140], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[130:140], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two targets and one covariate
@@ -1113,6 +1128,7 @@ class TestDataset:
                 self.target1[80:90],
                 self.cov1[85:95],
                 self.cov_st1,
+                None,
                 self.target1[85:95],
             ),
         )
@@ -1122,6 +1138,7 @@ class TestDataset:
                 self.target2[130:140],
                 self.cov2[135:145],
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -1137,7 +1154,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][0], target1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][2], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][3], target1.values()[-3:])
+        assert ds[0][3] is None
+        np.testing.assert_almost_equal(ds[0][4], target1.values()[-3:])
 
         # Should also contain correct values when time-indexed with covariates not aligned
         times1 = pd.date_range(start="20090201", end="20090220", freq="D")
@@ -1152,7 +1170,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][0], target1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][2], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][3], target1.values()[-3:])
+        assert ds[0][3] is None
+        np.testing.assert_almost_equal(ds[0][4], target1.values()[-3:])
 
         # Should fail if covariates are too short
         target1 = TimeSeries.from_values(np.random.randn(8)).with_static_covariates(
@@ -1173,7 +1192,7 @@ class TestDataset:
         assert len(ds) == 86
         self._assert_eq(
             ds[5],
-            (self.target1[80:90], None, None, self.cov_st1, self.target1[85:95]),
+            (self.target1[80:90], None, None, self.cov_st1, None, self.target1[85:95]),
         )
 
         # two target series
@@ -1183,7 +1202,7 @@ class TestDataset:
         assert len(ds) == 272
         self._assert_eq(
             ds[5],
-            (self.target1[80:90], None, None, self.cov_st1, self.target1[85:95]),
+            (self.target1[80:90], None, None, self.cov_st1, None, self.target1[85:95]),
         )
         self._assert_eq(
             ds[141],
@@ -1192,6 +1211,7 @@ class TestDataset:
                 None,
                 None,
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -1206,7 +1226,7 @@ class TestDataset:
         assert len(ds) == 100
         self._assert_eq(
             ds[5],
-            (self.target1[80:90], None, None, self.cov_st1, self.target1[85:95]),
+            (self.target1[80:90], None, None, self.cov_st1, None, self.target1[85:95]),
         )
         self._assert_eq(
             ds[55],
@@ -1215,6 +1235,7 @@ class TestDataset:
                 None,
                 None,
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -1239,6 +1260,7 @@ class TestDataset:
                 self.cov1[80:90],
                 self.cov1[85:95],
                 self.cov_st1,
+                None,
                 self.target1[85:95],
             ),
         )
@@ -1249,6 +1271,7 @@ class TestDataset:
                 self.cov2[130:140],
                 self.cov2[135:145],
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )
@@ -1265,7 +1288,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-7:-4])
         np.testing.assert_almost_equal(ds[0][2], cov1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][3], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][4], target1.values()[-3:])
+        assert ds[0][4] is None
+        np.testing.assert_almost_equal(ds[0][5], target1.values()[-3:])
 
         # Should also contain correct values when time-indexed with covariates not aligned
         times1 = pd.date_range(start="20090201", end="20090220", freq="D")
@@ -1281,7 +1305,8 @@ class TestDataset:
         np.testing.assert_almost_equal(ds[0][1], cov1.values()[-7:-4])
         np.testing.assert_almost_equal(ds[0][2], cov1.values()[-5:-2])
         np.testing.assert_almost_equal(ds[0][3], self.cov_st2)
-        np.testing.assert_almost_equal(ds[0][4], target1.values()[-3:])
+        assert ds[0][4] is None
+        np.testing.assert_almost_equal(ds[0][5], target1.values()[-3:])
 
         # Should fail if covariates are too short
         target1 = TimeSeries.from_values(np.random.randn(8)).with_static_covariates(
@@ -1304,7 +1329,7 @@ class TestDataset:
         )
         assert len(ds) == 20
         self._assert_eq(
-            ds[5], (self.target1[65:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[65:85], None, self.cov_st1, None, self.target1[85:95])
         )
 
         # two target series
@@ -1316,11 +1341,11 @@ class TestDataset:
         )
         assert len(ds) == 40
         self._assert_eq(
-            ds[5], (self.target1[65:85], None, self.cov_st1, self.target1[85:95])
+            ds[5], (self.target1[65:85], None, self.cov_st1, None, self.target1[85:95])
         )
         self._assert_eq(
             ds[25],
-            (self.target2[115:135], None, self.cov_st2, self.target2[135:145]),
+            (self.target2[115:135], None, self.cov_st2, None, self.target2[135:145]),
         )
 
         # two targets and one covariate
@@ -1343,6 +1368,7 @@ class TestDataset:
                 self.target1[65:85],
                 self.cov1[65:85],
                 self.cov_st1,
+                None,
                 self.target1[85:95],
             ),
         )
@@ -1352,6 +1378,7 @@ class TestDataset:
                 self.target2[115:135],
                 self.cov2[115:135],
                 self.cov_st2,
+                None,
                 self.target2[135:145],
             ),
         )

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -62,17 +62,30 @@ kwargs = {
     "n_epochs": 1,
     "pl_trainer_kwargs": {"fast_dev_run": True, **tfm_kwargs["pl_trainer_kwargs"]},
 }
+nbeats_light_kwargs = {
+    "num_stacks": 2,
+    "num_blocks": 1,
+    "num_layers": 1,
+    "layer_widths": 16,
+}
+trafo_light_kwargs = {
+    "d_model": 16,
+    "nhead": 2,
+    "num_encoder_layers": 1,
+    "num_decoder_layers": 1,
+    "dim_feedforward": 16,
+}
 models = [
     (BlockRNNModel, kwargs),
     (DLinearModel, kwargs),
-    (NBEATSModel, kwargs),
-    (NHiTSModel, kwargs),
+    (NBEATSModel, dict(kwargs, **nbeats_light_kwargs)),
+    (NHiTSModel, dict(kwargs, **nbeats_light_kwargs)),
     (NLinearModel, kwargs),
     (RNNModel, {"training_length": 10, **kwargs}),
     (TCNModel, kwargs),
     (TFTModel, {"add_relative_index": 2, **kwargs}),
     (TiDEModel, kwargs),
-    (TransformerModel, kwargs),
+    (TransformerModel, dict(kwargs, **trafo_light_kwargs)),
     (TSMixerModel, kwargs),
     (GlobalNaiveSeasonal, kwargs),
     (GlobalNaiveAggregate, kwargs),
@@ -1743,28 +1756,7 @@ class TestTorchForecastingModel:
     @pytest.mark.parametrize(
         "config",
         itertools.product(
-            [
-                (
-                    TFTModel,
-                    {
-                        "add_relative_index": True,
-                        "likelihood": None,
-                        "loss_fn": torch.nn.MSELoss(),
-                    },
-                ),
-                (TiDEModel, {}),
-                (NLinearModel, {}),
-                (DLinearModel, {}),
-                (NBEATSModel, {}),
-                (NHiTSModel, {}),
-                (TransformerModel, {}),
-                (TCNModel, {}),
-                (TSMixerModel, {}),
-                (BlockRNNModel, {}),
-                (GlobalNaiveSeasonal, {}),
-                (GlobalNaiveAggregate, {}),
-                (GlobalNaiveDrift, {}),
-            ],
+            models,
             [3, 7, 10],
         ),
     )
@@ -1773,14 +1765,26 @@ class TestTorchForecastingModel:
         RNNModel does not support shift output chunk.
         """
         np.random.seed(0)
-        (model_cls, add_params), shift = config
+        (model_cls, model_kwargs), shift = config
+        if issubclass(model_cls, RNNModel):
+            return
+
+        model_kwargs = copy.deepcopy(model_kwargs)
+        model_kwargs.pop("input_chunk_length")
+        model_kwargs.pop("output_chunk_length")
+
+        if issubclass(model_cls, TFTModel):
+            model_kwargs.update({"likelihood": None, "loss_fn": torch.nn.MSELoss()})
+
         icl = 8
         ocl = 7
         series = tg.gaussian_timeseries(
             length=28, start=pd.Timestamp("2000-01-01"), freq="d"
         )
 
-        model = self.helper_create_torch_model(model_cls, icl, ocl, shift, **add_params)
+        model = self.helper_create_torch_model(
+            model_cls, icl, ocl, shift, **model_kwargs
+        )
         model.fit(series)
 
         # no auto-regression with shifted output
@@ -1823,13 +1827,13 @@ class TestTorchForecastingModel:
             "datetime_attribute": {cov: ["dayofweek"] for cov in cov_support}
         }
         model_enc_shift = self.helper_create_torch_model(
-            model_cls, icl, ocl, shift, add_encoders=add_encoders, **add_params
+            model_cls, icl, ocl, shift, add_encoders=add_encoders, **model_kwargs
         )
         model_enc_shift.fit(series)
 
         # model trained with identical covariates
         model_fc_shift = self.helper_create_torch_model(
-            model_cls, icl, ocl, shift, **add_params
+            model_cls, icl, ocl, shift, **model_kwargs
         )
 
         model_fc_shift.fit(series, **covs)
@@ -1947,6 +1951,64 @@ class TestTorchForecastingModel:
                     np.testing.assert_array_almost_equal(
                         pred.all_values(), pred_no_weight.all_values()
                     )
+
+    @pytest.mark.parametrize(
+        "config",
+        itertools.product(models, [True, False], [True, False], [True, False]),
+    )
+    def test_weights(self, config):
+        (model_cls, model_kwargs), built_in_weight, single_series, univ_series = config
+        ts = tg.linear_timeseries(
+            length=model_kwargs["input_chunk_length"]
+            + model_kwargs["output_chunk_length"]
+        )
+        if not univ_series:
+            ts = ts.stack(ts)
+
+        if built_in_weight:
+            weights = "linear_decay"
+        else:
+            weights = np.ones((len(ts), ts.n_components))
+            weights[: len(weights) - 3] = 1.5
+            weights = ts.with_values(weights)
+
+        if not single_series:
+            ts = [ts] * 2
+            weights = weights if built_in_weight else [weights] * 2
+
+        model = model_cls(**model_kwargs)
+        model.fit(ts, sample_weight=weights)
+        preds = model.predict(n=3, series=ts)
+
+        model_no_weight = model_cls(**model_kwargs)
+        model_no_weight.fit(ts, sample_weight=None)
+        preds_no_weight = model_no_weight.predict(n=3, series=ts)
+
+        if single_series:
+            preds = [preds]
+            preds_no_weight = [preds_no_weight]
+
+        for pred, pred_no_weight in zip(preds, preds_no_weight):
+            if isinstance(model, _GlobalNaiveModel):
+                # naive models don't learn, so output should be the same
+                np.testing.assert_array_almost_equal(
+                    pred.all_values(), pred_no_weight.all_values()
+                )
+            else:
+                # all other models should have different results from sample weights
+                with pytest.raises(AssertionError):
+                    np.testing.assert_array_almost_equal(
+                        pred.all_values(), pred_no_weight.all_values()
+                    )
+
+        # try with validation series and only train weights
+        model.fit(ts, val_series=ts, sample_weight=weights)
+
+        # try with validation series and only val weights
+        model.fit(ts, val_series=ts, val_sample_weight=weights)
+
+        # try with validation series and train and val weights
+        model.fit(ts, val_series=ts, sample_weight=weights, val_sample_weight=weights)
 
     def helper_equality_encoders(
         self, first_encoders: Dict[str, Any], second_encoders: Dict[str, Any]

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -1134,11 +1134,14 @@ class TestTorchForecastingModel:
             model_name, tmpdir_fn, best=False, map_location="cpu"
         )
         # custom loss function should be properly restored from ckpt
-        assert isinstance(loaded_model.model.criterion, torch.nn.L1Loss)
+        loss_fn_attrs = ["criterion", "train_criterion", "val_criterion"]
+        for attr in loss_fn_attrs:
+            assert isinstance(getattr(loaded_model.model, attr), torch.nn.L1Loss)
 
         loaded_model.fit(self.series, epochs=2)
         # calling fit() should not impact the loss function
-        assert isinstance(loaded_model.model.criterion, torch.nn.L1Loss)
+        for attr in loss_fn_attrs:
+            assert isinstance(getattr(loaded_model.model, attr), torch.nn.L1Loss)
 
     def test_load_from_checkpoint_w_metrics(self, tmpdir_fn):
         model_name = "pretraining_metrics"

--- a/darts/utils/data/horizon_based_dataset.py
+++ b/darts/utils/data/horizon_based_dataset.py
@@ -8,9 +8,10 @@ from typing import Optional, Sequence, Tuple, Union
 import numpy as np
 
 from darts import TimeSeries
-from darts.logging import get_logger, raise_if_not
+from darts.logging import get_logger, raise_log
 from darts.utils.data.training_dataset import PastCovariatesTrainingDataset
-from darts.utils.data.utils import CovariateType
+from darts.utils.data.utils import CovariateType, _process_sample_weight
+from darts.utils.ts_utils import series2seq
 
 logger = get_logger(__name__)
 
@@ -24,9 +25,11 @@ class HorizonBasedDataset(PastCovariatesTrainingDataset):
         lh: Tuple[int, int] = (1, 3),
         lookback: int = 3,
         use_static_covariates: bool = True,
+        sample_weight: Optional[Union[str, TimeSeries, Sequence[TimeSeries]]] = None,
     ) -> None:
         """
-        A time series dataset containing tuples of (past_target, past_covariates, static_covariates, future_target)
+        A time series dataset containing tuples of (past_target, past_covariates, static_covariates, sample weights,
+        future_target)
         arrays,
         in a way inspired by the N-BEATS way of training on the M4 dataset: https://arxiv.org/abs/1905.10437.
 
@@ -70,33 +73,46 @@ class HorizonBasedDataset(PastCovariatesTrainingDataset):
             `3 * output_chunk_length`.
         use_static_covariates
             Whether to use/include static covariate data from input series.
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
         """
         super().__init__()
 
-        self.target_series = (
-            [target_series] if isinstance(target_series, TimeSeries) else target_series
-        )
-        self.covariates = (
-            [covariates] if isinstance(covariates, TimeSeries) else covariates
-        )
+        self.target_series = series2seq(target_series)
+        self.covariates = series2seq(covariates)
         self.covariate_type = CovariateType.PAST
+        self.sample_weight = _process_sample_weight(sample_weight, self.target_series)
 
         self.output_chunk_length = output_chunk_length
         self.min_lh, self.max_lh = lh
         self.lookback = lookback
 
         # Checks
-        raise_if_not(
-            self.max_lh >= self.min_lh >= 1,
-            "The lh parameter should be an int tuple (min_lh, max_lh), "
-            "with 1 <= min_lh <= max_lh",
-        )
-        raise_if_not(
-            covariates is None or len(self.target_series) == len(self.covariates),
-            "The provided sequence of target series must have the same length as "
-            "the provided sequence of covariate series.",
-        )
-
+        if not (self.max_lh >= self.min_lh >= 1):
+            raise_log(
+                ValueError(
+                    "The lh parameter should be an int tuple (min_lh, max_lh), "
+                    "with 1 <= min_lh <= max_lh"
+                ),
+                logger=logger,
+            )
+        if covariates is not None and len(self.target_series) != len(self.covariates):
+            raise_log(
+                ValueError(
+                    "The provided sequence of target series must have the same length as "
+                    "the provided sequence of covariate series."
+                ),
+                logger=logger,
+            )
         self.nr_samples_per_ts = (self.max_lh - self.min_lh) * self.output_chunk_length
         self.total_nr_samples = len(self.target_series) * self.nr_samples_per_ts
         self.use_static_covariates = use_static_covariates
@@ -109,18 +125,26 @@ class HorizonBasedDataset(PastCovariatesTrainingDataset):
 
     def __getitem__(
         self, idx: int
-    ) -> Tuple[np.ndarray, Optional[np.ndarray], Optional[np.ndarray], np.ndarray]:
+    ) -> Tuple[
+        np.ndarray,
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        np.ndarray,
+    ]:
         # determine the index of the time series.
         target_idx = idx // self.nr_samples_per_ts
         target_series = self.target_series[target_idx]
         target_vals = target_series.random_component_values(copy=False)
 
-        raise_if_not(
-            len(target_vals)
-            >= (self.lookback + self.max_lh) * self.output_chunk_length,
-            "The dataset contains some input/target series that are shorter than "
-            f"`(lookback + max_lh) * H` ({target_idx}-th series)",
-        )
+        if len(target_vals) < (self.lookback + self.max_lh) * self.output_chunk_length:
+            raise_log(
+                ValueError(
+                    "The dataset contains some input/target series that are shorter than "
+                    f"`(lookback + max_lh) * H` ({target_idx}-th series)"
+                ),
+                logger=logger,
+            )
 
         # determine the index lh_idx of the forecasting point (the last point of the input series, before the target)
         # lh_idx should be in [0, self.nr_samples_per_ts)
@@ -168,24 +192,28 @@ class HorizonBasedDataset(PastCovariatesTrainingDataset):
         # optionally, extract sample covariates
         covariate = None
         if self.covariates is not None:
-            raise_if_not(
-                cov_end <= len(covariate_series),
-                f"The dataset contains 'past' covariates that don't extend far enough into the future. "
-                f"({idx}-th sample)",
-            )
-
+            if cov_end > len(covariate_series):
+                raise_log(
+                    ValueError(
+                        f"The dataset contains 'past' covariates that don't extend far enough into the future. "
+                        f"({idx}-th sample)"
+                    ),
+                    logger=logger,
+                )
             covariate = covariate_series.random_component_values(copy=False)[
                 cov_start:cov_end
             ]
-
-            raise_if_not(
-                len(covariate) == len(past_target),
-                "The dataset contains 'past' covariates whose time axis doesn't allow to obtain the "
-                "input (or output) chunk relative to the target series.",
-            )
+            if len(covariate) != len(past_target):
+                raise_log(
+                    ValueError(
+                        "The dataset contains 'past' covariates whose time axis doesn't allow to obtain the "
+                        "input (or output) chunk relative to the target series."
+                    ),
+                    logger=logger,
+                )
 
         if self.use_static_covariates:
             static_covariate = target_series.static_covariates_values(copy=False)
         else:
             static_covariate = None
-        return past_target, covariate, static_covariate, future_target
+        return past_target, covariate, static_covariate, None, future_target

--- a/darts/utils/data/sequential_dataset.py
+++ b/darts/utils/data/sequential_dataset.py
@@ -29,9 +29,11 @@ class PastCovariatesSequentialDataset(PastCovariatesTrainingDataset):
         output_chunk_shift: int = 0,
         max_samples_per_ts: Optional[int] = None,
         use_static_covariates: bool = True,
+        sample_weight: Optional[Union[str, TimeSeries, Sequence[TimeSeries]]] = None,
     ):
         """
-        A time series dataset containing tuples of (past_target, past_covariates, static_covariates, future_target).
+        A time series dataset containing tuples of (past_target, past_covariates, static_covariates, sample weights,
+        future_target).
         The "past" series have length `input_chunk_length` and the "future" series have
         length `output_chunk_length`. The "future" series are immediately consecutive to the "past" series.
         The slicing of past and future covariates matches that of past and future targets, respectively. The slicing
@@ -70,6 +72,17 @@ class PastCovariatesSequentialDataset(PastCovariatesTrainingDataset):
             most recent `max_samples_per_ts` samples will be considered.
         use_static_covariates
             Whether to use/include static covariate data from input series.
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
         """
 
         super().__init__()
@@ -84,6 +97,7 @@ class PastCovariatesSequentialDataset(PastCovariatesTrainingDataset):
             max_samples_per_ts=max_samples_per_ts,
             covariate_type=CovariateType.PAST,
             use_static_covariates=use_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def __len__(self):
@@ -91,7 +105,13 @@ class PastCovariatesSequentialDataset(PastCovariatesTrainingDataset):
 
     def __getitem__(
         self, idx
-    ) -> Tuple[np.ndarray, Optional[np.ndarray], Optional[np.ndarray], np.ndarray]:
+    ) -> Tuple[
+        np.ndarray,
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        np.ndarray,
+    ]:
         return self.ds[idx]
 
 
@@ -105,9 +125,11 @@ class FutureCovariatesSequentialDataset(FutureCovariatesTrainingDataset):
         output_chunk_shift: int = 0,
         max_samples_per_ts: Optional[int] = None,
         use_static_covariates: bool = True,
+        sample_weight: Optional[Union[str, TimeSeries, Sequence[TimeSeries]]] = None,
     ):
         """
-        A time series dataset containing tuples of (past_target, future_covariates, static_covariates, future_target).
+        A time series dataset containing tuples of (past_target, future_covariates, static_covariates, sample weights,
+        future_target).
         The "past" series have length `input_chunk_length` and the "future" series have
         length `output_chunk_length`. The "future" series are immediately consecutive to the "past" series.
         The slicing of past and future covariates matches that of past and future targets, respectively. The slicing
@@ -146,6 +168,17 @@ class FutureCovariatesSequentialDataset(FutureCovariatesTrainingDataset):
             most recent `max_samples_per_ts` samples will be considered.
         use_static_covariates
             Whether to use/include static covariate data from input series.
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
         """
 
         super().__init__()
@@ -160,6 +193,7 @@ class FutureCovariatesSequentialDataset(FutureCovariatesTrainingDataset):
             max_samples_per_ts=max_samples_per_ts,
             covariate_type=CovariateType.FUTURE,
             use_static_covariates=use_static_covariates,
+            sample_weight=sample_weight,
         )
 
     def __len__(self):
@@ -167,7 +201,13 @@ class FutureCovariatesSequentialDataset(FutureCovariatesTrainingDataset):
 
     def __getitem__(
         self, idx
-    ) -> Tuple[np.ndarray, Optional[np.ndarray], Optional[np.ndarray], np.ndarray]:
+    ) -> Tuple[
+        np.ndarray,
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        np.ndarray,
+    ]:
         return self.ds[idx]
 
 
@@ -181,10 +221,12 @@ class DualCovariatesSequentialDataset(DualCovariatesTrainingDataset):
         output_chunk_shift: int = 0,
         max_samples_per_ts: Optional[int] = None,
         use_static_covariates: bool = True,
+        sample_weight: Optional[Union[str, TimeSeries, Sequence[TimeSeries]]] = None,
     ):
         """
         A time series dataset containing tuples of
-        (past_target, historic_future_covariates, future_covariates, static_covariates, future_target).
+        (past_target, historic_future_covariates, future_covariates, static_covariates, sample weights,
+        future_target).
         The "past" series (incl `historic_future_covariates`) have length `input_chunk_length`
         and the "future" series have length `output_chunk_length`. The "future" series are immediately consecutive
         to the "past" series. The slicing of past and future covariates matches that of past and future targets,
@@ -223,6 +265,17 @@ class DualCovariatesSequentialDataset(DualCovariatesTrainingDataset):
             most recent `max_samples_per_ts` samples will be considered.
         use_static_covariates
             Whether to use/include static covariate data from input series.
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
         """
 
         super().__init__()
@@ -238,6 +291,7 @@ class DualCovariatesSequentialDataset(DualCovariatesTrainingDataset):
             max_samples_per_ts=max_samples_per_ts,
             covariate_type=CovariateType.HISTORIC_FUTURE,
             use_static_covariates=use_static_covariates,
+            sample_weight=sample_weight,
         )
 
         # This dataset is in charge of serving future covariates
@@ -263,15 +317,19 @@ class DualCovariatesSequentialDataset(DualCovariatesTrainingDataset):
         Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],
+        Optional[np.ndarray],
         np.ndarray,
     ]:
-        past_target, past_covariate, static_covariate, future_target = self.ds_past[idx]
-        _, future_covariate, _, _ = self.ds_future[idx]
+        past_target, past_covariate, static_covariate, sample_weight, future_target = (
+            self.ds_past[idx]
+        )
+        _, future_covariate, _, _, _ = self.ds_future[idx]
         return (
             past_target,
             past_covariate,
             future_covariate,
             static_covariate,
+            sample_weight,
             future_target,
         )
 
@@ -287,10 +345,12 @@ class MixedCovariatesSequentialDataset(MixedCovariatesTrainingDataset):
         output_chunk_shift: int = 0,
         max_samples_per_ts: Optional[int] = None,
         use_static_covariates: bool = True,
+        sample_weight: Optional[Union[str, TimeSeries, Sequence[TimeSeries]]] = None,
     ):
         """
         A time series dataset containing tuples of
-        (past_target, past_covariates, historic_future_covariates, future_covariates, static_covariates, future_target).
+        (past_target, past_covariates, historic_future_covariates, future_covariates, static_covariates,
+        sample weights, future_target).
         The "past" series (incl `historic_future_covariates`) have length `input_chunk_length`
         and the "future" series have length `output_chunk_length`. The "future" series are immediately consecutive
         to the "past" series. The slicing of past and future covariates matches that of past and future targets,
@@ -332,6 +392,17 @@ class MixedCovariatesSequentialDataset(MixedCovariatesTrainingDataset):
             most recent `max_samples_per_ts` samples will be considered.
         use_static_covariates
             Whether to use/include static covariate data from input series.
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
         """
 
         super().__init__()
@@ -347,6 +418,7 @@ class MixedCovariatesSequentialDataset(MixedCovariatesTrainingDataset):
             max_samples_per_ts=max_samples_per_ts,
             covariate_type=CovariateType.PAST,
             use_static_covariates=use_static_covariates,
+            sample_weight=sample_weight,
         )
 
         # This dataset is in charge of serving historical and future future covariates
@@ -371,16 +443,20 @@ class MixedCovariatesSequentialDataset(MixedCovariatesTrainingDataset):
         Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],
+        Optional[np.ndarray],
         np.ndarray,
     ]:
-        past_target, past_covariate, static_covariate, future_target = self.ds_past[idx]
-        _, historic_future_covariate, future_covariate, _, _ = self.ds_dual[idx]
+        past_target, past_covariate, static_covariate, sample_weight, future_target = (
+            self.ds_past[idx]
+        )
+        _, historic_future_covariate, future_covariate, _, _, _ = self.ds_dual[idx]
         return (
             past_target,
             past_covariate,
             historic_future_covariate,
             future_covariate,
             static_covariate,
+            sample_weight,
             future_target,
         )
 
@@ -396,10 +472,11 @@ class SplitCovariatesSequentialDataset(SplitCovariatesTrainingDataset):
         output_chunk_shift: int = 0,
         max_samples_per_ts: Optional[int] = None,
         use_static_covariates: bool = True,
+        sample_weight: Optional[Union[str, TimeSeries, Sequence[TimeSeries]]] = None,
     ):
         """
         A time series dataset containing tuples of (past_target, past_covariates, future_covariates, static_covariates,
-        future_target).
+        sample weights, future_target).
         The "past" series have length `input_chunk_length` and the "future" series have
         length `output_chunk_length`. The "future" series are immediately consecutive to the "past" series.
         The slicing of past and future covariates matches that of past and future targets, respectively. The slicing
@@ -441,6 +518,17 @@ class SplitCovariatesSequentialDataset(SplitCovariatesTrainingDataset):
             most recent `max_samples_per_ts` samples will be considered.
         use_static_covariates
             Whether to use/include static covariate data from input series.
+        sample_weight
+            Optionally, some sample weights to apply to the target `series` labels.
+            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
+            If a string, then the weights are generated using built-in weighting functions. The available options are
+            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
+            and then applied globally to all `series` to have a common time weighting.
+            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
+            match the number of target `series` and each series must contain at least all time steps from the
+            corresponding target `series`. If the weight series only have a single component / column, then the weights
+            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
+            of components must match those of `series`.
         """
         super().__init__()
         shift = input_chunk_length + output_chunk_shift
@@ -455,6 +543,7 @@ class SplitCovariatesSequentialDataset(SplitCovariatesTrainingDataset):
             max_samples_per_ts=max_samples_per_ts,
             covariate_type=CovariateType.PAST,
             use_static_covariates=use_static_covariates,
+            sample_weight=sample_weight,
         )
 
         # This dataset is in charge of serving future covariates
@@ -480,14 +569,18 @@ class SplitCovariatesSequentialDataset(SplitCovariatesTrainingDataset):
         Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],
+        Optional[np.ndarray],
         np.ndarray,
     ]:
-        past_target, past_covariate, static_covariate, future_target = self.ds_past[idx]
-        _, future_covariate, _, _ = self.ds_future[idx]
+        past_target, past_covariate, static_covariate, sample_weight, future_target = (
+            self.ds_past[idx]
+        )
+        _, future_covariate, _, _, _ = self.ds_future[idx]
         return (
             past_target,
             past_covariate,
             future_covariate,
             static_covariate,
+            sample_weight,
             future_target,
         )

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -745,9 +745,20 @@ class GenericShiftedDataset(TrainingDataset):
         )
 
         # optionally, load sample weight
-        sample_weight_series = (
-            self.sample_weight[target_idx] if self.sample_weight is not None else None
-        )
+        if self.sample_weight is not None:
+            sample_weight_series = self.sample_weight[target_idx]
+            weight_n_comp = sample_weight_series.n_components
+            if weight_n_comp > 1 and weight_n_comp != target_series.n_components:
+                raise_log(
+                    ValueError(
+                        "The number of components in `sample_weight` must either be `1` or match "
+                        f"the number of target series components `{target_series.n_components}`. "
+                        f"({target_idx}-th series)"
+                    ),
+                    logger=logger,
+                )
+        else:
+            sample_weight_series = None
 
         # get all indices for the current sample
         (

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -642,15 +642,6 @@ class GenericShiftedDataset(TrainingDataset):
         """
         super().__init__()
 
-        if covariates is not None and len(target_series) != len(covariates):
-            raise_log(
-                ValueError(
-                    "The provided sequence of target series must have the same length as "
-                    "the provided sequence of covariate series."
-                ),
-                logger=logger,
-            )
-
         # setup target and sequence
         self.target_series = series2seq(target_series)
         self.input_chunk_length = input_chunk_length
@@ -681,6 +672,17 @@ class GenericShiftedDataset(TrainingDataset):
             self.covariate_type = CovariateType.NONE
             self.shift_covariates = 0
         self.use_static_covariates = use_static_covariates
+
+        if self.covariates is not None and len(self.target_series) != len(
+            self.covariates
+        ):
+            raise_log(
+                ValueError(
+                    "The provided sequence of target series must have the same length as "
+                    "the provided sequence of covariate series."
+                ),
+                logger=logger,
+            )
 
         # setup sample weights; ignore weights when `ocl==0`
         self.sample_weight = None

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -689,7 +689,7 @@ class GenericShiftedDataset(TrainingDataset):
         if sample_weight is not None:
             if output_chunk_length > 0:
                 self.sample_weight = _process_sample_weight(
-                    sample_weight, target_series
+                    sample_weight, self.target_series
                 )
             else:
                 self.sample_weight = None

--- a/darts/utils/data/shifted_dataset.py
+++ b/darts/utils/data/shifted_dataset.py
@@ -656,10 +656,8 @@ class GenericShiftedDataset(TrainingDataset):
             )
         self.sample_weight = _process_sample_weight(sample_weight, target_series)
 
-        self.input_chunk_length, self.output_chunk_length = (
-            input_chunk_length,
-            output_chunk_length,
-        )
+        self.input_chunk_length = input_chunk_length
+        self.output_chunk_length = output_chunk_length
         self.shift, self.shift_covariates = shift, shift_covariates
         self.max_samples_per_ts = max_samples_per_ts
 
@@ -755,8 +753,8 @@ class GenericShiftedDataset(TrainingDataset):
         future_target = target_vals[future_start:future_end]
         past_target = target_vals[past_start:past_end]
 
-        # optionally, extract sample covariates
-        covariate, sample_weight = None, None
+        # extract sample covariates
+        covariate = None
         if self.covariates is not None:
             if covariate_end > len(covariate_series):
                 raise_log(
@@ -785,6 +783,8 @@ class GenericShiftedDataset(TrainingDataset):
                     logger=logger,
                 )
 
+        # extract sample weights
+        sample_weight = None
         if self.sample_weight is not None:
             if sample_weight_end > len(sample_weight_series):
                 raise_log(
@@ -808,6 +808,7 @@ class GenericShiftedDataset(TrainingDataset):
                     logger=logger,
                 )
 
+        # extract sample static covariates
         if self.use_static_covariates:
             static_covariate = target_series.static_covariates_values(copy=False)
         else:

--- a/darts/utils/data/training_dataset.py
+++ b/darts/utils/data/training_dataset.py
@@ -141,10 +141,7 @@ class TrainingDataset(ABC, Dataset):
             )
 
             if covariate_type is not CovariateType.NONE:
-                target_time_index = target_series._time_index
-                covariate_time_index = covariate_series._time_index
-
-                # not CovariateType.Future -> both CovariateType.PAST and CovariateType.HISTORIC_FUTURE
+                # not CovariateType.FUTURE -> both CovariateType.PAST and CovariateType.HISTORIC_FUTURE
                 start = (
                     future_start
                     if covariate_type is CovariateType.FUTURE
@@ -154,8 +151,10 @@ class TrainingDataset(ABC, Dataset):
 
                 # we need to be careful with getting ranges and indexes:
                 # to get entire range, full_range = ts[:len(ts)]; to get last index: last_idx = ts[len(ts) - 1]
-
-                # extract actual index value (respects datetime- and integer-based indexes; also from non-zero start)
+                # extract actual index value (respects datetime- and integer-based indexes; also from non-zero
+                # start)
+                target_time_index = target_series._time_index
+                covariate_time_index = covariate_series._time_index
                 start_time = target_time_index[start]
                 end_time = target_time_index[end - 1]
 

--- a/darts/utils/data/training_dataset.py
+++ b/darts/utils/data/training_dataset.py
@@ -10,7 +10,7 @@ import numpy as np
 from torch.utils.data import Dataset
 
 from darts import TimeSeries
-from darts.logging import get_logger, raise_if_not
+from darts.logging import get_logger, raise_log
 from darts.utils.data.utils import CovariateType
 
 logger = get_logger(__name__)
@@ -85,7 +85,7 @@ class TrainingDataset(ABC, Dataset):
         end_of_output_idx: int,
         covariate_series: Optional[TimeSeries] = None,
         covariate_type: CovariateType = CovariateType.NONE,
-        sample_weight: Optional[TimeSeries] = None,
+        sample_weight_series: Optional[TimeSeries] = None,
     ) -> SampleIndexType:
         """Returns the (start, end) indices for past target, future target and covariates (sub sets) of the current
         sample `i` from `target_idx`.
@@ -116,11 +116,12 @@ class TrainingDataset(ABC, Dataset):
         covariate_type
             the type of covariate to extract. Instance of `CovariateType`: One of (`CovariateType.PAST`,
             `CovariateType.FUTURE`, `CovariateType.NONE`).
-        sample_weight
+        sample_weight_series
             current sample weight TimeSeries.
         """
 
         covariate_start, covariate_end = None, None
+        sample_weight_start, sample_weight_end = None, None
 
         # the first time target_idx is observed
         if target_idx not in self._index_memory:
@@ -140,6 +141,9 @@ class TrainingDataset(ABC, Dataset):
             )
 
             if covariate_type is not CovariateType.NONE:
+                target_time_index = target_series._time_index
+                covariate_time_index = covariate_series._time_index
+
                 # not CovariateType.Future -> both CovariateType.PAST and CovariateType.HISTORIC_FUTURE
                 start = (
                     future_start
@@ -152,22 +156,48 @@ class TrainingDataset(ABC, Dataset):
                 # to get entire range, full_range = ts[:len(ts)]; to get last index: last_idx = ts[len(ts) - 1]
 
                 # extract actual index value (respects datetime- and integer-based indexes; also from non-zero start)
-                start_time = target_series.time_index[start]
-                end_time = target_series.time_index[end - 1]
+                start_time = target_time_index[start]
+                end_time = target_time_index[end - 1]
 
-                raise_if_not(
-                    start_time in covariate_series.time_index
-                    and end_time in covariate_series.time_index,
-                    f"Missing covariates; could not find {covariate_type.value} covariates in index value range: "
-                    f"{start_time} - {end_time}.",
-                )
+                if (
+                    start_time not in covariate_time_index
+                    or end_time not in covariate_time_index
+                ):
+                    raise_log(
+                        ValueError(
+                            f"Missing covariates; could not find {covariate_type.value} covariates in index "
+                            f"value range: {start_time} - {end_time}."
+                        ),
+                        logger=logger,
+                    )
 
                 # extract the index position (index) from index value
-                covariate_start = covariate_series.time_index.get_loc(start_time)
-                covariate_end = covariate_series.time_index.get_loc(end_time) + 1
+                covariate_start = covariate_time_index.get_loc(start_time)
+                covariate_end = covariate_time_index.get_loc(end_time) + 1
 
             # sample weight
-            sample_weight_start, sample_weight_end = None, None
+            if sample_weight_series is not None:
+                # extract the index position (index) from index value
+                target_time_index = target_series._time_index
+                sample_weight_time_index = sample_weight_series._time_index
+
+                start_time = target_time_index[future_start]
+                end_time = target_time_index[future_end - 1]
+
+                if (
+                    start_time not in sample_weight_time_index
+                    or end_time not in sample_weight_time_index
+                ):
+                    raise_log(
+                        ValueError(
+                            f"Missing sample weights; could not find sample weights in index "
+                            f"value range: {start_time} - {end_time}."
+                        ),
+                        logger=logger,
+                    )
+
+                sample_weight_start = sample_weight_time_index.get_loc(start_time)
+                sample_weight_end = sample_weight_time_index.get_loc(end_time) + 1
 
             # store position of initial sample and all relevant sub set indices
             self._index_memory[target_idx] = {
@@ -198,6 +228,14 @@ class TrainingDataset(ABC, Dataset):
             )
             covariate_end = (
                 covariate_end + idx_shift if covariate_end is not None else None
+            )
+            sample_weight_start = (
+                sample_weight_start + idx_shift
+                if sample_weight_start is not None
+                else None
+            )
+            sample_weight_end = (
+                sample_weight_end + idx_shift if sample_weight_end is not None else None
             )
 
         return (
@@ -291,12 +329,17 @@ class TrainingDataset(ABC, Dataset):
                 start_time = target_series.time_index[start]
                 end_time = target_series.time_index[end - 1]
 
-                raise_if_not(
-                    start_time in covariate_series.time_index
-                    and end_time in covariate_series.time_index,
-                    f"Missing covariates; could not find {covariate_type.value} covariates in index value range: "
-                    f"{start_time} - {end_time}.",
-                )
+                if (
+                    start_time not in covariate_series.time_index
+                    or end_time not in covariate_series.time_index
+                ):
+                    raise_log(
+                        ValueError(
+                            f"Missing covariates; could not find {covariate_type.value} covariates in index "
+                            f"value range: {start_time} - {end_time}."
+                        ),
+                        logger=logger,
+                    )
 
                 # extract the index position (index) from index value
                 covariate_start = covariate_series.time_index.get_loc(start_time)

--- a/darts/utils/data/training_dataset.py
+++ b/darts/utils/data/training_dataset.py
@@ -14,7 +14,9 @@ from darts.logging import get_logger, raise_if_not
 from darts.utils.data.utils import CovariateType
 
 logger = get_logger(__name__)
-SampleIndexType = Tuple[int, int, int, int, int, int]
+SampleIndexType = Tuple[
+    int, int, int, int, Optional[int], Optional[int], Optional[int], Optional[int]
+]
 
 
 class TrainingDataset(ABC, Dataset):
@@ -81,8 +83,9 @@ class TrainingDataset(ABC, Dataset):
         input_chunk_length: int,
         output_chunk_length: int,
         end_of_output_idx: int,
-        covariate_series: TimeSeries,
+        covariate_series: Optional[TimeSeries] = None,
         covariate_type: CovariateType = CovariateType.NONE,
+        sample_weight: Optional[TimeSeries] = None,
     ) -> SampleIndexType:
         """Returns the (start, end) indices for past target, future target and covariates (sub sets) of the current
         sample `i` from `target_idx`.
@@ -110,9 +113,11 @@ class TrainingDataset(ABC, Dataset):
             the index where the output chunk of the current sample ends in `target_series`.
         covariate_series
             current covariate TimeSeries.
-        covariate_type:
+        covariate_type
             the type of covariate to extract. Instance of `CovariateType`: One of (`CovariateType.PAST`,
             `CovariateType.FUTURE`, `CovariateType.NONE`).
+        sample_weight
+            current sample weight TimeSeries.
         """
 
         covariate_start, covariate_end = None, None
@@ -161,12 +166,16 @@ class TrainingDataset(ABC, Dataset):
                 covariate_start = covariate_series.time_index.get_loc(start_time)
                 covariate_end = covariate_series.time_index.get_loc(end_time) + 1
 
+            # sample weight
+            sample_weight_start, sample_weight_end = None, None
+
             # store position of initial sample and all relevant sub set indices
             self._index_memory[target_idx] = {
                 "end_of_output_idx": end_of_output_idx,
                 "past_target": (past_start, past_end),
                 "future_target": (future_start, future_end),
                 "covariate": (covariate_start, covariate_end),
+                "sample_weight": (sample_weight_start, sample_weight_end),
             }
         else:
             # load position of initial sample and its sub set indices
@@ -174,6 +183,9 @@ class TrainingDataset(ABC, Dataset):
             past_start, past_end = self._index_memory[target_idx]["past_target"]
             future_start, future_end = self._index_memory[target_idx]["future_target"]
             covariate_start, covariate_end = self._index_memory[target_idx]["covariate"]
+            sample_weight_start, sample_weight_end = self._index_memory[target_idx][
+                "sample_weight"
+            ]
 
             # evaluate how much the new sample needs to be shifted, and shift all indexes
             idx_shift = end_of_output_idx - end_of_output_idx_last
@@ -195,6 +207,146 @@ class TrainingDataset(ABC, Dataset):
             future_end,
             covariate_start,
             covariate_end,
+            sample_weight_start,
+            sample_weight_end,
+        )
+
+    def _memory_indexer2(
+        self,
+        target_idx: int,
+        target_series: TimeSeries,
+        shift: int,
+        input_chunk_length: int,
+        output_chunk_length: int,
+        end_of_output_idx: int,
+        covariate_series: Optional[TimeSeries] = None,
+        covariate_type: CovariateType = CovariateType.NONE,
+        sample_weight: Optional[TimeSeries] = None,
+    ) -> SampleIndexType:
+        """Returns the (start, end) indices for past target, future target and covariates (sub sets) of the current
+        sample `i` from `target_idx`.
+
+        Works for all TimeSeries index types: pd.DatetimeIndex, pd.RangeIndex (and the deprecated Int64Index)
+
+        When `target_idx` is observed for the first time, it stores the position of the sample `0` within the full
+        target time series and the (start, end) indices of all sub sets.
+        This allows to calculate the sub set indices for all future samples `i` by simply adjusting for the difference
+        between the positions of sample `i` and sample `0`.
+
+        Parameters
+        ----------
+        target_idx
+            index of the current target TimeSeries.
+        target_series
+            current target TimeSeries.
+        shift
+            The number of time steps by which to shift the output chunks relative to the input chunks.
+        input_chunk_length
+            The length of the emitted past series.
+        output_chunk_length
+            The length of the emitted future output series.
+        end_of_output_idx
+            the index where the output chunk of the current sample ends in `target_series`.
+        covariate_series
+            current covariate TimeSeries.
+        covariate_type
+            the type of covariate to extract. Instance of `CovariateType`: One of (`CovariateType.PAST`,
+            `CovariateType.FUTURE`, `CovariateType.NONE`).
+        sample_weight
+            current sample weight TimeSeries.
+        """
+
+        covariate_start, covariate_end = None, None
+
+        # the first time target_idx is observed
+        if target_idx not in self._index_memory:
+            start_of_output_idx = end_of_output_idx - output_chunk_length
+            start_of_input_idx = start_of_output_idx - shift
+
+            # select forecast point and target period, using the previously computed indexes
+            future_start, future_end = (
+                start_of_output_idx,
+                start_of_output_idx + output_chunk_length,
+            )
+
+            # select input period; look at the `input_chunk_length` points after start of input
+            past_start, past_end = (
+                start_of_input_idx,
+                start_of_input_idx + input_chunk_length,
+            )
+
+            if covariate_type is not CovariateType.NONE:
+                # not CovariateType.Future -> both CovariateType.PAST and CovariateType.HISTORIC_FUTURE
+                start = (
+                    future_start
+                    if covariate_type is CovariateType.FUTURE
+                    else past_start
+                )
+                end = future_end if covariate_type is CovariateType.FUTURE else past_end
+
+                # we need to be careful with getting ranges and indexes:
+                # to get entire range, full_range = ts[:len(ts)]; to get last index: last_idx = ts[len(ts) - 1]
+
+                # extract actual index value (respects datetime- and integer-based indexes; also from non-zero start)
+                start_time = target_series.time_index[start]
+                end_time = target_series.time_index[end - 1]
+
+                raise_if_not(
+                    start_time in covariate_series.time_index
+                    and end_time in covariate_series.time_index,
+                    f"Missing covariates; could not find {covariate_type.value} covariates in index value range: "
+                    f"{start_time} - {end_time}.",
+                )
+
+                # extract the index position (index) from index value
+                covariate_start = covariate_series.time_index.get_loc(start_time)
+                covariate_end = covariate_series.time_index.get_loc(end_time) + 1
+
+            # sample weight
+            sample_weight_start, sample_weight_end = self._index_memory[target_idx][
+                "sample_weight"
+            ]
+
+            # store position of initial sample and all relevant sub set indices
+            self._index_memory[target_idx] = {
+                "end_of_output_idx": end_of_output_idx,
+                "past_target": (past_start, past_end),
+                "future_target": (future_start, future_end),
+                "covariate": (covariate_start, covariate_end),
+                "sample_weight": (sample_weight_start, sample_weight_end),
+            }
+        else:
+            # load position of initial sample and its sub set indices
+            end_of_output_idx_last = self._index_memory[target_idx]["end_of_output_idx"]
+            past_start, past_end = self._index_memory[target_idx]["past_target"]
+            future_start, future_end = self._index_memory[target_idx]["future_target"]
+            covariate_start, covariate_end = self._index_memory[target_idx]["covariate"]
+            sample_weight_start, sample_weight_end = self._index_memory[target_idx][
+                "sample_weight"
+            ]
+
+            # evaluate how much the new sample needs to be shifted, and shift all indexes
+            idx_shift = end_of_output_idx - end_of_output_idx_last
+            past_start += idx_shift
+            past_end += idx_shift
+            future_start += idx_shift
+            future_end += idx_shift
+            covariate_start = (
+                covariate_start + idx_shift if covariate_start is not None else None
+            )
+            covariate_end = (
+                covariate_end + idx_shift if covariate_end is not None else None
+            )
+
+        return (
+            past_start,
+            past_end,
+            future_start,
+            future_end,
+            covariate_start,
+            covariate_end,
+            sample_weight_start,
+            sample_weight_end,
         )
 
 

--- a/darts/utils/data/training_dataset.py
+++ b/darts/utils/data/training_dataset.py
@@ -405,7 +405,13 @@ class PastCovariatesTrainingDataset(TrainingDataset, ABC):
     @abstractmethod
     def __getitem__(
         self, idx: int
-    ) -> Tuple[np.ndarray, Optional[np.ndarray], Optional[np.ndarray], np.ndarray]:
+    ) -> Tuple[
+        np.ndarray,
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        np.ndarray,
+    ]:
         pass
 
 
@@ -421,7 +427,13 @@ class FutureCovariatesTrainingDataset(TrainingDataset, ABC):
     @abstractmethod
     def __getitem__(
         self, idx: int
-    ) -> Tuple[np.ndarray, Optional[np.ndarray], Optional[np.ndarray], np.ndarray]:
+    ) -> Tuple[
+        np.ndarray,
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        np.ndarray,
+    ]:
         pass
 
 
@@ -439,6 +451,7 @@ class DualCovariatesTrainingDataset(TrainingDataset, ABC):
         self, idx: int
     ) -> Tuple[
         np.ndarray,
+        Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],
@@ -466,6 +479,7 @@ class MixedCovariatesTrainingDataset(TrainingDataset, ABC):
         Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],
+        Optional[np.ndarray],
         np.ndarray,
     ]:
         pass
@@ -485,6 +499,7 @@ class SplitCovariatesTrainingDataset(TrainingDataset, ABC):
         self, idx: int
     ) -> Tuple[
         np.ndarray,
+        Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],
         Optional[np.ndarray],

--- a/darts/utils/data/utils.py
+++ b/darts/utils/data/utils.py
@@ -93,7 +93,7 @@ def _process_sample_weight(sample_weight, target_series):
         else:  # "exponential_decay"
             time_steps = np.linspace(0, 1, max_len)
             weights = np.exp(-10 * (1 - time_steps))
-        weights = np.expand_dims(weights, -1)
+        weights = np.expand_dims(weights, -1).astype(target_series[0].dtype)
 
         # create sequence of series for tabularization
         sample_weight = [

--- a/darts/utils/data/utils.py
+++ b/darts/utils/data/utils.py
@@ -1,13 +1,19 @@
 from enum import Enum
 from typing import Union
 
+import numpy as np
 import pandas as pd
 
 from darts import TimeSeries
-from darts.logging import raise_if_not
+from darts.logging import get_logger, raise_log
+from darts.utils.ts_utils import series2seq
+
+logger = get_logger(__name__)
 
 # Those freqs can be used to divide Time deltas (the others can't):
 DIVISIBLE_FREQS = {"D", "h", "H", "T", "min", "s", "S", "L", "ms", "U", "us", "N", "ns"}
+# supported built-in sample weight generators for regression and torch models
+SUPPORTED_SAMPLE_WEIGHT = {"linear_decay", "exponential_decay"}
 
 
 class CovariateType(Enum):
@@ -29,11 +35,14 @@ def _get_matching_index(ts_target: TimeSeries, ts_covariate: TimeSeries, idx: in
 
     Note: this function does not check if the matching index value is in `ts_covariate` or not.
     """
-    raise_if_not(
-        ts_target.freq == ts_covariate.freq,
-        "The dataset contains some target/covariates series pair that have incompatible "
-        'time axes (not the same "freq") and thus cannot be matched',
-    )
+    if ts_target.freq != ts_covariate.freq:
+        raise_log(
+            ValueError(
+                "The dataset contains some target/covariates series pair that have incompatible "
+                'time axes (not the same "freq") and thus cannot be matched'
+            ),
+            logger=logger,
+        )
 
     freq = ts_target.freq
 
@@ -59,3 +68,50 @@ def _index_diff(
         return -1 + len(pd.date_range(start=self, end=other, freq=freq))
     else:
         return 1 - len(pd.date_range(start=other, end=self, freq=freq))
+
+
+def _process_sample_weight(sample_weight, target_series):
+    # get sample weights
+    if isinstance(sample_weight, str):
+        if sample_weight not in SUPPORTED_SAMPLE_WEIGHT:
+            raise_log(
+                ValueError(
+                    f"Invalid `sample_weight` value: {sample_weight}. "
+                    f"If a string, must be one of: {SUPPORTED_SAMPLE_WEIGHT}."
+                ),
+                logger=logger,
+            )
+        if target_series is None:
+            raise_log(
+                ValueError("Must supply `target_series` when using `sample_weight`."),
+                logger=logger,
+            )
+        # create global time weights based on the longest target series
+        max_len = max(len(target_i) for target_i in target_series)
+        if sample_weight == "linear_decay":
+            weights = np.linspace(0, 1, max_len)
+        else:  # "exponential_decay"
+            time_steps = np.linspace(0, 1, max_len)
+            weights = np.exp(-10 * (1 - time_steps))
+        weights = np.expand_dims(weights, -1)
+
+        # create sequence of series for tabularization
+        sample_weight = [
+            TimeSeries.from_times_and_values(
+                times=target_i.time_index,
+                values=weights[-len(target_i) :],
+            )
+            for target_i in target_series
+        ]
+    if sample_weight is not None:
+        sample_weight = series2seq(sample_weight)
+
+    if sample_weight is not None and len(target_series) != len(sample_weight):
+        raise_log(
+            ValueError(
+                "The provided sequence of target series must have the same length as "
+                "the provided sequence of sample weights."
+            ),
+            logger=logger,
+        )
+    return sample_weight

--- a/darts/utils/data/utils.py
+++ b/darts/utils/data/utils.py
@@ -71,12 +71,15 @@ def _index_diff(
 
 
 def _process_sample_weight(sample_weight, target_series):
+    if sample_weight is None:
+        return None
+
     # get sample weights
     if isinstance(sample_weight, str):
         if sample_weight not in SUPPORTED_SAMPLE_WEIGHT:
             raise_log(
                 ValueError(
-                    f"Invalid `sample_weight` value: {sample_weight}. "
+                    f"Invalid `sample_weight` value: `'{sample_weight}'`. "
                     f"If a string, must be one of: {SUPPORTED_SAMPLE_WEIGHT}."
                 ),
                 logger=logger,
@@ -103,10 +106,9 @@ def _process_sample_weight(sample_weight, target_series):
             )
             for target_i in target_series
         ]
-    if sample_weight is not None:
-        sample_weight = series2seq(sample_weight)
 
-    if sample_weight is not None and len(target_series) != len(sample_weight):
+    sample_weight = series2seq(sample_weight)
+    if len(target_series) != len(sample_weight):
         raise_log(
             ValueError(
                 "The provided sequence of target series must have the same length as "


### PR DESCRIPTION
Checklist before merging this PR:
- [ ] Mentioned all issues that this PR fixes or addresses.
- [ ] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #1175, fixes #2107.

(this is a continuation of #2404)

### Summary
- adds support for training torch forecasting models with sample weights.
- `fit()` now has two new parameters  `sample_weight` and `val_sample_weight` which allow to pass sample weights for training and validation

```
sample_weight
            Optionally, some sample weights to apply to the target `series` labels.
            They are applied per observation, per label (each step in `output_chunk_length`), and per component.
            If a string, then the weights are generated using built-in weighting functions. The available options are
            `"linear_decay"` or `"exponential_decay"`. The weights are only computed the longest series in `series`,
            and then applied globally to all `series` to have a common time weighting.
            If a `TimeSeries` or `Sequence[TimeSeries]`, then those weights are used. The number of series must
            match the number of target `series` and each series must contain at least all time steps from the
            corresponding target `series`. If the weight series only have a single component / column, then the weights
            are applied globally to all components in `series`. Otherwise, for component-specific weights, the number
            of components must match those of `series`.
val_sample_weight
            Same as for `sample_weight` but for the evaluation dataset.
```
