### PR TITLE
fix: PerformanceWarning - DataFrame is highly fragmented

### DIFF
--- a/darts/utils/timeseries_generation.py
+++ b/darts/utils/timeseries_generation.py
@@ -675,11 +675,21 @@ def datetime_attribute_timeseries(
     if one_hot:
         values_df = pd.get_dummies(values)
         # fill missing columns (in case not all values appear in time_index)
-        attribute_range = range(num_values_dict[attribute])
-        for i in attribute_range:
-            if i not in values_df.columns:
-                values_df[i] = 0
-        values_df = values_df[attribute_range]
+        attribute_range = np.arange(num_values_dict[attribute])
+        mask_bool = np.isin(attribute_range, values_df.columns.values, invert=True)
+        # if there are attribute_range columns that are
+        # not in values_df.columns.values
+        if attribute_range[mask_bool].size != 0:
+            list_0 = [0] * len(values_df)
+            dict_0 = {i: list_0 for i in attribute_range[mask_bool]}
+            # Make a dataframe from the dictionary and concatenate it
+            # to the values values_df  in which the columns selected
+            # by opposite mask ~.
+            values_df = pd.concat(
+                [values_df[attribute_range[~mask_bool]], pd.DataFrame(dict_0)], axis=1
+            ).sort_index(axis=1)
+        else:
+            values_df = values_df[attribute_range]
 
         if with_columns is None:
             with_columns = [


### PR DESCRIPTION
Fixes  #2446 

Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [ ] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2446 

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

```
When setting columns multiple times, a warning occurs:
darts/tests/utils/test_timeseries_generation.py: 635 warnings
/darts/darts/utils/timeseries_generation.py:681: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`
    values_df[i] = 0
```
Creating columns multiple times, as it turns out, this takes a lot of [resources.](https://github.com/pandas-dev/pandas/issues/42477)          (though judging by the tests from Actions it takes the same amount of time, but there are no warnings.Perhaps `timeseries_generation` takes a little time in relation to all `test_timeseries_generation`).

Description:
If there are `attribute_range `elements that are not in `values_df.columns.values`, then we create a dictionary from which the dataframe will be created. The dictionary is filled with zeros.

Make a `dataframe` from the dictionary and `concatenate` it to the `values values_df`  in which the columns selected
by opposite `mask ~`.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
