### PR TITLE
upper cap numpy<2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Improvements to unified linting by switch `isort` to Ruff's rule I. [#2339](https://github.com/unit8co/darts/pull/2339) by [Jirka Borovec](https://github.com/borda)
 - Improvements to unified linting by switch `pyupgrade` to Ruff's rule UP. [#2340](https://github.com/unit8co/darts/pull/2340) by [Jirka Borovec](https://github.com/borda)
 - Improvements to CI, running lint locally via pre-commit instead of particular tools. [#2327](https://github.com/unit8co/darts/pull/2327) by [Jirka Borovec](https://github.com/borda)
+- We set an upper version cap on `numpy<2.0.0` until all dependencies have migrated. [#2413](https://github.com/unit8co/darts/pull/2413) by [Dennis Bader](https://github.com/dennisbader).
 
 
 ### For developers of the library:

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -2,7 +2,7 @@ holidays>=0.11.1
 joblib>=0.16.0
 matplotlib>=3.3.0
 nfoursid>=1.0.0
-numpy>=1.19.0
+numpy>=1.19.0,<2.0.0
 pandas>=1.0.5,<2.0.0; python_version < "3.9"
 pandas>=1.0.5; python_version >= "3.9"
 pmdarima>=1.8.0

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -17,3 +17,4 @@ sphinx==5.0.0
 sphinx-automodapi==0.14.0
 sphinx_autodoc_typehints==1.12.0
 twine==3.3.0
+tenacity<=8.3.0


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).


### Summary
Numpy released version 2.0.0. This broke a lot of our dependencies. Until they have migrated, we set an upper cap. 
- fixes failing CI pipeline due to `numpy==2.0.0` and `tenacity==8.4.0`
- sets upper caps `numpy<2.0.0` and `tenacity<=8.3.0`
- we'll monitor the dependencies until we can migrate as well