### PR TITLE
Replacing the obsolete applymap with map

### DIFF
--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1446,10 +1446,10 @@ class TestTimeSeries:
         df_01 = series.pd_dataframe()
         df_012 = series.pd_dataframe()
 
-        df_0[["0"]] = df_0[["0"]].applymap(fn)
-        df_2[["2"]] = df_2[["2"]].applymap(fn)
-        df_01[["0", "1"]] = df_01[["0", "1"]].applymap(fn)
-        df_012 = df_012.applymap(fn)
+        df_0[["0"]] = df_0[["0"]].map(fn)
+        df_2[["2"]] = df_2[["2"]].map(fn)
+        df_01[["0", "1"]] = df_01[["0", "1"]].map(fn)
+        df_012 = df_012.map(fn)
 
         series_0 = TimeSeries.from_dataframe(df_0, freq="D")
         series_2 = TimeSeries.from_dataframe(df_2, freq="D")


### PR DESCRIPTION

Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Contributes to #2435

<!-- Please mention an issue this pull request addresses. -->
Fixes #.
Replacing `DataFrame.applymap` to `DataFrame.map`.

Removes the warning:

`FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.`

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->
Replacing the obsolete applymap with map

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
