### PR TITLE
Fix/RegressionEnsembleModel save and load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 ### For users of the library:
 
 **Improved**
+
 - Added `IQRDetector`, that allows to detect anomalies using the interquartile range algorithm. [#2441] by [Igor Urbanik](https://github.com/u8-igor).
 - Added hyperparameters controlling the hidden layer sizes for the feature encoders in `TiDEModel`. [#2408](https://github.com/unit8co/darts/issues/2408) by [eschibli](https://github.com/eschibli).
 - Made README's forecasting model support table more colorblind-friendly. [#2433](https://github.com/unit8co/darts/pull/2433)
@@ -21,6 +22,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug with `xgboost>=2.1.0`, where multi output regression was not properly handled. [#2426](https://github.com/unit8co/darts/pull/2426) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `ShapExplainer.explain()` with some selected `target_components` and a regression model that natively supports multi output regression: The target components were not properly mapped. [#2428](https://github.com/unit8co/darts/pull/2428) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `fit()` with a `RegressionModel` that uses an underlying `model` which does not support `sample_weight`. [#2445](https://github.com/unit8co/darts/pull/2445) by [He Weilin](https://github.com/cnhwl).
+- Fixed a bug when using `save()` and `load()` with a `RegressionEnsembleModel` that ensembles any `TorchForecastingModel`. [#2437](https://github.com/unit8co/darts/pull/2445) by [He Weilin](https://github.com/cnhwl).
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 - Added `IQRDetector`, that allows to detect anomalies using the interquartile range algorithm. [#2441] by [Igor Urbanik](https://github.com/u8-igor).
+- Added hyperparameters controlling the hidden layer sizes for the feature encoders in `TiDEModel`. [#2408](https://github.com/unit8co/darts/issues/2408) by [eschibli](https://github.com/eschibli).
 - Made README's forecasting model support table more colorblind-friendly. [#2433](https://github.com/unit8co/darts/pull/2433)
 - Updated the Ray Tune Hyperparameter Optimization example in the [user guide](https://unit8co.github.io/darts/userguide/hyperparameter_optimization.html) to work with the latest `ray` versions (`>=2.31.0`). [#2459](https://github.com/unit8co/darts/pull/2459) by [He Weilin](https://github.com/cnhwl).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug with `xgboost>=2.1.0`, where multi output regression was not properly handled. [#2426](https://github.com/unit8co/darts/pull/2426) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `ShapExplainer.explain()` with some selected `target_components` and a regression model that natively supports multi output regression: The target components were not properly mapped. [#2428](https://github.com/unit8co/darts/pull/2428) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `fit()` with a `RegressionModel` that uses an underlying `model` which does not support `sample_weight`. [#2445](https://github.com/unit8co/darts/pull/2445) by [He Weilin](https://github.com/cnhwl).
-- Fixed a bug when using `save()` and `load()` with a `RegressionEnsembleModel` that ensembles any `TorchForecastingModel`. [#2437](https://github.com/unit8co/darts/pull/2445) by [He Weilin](https://github.com/cnhwl).
+- Fixed a bug when using `save()` and `load()` with a `RegressionEnsembleModel` that ensembles any `TorchForecastingModel`. [#2437](https://github.com/unit8co/darts/issues/2437) by [He Weilin](https://github.com/cnhwl).
 
 **Dependencies**
 

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -386,7 +386,9 @@ class EnsembleModel(GlobalForecastingModel):
         self, path: Optional[Union[str, os.PathLike, BinaryIO]] = None, **pkl_kwargs
     ) -> None:
         """
-        Saves the model under a given path or file handle.
+        Saves the ensemble model under a given path or file handle.
+
+        If `forecasting_models` contains TorchForecastingModel, the checkpoint file would be saved.
 
         Example for saving and loading a :class:`RegressionEnsembleModel`:
 
@@ -403,16 +405,19 @@ class EnsembleModel(GlobalForecastingModel):
                         regression_train_n_points=10,
                 )
 
-                model.save("my_model.pkl")
-                model_loaded = RegressionEnsembleModel.load("my_model.pkl")
+                model.save("my_ensemble_model.pkl")
+                model_loaded = RegressionEnsembleModel.load("my_ensemble_model.pkl")
             ..
 
         Parameters
         ----------
         path
-            Path or file handle under which to save the model at its current state. If no path is specified, the model
-            is automatically saved under ``"{ModelClass}_{YYYY-mm-dd_HH_MM_SS}.pkl"``.
-            E.g., ``"RegressionEnsembleModel_2020-01-01_12_00_00.pkl"``.
+            Path or file handle under which to save the ensemble model at its current state. If no path is specified,
+            the ensemble model is automatically saved under ``"{RegressionEnsembleModel}_{YYYY-mm-dd_HH_MM_SS}.pkl"``.
+            If the ith model of `forecasting_models` is a TorchForecastingModel, the checkpoint file would be saved
+            under ``"{path}.{ithModelClass}_{i}.ckpt"``.
+            E.g., ``"RegressionEnsembleModel_2024-07-25_14_58_53.pkl"`` and
+            ``"RegressionEnsembleModel_2024-07-25_14_58_53.pkl.TiDEModel_1.ckpt"``
         pkl_kwargs
             Keyword arguments passed to `pickle.dump()`
         """
@@ -443,7 +448,6 @@ class EnsembleModel(GlobalForecastingModel):
                 path_ptl_ckpt = f"{path}.{type(m).__name__}_{i}.ckpt"
                 if m.trainer is not None:
                     m.trainer.save_checkpoint(path_ptl_ckpt)
-                    print(path_ptl_ckpt + " is saved!")
                 # TODO: keep track of PyTorch Lightning to see if they implement model checkpoint saving
                 #  without having to call fit/predict/validate/test before
                 # try to recover original automatic PL checkpoint
@@ -460,12 +464,12 @@ class EnsembleModel(GlobalForecastingModel):
     @staticmethod
     def load(path: Union[str, os.PathLike, BinaryIO]) -> "ForecastingModel":
         """
-        Loads the model from a given path or file handle.
+        Loads the ensemble model from a given path or file handle.
 
         Parameters
         ----------
         path
-            Path or file handle from which to load the model.
+            Path or file handle from which to load the ensemble model.
         """
 
         if isinstance(path, (str, os.PathLike)):

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -2,9 +2,7 @@
 Ensemble Model Base Class
 """
 
-import io
 import os
-import pickle
 from abc import abstractmethod
 from typing import BinaryIO, List, Optional, Sequence, Tuple, Union
 

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -15,9 +15,14 @@ from darts.models.forecasting.forecasting_model import (
     GlobalForecastingModel,
     LocalForecastingModel,
 )
-from darts.models.forecasting.torch_forecasting_model import TorchForecastingModel
+from darts.models.utils import TORCH_AVAILABLE
 from darts.timeseries import TimeSeries, concatenate
 from darts.utils.ts_utils import series2seq
+
+if TORCH_AVAILABLE:
+    from darts.models.forecasting.torch_forecasting_model import TorchForecastingModel
+else:
+    TorchForecastingModel = None
 
 logger = get_logger(__name__)
 
@@ -443,7 +448,7 @@ class EnsembleModel(GlobalForecastingModel):
             )
 
         for i, m in enumerate(self.forecasting_models):
-            if issubclass(type(m), TorchForecastingModel):
+            if TORCH_AVAILABLE and issubclass(type(m), TorchForecastingModel):
                 # save the LightningModule checkpoint
                 path_ptl_ckpt = f"{path}.{type(m).__name__}_{i}.ckpt"
                 if m.trainer is not None:

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -462,7 +462,7 @@ class EnsembleModel(GlobalForecastingModel):
                         )
 
     @staticmethod
-    def load(path: Union[str, os.PathLike, BinaryIO]) -> "ForecastingModel":
+    def load(path: Union[str, os.PathLike, BinaryIO]) -> "EnsembleModel":
         """
         Loads the ensemble model from a given path or file handle.
 

--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -486,7 +486,7 @@ class EnsembleModel(GlobalForecastingModel):
         for i, m in enumerate(model.forecasting_models):
             if issubclass(type(m), TorchForecastingModel):
                 # if a checkpoint was saved, we also load the PyTorch LightningModule from checkpoint
-                path_ptl_ckpt = f"{path}.{type(m).__name__}_{i}.ckpt"
+                path_ptl_ckpt = f"{path}.{type(m).__name__}_{i}.pt.ckpt"
                 if os.path.exists(path_ptl_ckpt):
                     m.model = m._load_from_checkpoint(path_ptl_ckpt)
                 else:

--- a/darts/models/forecasting/tide_model.py
+++ b/darts/models/forecasting/tide_model.py
@@ -81,6 +81,8 @@ class _TideModule(PLMixedCovariatesModule):
         temporal_width_future: int,
         use_layer_norm: bool,
         dropout: float,
+        temporal_hidden_size_past: Optional[int] = None,
+        temporal_hidden_size_future: Optional[int] = None,
         **kwargs,
     ):
         """Pytorch module implementing the TiDE architecture.
@@ -111,6 +113,10 @@ class _TideModule(PLMixedCovariatesModule):
             The width of the past covariate embedding space.
         temporal_width_future
             The width of the future covariate embedding space.
+        temporal_hidden_size_past
+            The width of the hidden layers in the past covariate projection Residual Block.
+        temporal_hidden_size_future
+            The width of the hidden layers in the future covariate projection Residual Block.
         use_layer_norm
             Whether to use layer normalization in the Residual Blocks.
         dropout
@@ -148,6 +154,8 @@ class _TideModule(PLMixedCovariatesModule):
         self.dropout = dropout
         self.temporal_width_past = temporal_width_past
         self.temporal_width_future = temporal_width_future
+        self.temporal_hidden_size_past = temporal_hidden_size_past or hidden_size
+        self.temporal_hidden_size_future = temporal_hidden_size_future or hidden_size
 
         # past covariates handling: either feature projection, raw features, or no features
         self.past_cov_projection = None
@@ -156,7 +164,7 @@ class _TideModule(PLMixedCovariatesModule):
             self.past_cov_projection = _ResidualBlock(
                 input_dim=self.past_cov_dim,
                 output_dim=temporal_width_past,
-                hidden_size=hidden_size,
+                hidden_size=temporal_hidden_size_past,
                 use_layer_norm=use_layer_norm,
                 dropout=dropout,
             )
@@ -174,7 +182,7 @@ class _TideModule(PLMixedCovariatesModule):
             self.future_cov_projection = _ResidualBlock(
                 input_dim=future_cov_dim,
                 output_dim=temporal_width_future,
-                hidden_size=hidden_size,
+                hidden_size=temporal_hidden_size_future,
                 use_layer_norm=use_layer_norm,
                 dropout=dropout,
             )
@@ -375,6 +383,8 @@ class TiDEModel(MixedCovariatesTorchModel):
         hidden_size: int = 128,
         temporal_width_past: int = 4,
         temporal_width_future: int = 4,
+        temporal_hidden_size_past: int = None,
+        temporal_hidden_size_future: int = None,
         temporal_decoder_hidden: int = 32,
         use_layer_norm: bool = False,
         dropout: float = 0.1,
@@ -424,11 +434,19 @@ class TiDEModel(MixedCovariatesTorchModel):
         hidden_size
             The width of the layers in the residual blocks of the encoder and decoder.
         temporal_width_past
-            The width of the layers in the past covariate projection residual block. If `0`,
+            The width of the output layer in the past covariate projection residual block. If `0`,
             will bypass feature projection and use the raw feature data.
         temporal_width_future
-            The width of the layers in the future covariate projection residual block. If `0`,
+            The width of the output layer in the future covariate projection residual block. If `0`,
             will bypass feature projection and use the raw feature data.
+        temporal_hidden_size_past
+            The width of the hidden layer in the past covariate projection residual block. If not specified,
+            defaults to `hidden_size`, which is the width of the hidden layer in the encoder and decoder.
+            This is likely to be too large in many cases, so it is recommended to set this parameter explicitly.
+        temporal_hidden_size_future
+            The width of the hidden layer in the future covariate projection residual block. If not specified,
+            defaults to `hidden_size`, which is the width of the hidden layer in the encoder and decoder.
+            This is likely to be too large in many cases, so it is recommended to set this parameter explicitly.
         temporal_decoder_hidden
             The width of the layers in the temporal decoder.
         use_layer_norm
@@ -626,6 +644,8 @@ class TiDEModel(MixedCovariatesTorchModel):
         self.hidden_size = hidden_size
         self.temporal_width_past = temporal_width_past
         self.temporal_width_future = temporal_width_future
+        self.temporal_hidden_size_past = temporal_hidden_size_past or hidden_size
+        self.temporal_hidden_size_future = temporal_hidden_size_future or hidden_size
         self.temporal_decoder_hidden = temporal_decoder_hidden
 
         self._considers_static_covariates = use_static_covariates
@@ -693,6 +713,8 @@ class TiDEModel(MixedCovariatesTorchModel):
             hidden_size=self.hidden_size,
             temporal_width_past=self.temporal_width_past,
             temporal_width_future=self.temporal_width_future,
+            temporal_hidden_size_past=self.temporal_hidden_size_past,
+            temporal_hidden_size_future=self.temporal_hidden_size_future,
             temporal_decoder_hidden=self.temporal_decoder_hidden,
             use_layer_norm=self.use_layer_norm,
             dropout=self.dropout,
@@ -706,3 +728,11 @@ class TiDEModel(MixedCovariatesTorchModel):
     @property
     def supports_multivariate(self) -> bool:
         return True
+
+    def _check_ckpt_parameters(self, tfm_save):
+        # new parameters were added that will break loading weights
+        new_params = ["temporal_hidden_size_past", "temporal_hidden_size_future"]
+        for param in new_params:
+            if param not in tfm_save.model_params:
+                tfm_save.model_params[param] = None
+        super()._check_ckpt_parameters(tfm_save)

--- a/darts/models/utils.py
+++ b/darts/models/utils.py
@@ -2,6 +2,13 @@ from darts.logging import get_logger, raise_log
 
 logger = get_logger(__name__)
 
+try:
+    import torch  # noqa: F401
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+
 
 class NotImportedModule:
     """Helper class for handling import errors of optional dependencies."""

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -785,7 +785,7 @@ class TestEnsembleModels:
                 [
                     LinearRegressionModel(lags=[-1]),
                     NaiveSeasonal(K=1),
-                    RNNModel(10, n_epochs=1),
+                    RNNModel(10, n_epochs=1, **tfm_kwargs),
                 ],
                 **kwargs,
             )

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -824,7 +824,6 @@ class TestEnsembleModels:
         for filename in os.listdir(full_model_path_str):
             if filename.endswith(".pkl"):
                 pkl_files.append(os.path.join(full_model_path_str, filename))
-        print(pkl_files)
         for p in pkl_files:
             loaded_model = model_cls.load(p)
             assert model_prediction == loaded_model.predict(5)

--- a/darts/tests/models/forecasting/test_ensemble_models.py
+++ b/darts/tests/models/forecasting/test_ensemble_models.py
@@ -799,11 +799,12 @@ class TestEnsembleModels:
 
         # test save
         model.save()
+        model.save(os.path.join(full_model_path_str, f"{model_cls.__name__}.pkl"))
 
         assert os.path.exists(full_model_path_str)
         files = os.listdir(full_model_path_str)
         if TORCH_AVAILABLE:
-            assert len(files) == 3
+            assert len(files) == 6
             for f in files:
                 assert f.startswith(model_cls.__name__)
             suffix_counts = {
@@ -812,19 +813,20 @@ class TestEnsembleModels:
                 )
                 for suffix in expected_suffixes
             }
-            assert all(count == 1 for count in suffix_counts.values())
+            assert all(count == 2 for count in suffix_counts.values())
         else:
-            assert (
-                len(files) == 1
-                and files[0].startswith(model_cls.__name__)
-                and files[0].endswith(".pkl")
-            )
+            assert len(files) == 2
+            for f in files:
+                assert f.startswith(model_cls.__name__) and f.endswith(".pkl")
 
         # test load
-        loaded_model = model_cls.load(
-            os.path.join(full_model_path_str, min(files, key=len))
-        )
-
-        assert model_prediction == loaded_model.predict(5)
+        pkl_files = []
+        for filename in os.listdir(full_model_path_str):
+            if filename.endswith(".pkl"):
+                pkl_files.append(os.path.join(full_model_path_str, filename))
+        print(pkl_files)
+        for p in pkl_files:
+            loaded_model = model_cls.load(p)
+            assert model_prediction == loaded_model.predict(5)
 
         os.chdir(cwd)


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2437.

### Summary

Since `EnsembleModel` uses the `save` and `load` methods of the `ForecastingModel` class, it is not possible to save the .ckpt file of `TorchForecastingModel`. In this case, even torch model does not load the .ckpt file, its `model._fit_called` attribute remains True, which may cause `AttributeError: 'NoneType' object has no attribute 'set_predict_parameters'`. 

Therefore, I overwrote the `save` and `load` methods of the `EnsembleModel` to save and load the .ckpt file of the `TorchForecastingModel` if it exists in the `forecasting_models` list.