### PR TITLE
Convert pd_series1 to float64 type

### DIFF
--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -74,7 +74,9 @@ class TestMetrics:
     pd_train_not_periodic = pd.Series(
         range(31), index=pd.date_range("20121201", "20121231")
     )
-    pd_series1 = pd.Series(range(10), index=pd.date_range("20130101", "20130110"))
+    pd_series1 = pd.Series(
+        range(10), index=pd.date_range("20130101", "20130110")
+    ).astype("float64")
     pd_series2 = pd.Series(
         np.random.rand(10) * 10 + 1, index=pd.date_range("20130101", "20130110")
     )


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #.
Removes warning:
```
darts/tests/metrics/test_metrics.py:88
  /home/runner/work/darts/darts/darts/tests/metrics/test_metrics.py:88: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '4.5' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
    pd_series1[:] = pd_series1.mean()
```
### Summary
Setting in `pd_series1[:] `with type `int64` to `pd_series1.mean()` with type `float64` causes a warning. 
The average itself implies a float value. To avoid this, pd_series1 is converted to float64.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
