### PR TITLE
Replacement of deprecated Series.fillna -> 'method' with ffill() and bfill()

### DIFF
--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -572,8 +572,8 @@ class ElectricityDataset(DatasetLoaderCSV):
 
             # filter column down to the period of recording
             srs = srs.replace(0.0, np.nan)
-            start_date = min(srs.fillna(method="ffill").dropna().index)
-            end_date = max(srs.fillna(method="bfill").dropna().index)
+            start_date = min(srs.ffill().dropna().index)
+            end_date = max(srs.bfill().dropna().index)
             active_range = (srs.index >= start_date) & (srs.index <= end_date)
             srs = srs[active_range].fillna(0.0)
 
@@ -670,8 +670,8 @@ class UberTLCDataset(DatasetLoaderCSV):
             srs = series[label]
 
             # filter column down to the period of recording
-            start_date = min(srs.fillna(method="ffill").dropna().index)
-            end_date = max(srs.fillna(method="bfill").dropna().index)
+            start_date = min(srs.ffill().dropna().index)
+            end_date = max(srs.bfill().dropna().index)
             active_range = (srs.index >= start_date) & (srs.index <= end_date)
             srs = srs[active_range]
 


### PR DESCRIPTION
Fixes #2325 

Need checking for older versions of pandas.

FutureWarning:` Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.`

Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2325 

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

Replacement of deprecated Series.fillna -> 'method' with ffill() and bfill().

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
