### PR TITLE
Minor fix: Use pd_series3 for series3 in tests

### DIFF
--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -21,7 +21,7 @@ class TestTimeSeries:
     pd_series3 = pd.Series(range(15, 25), index=times)
     series1: TimeSeries = TimeSeries.from_series(pd_series1)
     series2: TimeSeries = TimeSeries.from_series(pd_series2)
-    series3: TimeSeries = TimeSeries.from_series(pd_series2)
+    series3: TimeSeries = TimeSeries.from_series(pd_series3)
 
     def test_creation(self):
         series_test = TimeSeries.from_series(self.pd_series1)
@@ -536,19 +536,19 @@ class TestTimeSeries:
         with pytest.raises(ValueError):
             self.series1.rescale_with_value(1)
 
-        seriesA = self.series3.rescale_with_value(0)
+        seriesA = self.series2.rescale_with_value(0)
         assert np.all(seriesA.values() == 0)
 
-        seriesB = self.series3.rescale_with_value(-5)
-        assert self.series3 * -1.0 == seriesB
+        seriesB = self.series2.rescale_with_value(-5)
+        assert self.series2 * -1.0 == seriesB
 
-        seriesC = self.series3.rescale_with_value(1)
-        assert self.series3 * 0.2 == seriesC
+        seriesC = self.series2.rescale_with_value(1)
+        assert self.series2 * 0.2 == seriesC
 
-        seriesD = self.series3.rescale_with_value(
+        seriesD = self.series2.rescale_with_value(
             1e20
         )  # TODO: test will fail if value > 1e24 due to num imprecision
-        assert self.series3 * 0.2e20 == seriesD
+        assert self.series2 * 0.2e20 == seriesD
 
     @staticmethod
     def helper_test_intersect(freq, is_mixed_freq: bool, is_univariate: bool):


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

I didn't open an issue for this tiny change because it's so small and internal to the tests.
Hope that's okay; will of course open issues for anything substantial.

### Summary

Minor fix to actually use `pd_series3` for `series3` in `test_timeseries.py` (instead of `pd_series2`).

Luckily only one test needed to be adjusted for everything to pass.

### Other Information

No entry in changelog because it's a negligible and internal change.

I read the contribution guidelines but it's my first contribution to Darts nonetheless, so I am more than happy to get notes or feedback :)

