### PR TITLE
Feat/Pass kwargs to the underlying models fit functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Made README's forecasting model support table more colorblind-friendly. [#2433](https://github.com/unit8co/darts/pull/2433)
 - Allowed passing of kwargs to the `fit` functions of `Prophet` and `AutoARIMA`
 - 🔴 Restructured the signatures of `ExponentialSmoothing` `__init__` and `fit` functions so that the passing of additional parameters is consistent with other models
-  - Keyword arguments to be passed to the underlying model's constructor must now be passed as keyword arguments instead of a `dict` to the `ExponentialSmoothing` constructor 
+  - Keyword arguments to be passed to the underlying model's constructor must now be passed as keyword arguments instead of a `dict` to the `ExponentialSmoothing` constructor
   - Keyword arguments to be passed to the underlying model's `fit` function must now be passed to the `ExponentialSmoothing.fit` function instead of the constructor
 
 **Fixed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Improved**
 - Added `IQRDetector`, that allows to detect anomalies using the interquartile range algorithm. [#2441] by [Igor Urbanik](https://github.com/u8-igor).
 - Made README's forecasting model support table more colorblind-friendly. [#2433](https://github.com/unit8co/darts/pull/2433)
+- Allowed passing of kwargs to the `fit` functions of `Prophet` and `AutoARIMA`
+- 🔴 Restructured the signatures of `ExponentialSmoothing` `__init__` and `fit` functions so that the passing of additional parameters is consistent with other models
+  - Keyword arguments to be passed to the underlying model's constructor must now be passed as keyword arguments instead of a `dict` to the `ExponentialSmoothing` constructor 
+  - Keyword arguments to be passed to the underlying model's `fit` function must now be passed to the `ExponentialSmoothing.fit` function instead of the constructor
 
 **Fixed**
 - Fixed a bug when using `historical_forecasts()` with a pre-trained `RegressionModel` that has no target lags `lags=None` but uses static covariates. [#2426](https://github.com/unit8co/darts/pull/2426) by [Dennis Bader](https://github.com/dennisbader).

--- a/darts/logging.py
+++ b/darts/logging.py
@@ -192,7 +192,9 @@ class SuppressStdoutStderr:
             os.close(fd)
 
 
-def execute_and_suppress_output(function, logger, suppression_threshold_level, *args):
+def execute_and_suppress_output(
+    function, logger, suppression_threshold_level, *args, **kwargs
+):
     """
     This function conditionally executes the given function with the given arguments
     based on whether the current level of 'logger' is below, above or equal to
@@ -207,9 +209,9 @@ def execute_and_suppress_output(function, logger, suppression_threshold_level, *
     """
     if logger.level >= suppression_threshold_level:
         with SuppressStdoutStderr():
-            return_value = function(*args)
+            return_value = function(*args, **kwargs)
     else:
-        return_value = function(*args)
+        return_value = function(*args, **kwargs)
     return return_value
 
 

--- a/darts/models/forecasting/auto_arima.py
+++ b/darts/models/forecasting/auto_arima.py
@@ -99,7 +99,7 @@ class AutoARIMA(FutureCovariatesLocalForecastingModel):
         self,
         series: TimeSeries,
         future_covariates: Optional[TimeSeries] = None,
-        **fit_kwargs
+        **fit_kwargs,
     ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
@@ -107,7 +107,7 @@ class AutoARIMA(FutureCovariatesLocalForecastingModel):
         self.model.fit(
             series.values(),
             X=future_covariates.values() if future_covariates else None,
-            **fit_kwargs
+            **fit_kwargs,
         )
         return self
 

--- a/darts/models/forecasting/auto_arima.py
+++ b/darts/models/forecasting/auto_arima.py
@@ -99,7 +99,7 @@ class AutoARIMA(FutureCovariatesLocalForecastingModel):
         self,
         series: TimeSeries,
         future_covariates: Optional[TimeSeries] = None,
-        **fit_kwargs,
+        **kwargs,
     ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
@@ -107,7 +107,7 @@ class AutoARIMA(FutureCovariatesLocalForecastingModel):
         self.model.fit(
             series.values(),
             X=future_covariates.values() if future_covariates else None,
-            **fit_kwargs,
+            **kwargs,
         )
         return self
 

--- a/darts/models/forecasting/auto_arima.py
+++ b/darts/models/forecasting/auto_arima.py
@@ -95,12 +95,19 @@ class AutoARIMA(FutureCovariatesLocalForecastingModel):
     def supports_multivariate(self) -> bool:
         return False
 
-    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+    def _fit(
+        self,
+        series: TimeSeries,
+        future_covariates: Optional[TimeSeries] = None,
+        **fit_kwargs
+    ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
         series = self.training_series
         self.model.fit(
-            series.values(), X=future_covariates.values() if future_covariates else None
+            series.values(),
+            X=future_covariates.values() if future_covariates else None,
+            **fit_kwargs
         )
         return self
 

--- a/darts/models/forecasting/croston.py
+++ b/darts/models/forecasting/croston.py
@@ -123,7 +123,9 @@ class Croston(FutureCovariatesLocalForecastingModel):
     def supports_multivariate(self) -> bool:
         return False
 
-    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+    def _fit(
+        self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None, **_
+    ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
         series = self.training_series

--- a/darts/models/forecasting/croston.py
+++ b/darts/models/forecasting/croston.py
@@ -124,7 +124,10 @@ class Croston(FutureCovariatesLocalForecastingModel):
         return False
 
     def _fit(
-        self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None, **_
+        self,
+        series: TimeSeries,
+        future_covariates: Optional[TimeSeries] = None,
+        **kwargs,
     ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
@@ -137,6 +140,7 @@ class Croston(FutureCovariatesLocalForecastingModel):
                 if future_covariates is not None
                 else None
             ),
+            **kwargs,
         )
 
         return self

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -94,14 +94,14 @@ class ExponentialSmoothing(LocalForecastingModel):
         self.model = None
         np.random.seed(random_state)
 
-    def fit(self, series: TimeSeries, **fit_kwargs):
+    def fit(self, series: TimeSeries, **kwargs):
         """Fit/train the model on the (single) provided series.
 
         Parameters
         ----------
         series
             The model will be trained to forecast this time series.
-        fit_kwargs
+        kwargs
             Some optional keyword arguments that will be used to call
             :func:`statsmodels.tsa.holtwinters.ExponentialSmoothing.fit()`.
             See `the documentation
@@ -138,7 +138,7 @@ class ExponentialSmoothing(LocalForecastingModel):
             dates=series.time_index if series.has_datetime_index else None,
             **self.constructor_kwargs,
         )
-        hw_results = hw_model.fit(**fit_kwargs)
+        hw_results = hw_model.fit(**kwargs)
         self.model = hw_results
 
         if self.infer_seasonal_periods:

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -3,7 +3,7 @@ Exponential Smoothing
 ---------------------
 """
 
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import numpy as np
 import statsmodels.tsa.holtwinters as hw
@@ -24,8 +24,7 @@ class ExponentialSmoothing(LocalForecastingModel):
         seasonal: Optional[SeasonalityMode] = SeasonalityMode.ADDITIVE,
         seasonal_periods: Optional[int] = None,
         random_state: int = 0,
-        kwargs: Optional[Dict[str, Any]] = None,
-        **fit_kwargs,
+        **kwargs,
     ):
         """Exponential Smoothing
 
@@ -66,11 +65,6 @@ class ExponentialSmoothing(LocalForecastingModel):
             :func:`statsmodels.tsa.holtwinters.ExponentialSmoothing()`.
             See `the documentation
             <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.ExponentialSmoothing.html>`_.
-        fit_kwargs
-            Some optional keyword arguments that will be used to call
-            :func:`statsmodels.tsa.holtwinters.ExponentialSmoothing.fit()`.
-            See `the documentation
-            <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.ExponentialSmoothing.fit.html>`_.
 
         Examples
         --------
@@ -96,12 +90,28 @@ class ExponentialSmoothing(LocalForecastingModel):
         self.seasonal = seasonal
         self.infer_seasonal_periods = seasonal_periods is None
         self.seasonal_periods = seasonal_periods
-        self.constructor_kwargs = dict() if kwargs is None else kwargs
-        self.fit_kwargs = fit_kwargs
+        self.constructor_kwargs = kwargs
         self.model = None
         np.random.seed(random_state)
 
-    def fit(self, series: TimeSeries):
+    def fit(self, series: TimeSeries, **fit_kwargs):
+        """Fit/train the model on the (single) provided series.
+
+        Parameters
+        ----------
+        series
+            The model will be trained to forecast this time series.
+        fit_kwargs
+            Some optional keyword arguments that will be used to call
+            :func:`statsmodels.tsa.holtwinters.ExponentialSmoothing.fit()`.
+            See `the documentation
+            <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.ExponentialSmoothing.fit.html>`_.
+
+        Returns
+        -------
+        self
+            Fitted model.
+        """
         super().fit(series)
         self._assert_univariate(series)
         series = self.training_series
@@ -128,7 +138,7 @@ class ExponentialSmoothing(LocalForecastingModel):
             dates=series.time_index if series.has_datetime_index else None,
             **self.constructor_kwargs,
         )
-        hw_results = hw_model.fit(**self.fit_kwargs)
+        hw_results = hw_model.fit(**fit_kwargs)
         self.model = hw_results
 
         if self.infer_seasonal_periods:

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -2906,7 +2906,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
         self,
         series: TimeSeries,
         future_covariates: Optional[TimeSeries] = None,
-        **fit_kwargs,
+        **kwargs,
     ):
         """Fit/train the model on the (single) provided series.
 
@@ -2920,7 +2920,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
             A time series of future-known covariates. This time series will not be forecasted, but can be used by
             some models as an input. It must contain at least the same time steps/indices as the target `series`.
             If it is longer than necessary, it will be automatically trimmed.
-        fit_kwargs
+        kwargs
             Optional keyword arguments that will be passed to the fit function of the underlying model if supported
             by the underlying model.
 
@@ -2954,7 +2954,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
 
         super().fit(series)
 
-        return self._fit(series, future_covariates=future_covariates, **fit_kwargs)
+        return self._fit(series, future_covariates=future_covariates, **kwargs)
 
     @abstractmethod
     def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -2956,7 +2956,12 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
         return self._fit(series, future_covariates=future_covariates, **kwargs)
 
     @abstractmethod
-    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+    def _fit(
+        self,
+        series: TimeSeries,
+        future_covariates: Optional[TimeSeries] = None,
+        **kwargs,
+    ):
         """Fits/trains the model on the provided series.
         DualCovariatesModels must implement the fit logic in this method.
         """

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -2902,7 +2902,12 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
     All implementations must implement the :func:`_fit()` and :func:`_predict()` methods.
     """
 
-    def fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+    def fit(
+        self,
+        series: TimeSeries,
+        future_covariates: Optional[TimeSeries] = None,
+        **fit_kwargs,
+    ):
         """Fit/train the model on the (single) provided series.
 
         Optionally, a future covariates series can be provided as well.
@@ -2915,6 +2920,9 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
             A time series of future-known covariates. This time series will not be forecasted, but can be used by
             some models as an input. It must contain at least the same time steps/indices as the target `series`.
             If it is longer than necessary, it will be automatically trimmed.
+        fit_kwargs
+            Optional keyword arguments that will be passed to the fit function of the underlying model if supported
+            by the underlying model.
 
         Returns
         -------
@@ -2946,7 +2954,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
 
         super().fit(series)
 
-        return self._fit(series, future_covariates=future_covariates)
+        return self._fit(series, future_covariates=future_covariates, **fit_kwargs)
 
     @abstractmethod
     def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -2921,8 +2921,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
             some models as an input. It must contain at least the same time steps/indices as the target `series`.
             If it is longer than necessary, it will be automatically trimmed.
         kwargs
-            Optional keyword arguments that will be passed to the fit function of the underlying model if supported
-            by the underlying model.
+            Optional keyword arguments that will be passed to the fit function of the underlying model.
 
         Returns
         -------

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -203,7 +203,12 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                 # Use 0 as default value
                 self._floor = 0
 
-    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+    def _fit(
+        self,
+        series: TimeSeries,
+        future_covariates: Optional[TimeSeries] = None,
+        **fit_kwargs,
+    ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
         series = self.training_series
@@ -249,10 +254,10 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         if self.suppress_stdout_stderr:
             self._execute_and_suppress_output(
-                self.model.fit, logger, logging.WARNING, fit_df
+                self.model.fit, logger, logging.WARNING, fit_df, **fit_kwargs
             )
         else:
-            self.model.fit(fit_df)
+            self.model.fit(fit_df, **fit_kwargs)
 
         return self
 
@@ -348,11 +353,13 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             condition_name = attributes["condition_name"]
             if condition_name is not None:
                 if condition_name not in future_covariates_columns:
-                    invalid_conditional_seasonalities.append((
-                        seasonality_name,
-                        condition_name,
-                        "column missing",
-                    ))
+                    invalid_conditional_seasonalities.append(
+                        (
+                            seasonality_name,
+                            condition_name,
+                            "column missing",
+                        )
+                    )
                     continue
                 if (
                     not future_covariates[condition_name]
@@ -360,11 +367,13 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                     .isin([True, False])
                     .all()
                 ):
-                    invalid_conditional_seasonalities.append((
-                        seasonality_name,
-                        condition_name,
-                        "invalid values",
-                    ))
+                    invalid_conditional_seasonalities.append(
+                        (
+                            seasonality_name,
+                            condition_name,
+                            "invalid values",
+                        )
+                    )
                     continue
                 conditional_seasonality_covariates.append(condition_name)
 
@@ -597,19 +606,23 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         seconds_per_day = 86400
         days = 0
-        if freq in ["A", "BA", "Y", "BY", "RE"] or freq.startswith((
-            "A",
-            "BA",
-            "Y",
-            "BY",
-            "RE",
-        )):  # year
+        if freq in ["A", "BA", "Y", "BY", "RE"] or freq.startswith(
+            (
+                "A",
+                "BA",
+                "Y",
+                "BY",
+                "RE",
+            )
+        ):  # year
             days = 365.25
-        elif freq in ["Q", "BQ", "REQ"] or freq.startswith((
-            "Q",
-            "BQ",
-            "REQ",
-        )):  # quarter
+        elif freq in ["Q", "BQ", "REQ"] or freq.startswith(
+            (
+                "Q",
+                "BQ",
+                "REQ",
+            )
+        ):  # quarter
             days = 3 * 30.4375
         elif freq in [
             "M",
@@ -618,7 +631,9 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             "SM",
             "LWOM",
             "WOM",
-        ] or freq.startswith(("M", "BME", "BS", "CBM", "SM", "LWOM", "WOM")):  # month
+        ] or freq.startswith(
+            ("M", "BME", "BS", "CBM", "SM", "LWOM", "WOM")
+        ):  # month
             days = 30.4375
         elif freq == "W" or freq.startswith("W-"):  # week
             days = 7.0

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -207,7 +207,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
         self,
         series: TimeSeries,
         future_covariates: Optional[TimeSeries] = None,
-        **fit_kwargs,
+        **kwargs,
     ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
@@ -254,10 +254,10 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         if self.suppress_stdout_stderr:
             self._execute_and_suppress_output(
-                self.model.fit, logger, logging.WARNING, fit_df, **fit_kwargs
+                self.model.fit, logger, logging.WARNING, fit_df, **kwargs
             )
         else:
-            self.model.fit(fit_df, **fit_kwargs)
+            self.model.fit(fit_df, **kwargs)
 
         return self
 

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -353,13 +353,11 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             condition_name = attributes["condition_name"]
             if condition_name is not None:
                 if condition_name not in future_covariates_columns:
-                    invalid_conditional_seasonalities.append(
-                        (
-                            seasonality_name,
-                            condition_name,
-                            "column missing",
-                        )
-                    )
+                    invalid_conditional_seasonalities.append((
+                        seasonality_name,
+                        condition_name,
+                        "column missing",
+                    ))
                     continue
                 if (
                     not future_covariates[condition_name]
@@ -367,13 +365,11 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                     .isin([True, False])
                     .all()
                 ):
-                    invalid_conditional_seasonalities.append(
-                        (
-                            seasonality_name,
-                            condition_name,
-                            "invalid values",
-                        )
-                    )
+                    invalid_conditional_seasonalities.append((
+                        seasonality_name,
+                        condition_name,
+                        "invalid values",
+                    ))
                     continue
                 conditional_seasonality_covariates.append(condition_name)
 
@@ -606,23 +602,19 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         seconds_per_day = 86400
         days = 0
-        if freq in ["A", "BA", "Y", "BY", "RE"] or freq.startswith(
-            (
-                "A",
-                "BA",
-                "Y",
-                "BY",
-                "RE",
-            )
-        ):  # year
+        if freq in ["A", "BA", "Y", "BY", "RE"] or freq.startswith((
+            "A",
+            "BA",
+            "Y",
+            "BY",
+            "RE",
+        )):  # year
             days = 365.25
-        elif freq in ["Q", "BQ", "REQ"] or freq.startswith(
-            (
-                "Q",
-                "BQ",
-                "REQ",
-            )
-        ):  # quarter
+        elif freq in ["Q", "BQ", "REQ"] or freq.startswith((
+            "Q",
+            "BQ",
+            "REQ",
+        )):  # quarter
             days = 3 * 30.4375
         elif freq in [
             "M",
@@ -631,9 +623,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             "SM",
             "LWOM",
             "WOM",
-        ] or freq.startswith(
-            ("M", "BME", "BS", "CBM", "SM", "LWOM", "WOM")
-        ):  # month
+        ] or freq.startswith(("M", "BME", "BS", "CBM", "SM", "LWOM", "WOM")):  # month
             days = 30.4375
         elif freq == "W" or freq.startswith("W-"):  # week
             days = 7.0

--- a/darts/models/forecasting/sf_auto_arima.py
+++ b/darts/models/forecasting/sf_auto_arima.py
@@ -89,7 +89,9 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
         super().__init__(add_encoders=add_encoders)
         self.model = SFAutoARIMA(*autoarima_args, **autoarima_kwargs)
 
-    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+    def _fit(
+        self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None, **_
+    ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
         series = self.training_series

--- a/darts/models/forecasting/sf_auto_arima.py
+++ b/darts/models/forecasting/sf_auto_arima.py
@@ -90,7 +90,10 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
         self.model = SFAutoARIMA(*autoarima_args, **autoarima_kwargs)
 
     def _fit(
-        self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None, **_
+        self,
+        series: TimeSeries,
+        future_covariates: Optional[TimeSeries] = None,
+        **kwargs,
     ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
@@ -98,6 +101,7 @@ class StatsForecastAutoARIMA(FutureCovariatesLocalForecastingModel):
         self.model.fit(
             series.values(copy=False).flatten(),
             X=future_covariates.values(copy=False) if future_covariates else None,
+            **kwargs,
         )
         return self
 

--- a/darts/models/forecasting/sf_auto_ets.py
+++ b/darts/models/forecasting/sf_auto_ets.py
@@ -95,7 +95,9 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         self.model = SFAutoETS(*autoets_args, **autoets_kwargs)
         self._linreg = None
 
-    def _fit(self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None):
+    def _fit(
+        self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None, **_
+    ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
         series = self.training_series

--- a/darts/models/forecasting/sf_auto_ets.py
+++ b/darts/models/forecasting/sf_auto_ets.py
@@ -96,7 +96,10 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         self._linreg = None
 
     def _fit(
-        self, series: TimeSeries, future_covariates: Optional[TimeSeries] = None, **_
+        self,
+        series: TimeSeries,
+        future_covariates: Optional[TimeSeries] = None,
+        **kwargs,
     ):
         super()._fit(series, future_covariates)
         self._assert_univariate(series)
@@ -118,9 +121,7 @@ class StatsForecastAutoETS(FutureCovariatesLocalForecastingModel):
         else:
             target = series
 
-        self.model.fit(
-            target.values(copy=False).flatten(),
-        )
+        self.model.fit(target.values(copy=False).flatten(), **kwargs)
         return self
 
     def _predict(

--- a/darts/tests/models/forecasting/test_exponential_smoothing.py
+++ b/darts/tests/models/forecasting/test_exponential_smoothing.py
@@ -53,7 +53,7 @@ class TestExponentialSmoothing:
             "initial_trend": 0.2,
             "initial_seasonal": np.arange(1, 25),
         }
-        model = ExponentialSmoothing(kwargs=constructor_kwargs)
+        model = ExponentialSmoothing(**constructor_kwargs)
         model.fit(self.series)
         # must be checked separately, name is not consistent
         np.testing.assert_array_almost_equal(
@@ -70,12 +70,10 @@ class TestExponentialSmoothing:
         # using default optimization method
         model = ExponentialSmoothing()
         model.fit(self.series)
-        assert model.fit_kwargs == {}
         pred = model.predict(n=2)
 
         model_bis = ExponentialSmoothing()
         model_bis.fit(self.series)
-        assert model_bis.fit_kwargs == {}
         pred_bis = model_bis.predict(n=2)
 
         # two methods with the same parameters should yield the same forecasts
@@ -83,9 +81,8 @@ class TestExponentialSmoothing:
         np.testing.assert_array_almost_equal(pred.values(), pred_bis.values())
 
         # change optimization method
-        model_ls = ExponentialSmoothing(method="least_squares")
-        model_ls.fit(self.series)
-        assert model_ls.fit_kwargs == {"method": "least_squares"}
+        model_ls = ExponentialSmoothing()
+        model_ls.fit(self.series, method="least_squares")
         pred_ls = model_ls.predict(n=2)
 
         # forecasts should be slightly different

--- a/darts/tests/models/forecasting/test_local_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_local_forecasting_models.py
@@ -164,11 +164,13 @@ class TestLocalForecastingModels:
             assert os.path.exists(p)
 
         assert (
-            len([
-                p
-                for p in os.listdir(tmpdir_module)
-                if p.startswith(type(model).__name__)
-            ])
+            len(
+                [
+                    p
+                    for p in os.listdir(tmpdir_module)
+                    if p.startswith(type(model).__name__)
+                ]
+            )
             == len(full_model_paths) + 1
         )
 
@@ -647,7 +649,7 @@ class TestLocalForecastingModels:
             (
                 ExponentialSmoothing(),
                 "ExponentialSmoothing(trend=ModelMode.ADDITIVE, damped=False, seasonal=SeasonalityMode.ADDITIVE, "
-                + "seasonal_periods=None, random_state=0, kwargs=None)",
+                + "seasonal_periods=None, random_state=0)",
             ),  # no params changed
             (
                 ARIMA(1, 1, 1),

--- a/darts/tests/models/forecasting/test_local_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_local_forecasting_models.py
@@ -164,13 +164,11 @@ class TestLocalForecastingModels:
             assert os.path.exists(p)
 
         assert (
-            len(
-                [
-                    p
-                    for p in os.listdir(tmpdir_module)
-                    if p.startswith(type(model).__name__)
-                ]
-            )
+            len([
+                p
+                for p in os.listdir(tmpdir_module)
+                if p.startswith(type(model).__name__)
+            ])
             == len(full_model_paths) + 1
         )
 


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2438 .

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->
Basically as described in #2438 
- Updated the `FutureCovariatesLocalForecastingModel.fit` function to pass `**kwargs` to each models `._fit` function. There the arguments are either swallowed (if the underlying model's `fit` function does not support additional arguments) or passed to the underlying model's fit function (`Prophet`, `AutoArima`).
- Updated `ExponentialSmoothing` function signatures for consistency: 
  - kwargs to be passed to the underlying models constructor can now be specified as kwargs in the `ExponentialSmoothing` constructor (rather than as a `dict`)
  - kwargs to be passed to the underlying models `fit` function can now be specified as kwargs in the `ExponentialSmoothing.fit` function
- Updated docstrings accordingly

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
