### PR TITLE
Allow broadcasting single-sample TimeSeries onto multi-sample TimeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
 
-- Added support for broadcasting single-sample TimeSeries onto multi-sample TimeSeries. [#2476](https://https://github.com/unit8co/darts/pull/2476)
+- Added support for broadcasting to TimeSeries on component and sample level. [#2476](https://https://github.com/unit8co/darts/pull/2476)
   by [Joel L.](https://github.com/Joelius300).
 - Fixed bug preventing TimeSeries to be divided by xarray or ndarray. [#2476](https://https://github.com/unit8co/darts/pull/2476)
   by [Joel L.](https://github.com/Joelius300).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
 
-- Added support for broadcasting to TimeSeries on component and sample level. [#2476](https://https://github.com/unit8co/darts/pull/2476)
-  by [Joel L.](https://github.com/Joelius300).
-- Fixed bug preventing TimeSeries to be divided by xarray or ndarray. [#2476](https://https://github.com/unit8co/darts/pull/2476)
-  by [Joel L.](https://github.com/Joelius300).
-
 [Full Changelog](https://github.com/unit8co/darts/compare/0.30.0...master)
 
 ### For users of the library:
@@ -19,6 +14,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Added hyperparameters controlling the hidden layer sizes for the feature encoders in `TiDEModel`. [#2408](https://github.com/unit8co/darts/issues/2408) by [eschibli](https://github.com/eschibli).
 - Made README's forecasting model support table more colorblind-friendly. [#2433](https://github.com/unit8co/darts/pull/2433)
 - Updated the Ray Tune Hyperparameter Optimization example in the [user guide](https://unit8co.github.io/darts/userguide/hyperparameter_optimization.html) to work with the latest `ray` versions (`>=2.31.0`). [#2459](https://github.com/unit8co/darts/pull/2459) by [He Weilin](https://github.com/cnhwl).
+- Added support for broadcasting to TimeSeries on component and sample level. [#2476](https://https://github.com/unit8co/darts/pull/2476) by [Joel L.](https://github.com/Joelius300).
 
 **Fixed**
 
@@ -26,6 +22,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug with `xgboost>=2.1.0`, where multi output regression was not properly handled. [#2426](https://github.com/unit8co/darts/pull/2426) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `ShapExplainer.explain()` with some selected `target_components` and a regression model that natively supports multi output regression: The target components were not properly mapped. [#2428](https://github.com/unit8co/darts/pull/2428) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `fit()` with a `RegressionModel` that uses an underlying `model` which does not support `sample_weight`. [#2445](https://github.com/unit8co/darts/pull/2445) by [He Weilin](https://github.com/cnhwl).
+- Fixed a bug preventing TimeSeries to be divided by xarray or ndarray. [#2476](https://https://github.com/unit8co/darts/pull/2476) by [Joel L.](https://github.com/Joelius300).
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - Added support for broadcasting single-sample TimeSeries onto multi-sample TimeSeries. [#2476](https://https://github.com/unit8co/darts/pull/2476)
   by [Joel L.](https://github.com/Joelius300).
+- Fixed bug preventing TimeSeries to be divided by xarray or ndarray. [#2476](https://https://github.com/unit8co/darts/pull/2476)
+  by [Joel L.](https://github.com/Joelius300).
 
 [Full Changelog](https://github.com/unit8co/darts/compare/0.30.0...master)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
 
+- Added support for broadcasting single-sample TimeSeries onto multi-sample TimeSeries. [#2476](https://https://github.com/unit8co/darts/pull/2476)
+  by [Joel L.](https://github.com/Joelius300).
+
 [Full Changelog](https://github.com/unit8co/darts/compare/0.30.0...master)
 
 ### For users of the library:

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -975,6 +975,22 @@ class TestTimeSeries:
             # Cannot divide by 0.
             self.series1 / 0
 
+    def test_ops_array(self):
+        # can work with xarray directly
+        series2_x = self.series2.data_array(copy=False)
+        assert self.series1 + self.series2 == self.series1 + series2_x
+        assert self.series1 - self.series2 == self.series1 - series2_x
+        assert self.series1 * self.series2 == self.series1 * series2_x
+        assert self.series1 / self.series2 == self.series1 / series2_x
+        assert self.series1**self.series2 == self.series1**series2_x
+        # can work with ndarray directly
+        series2_nd = self.series2.all_values(copy=False)
+        assert self.series1 + self.series2 == self.series1 + series2_nd
+        assert self.series1 - self.series2 == self.series1 - series2_nd
+        assert self.series1 * self.series2 == self.series1 * series2_nd
+        assert self.series1 / self.series2 == self.series1 / series2_nd
+        assert self.series1**self.series2 == self.series1**series2_nd
+
     @pytest.mark.parametrize(
         "broadcast_components,broadcast_samples",
         itertools.product([True, False], [True, False]),

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4987,12 +4987,18 @@ class TimeSeries:
             )
             return self.__class__(xa_)
         elif isinstance(other, (TimeSeries, xr.DataArray, np.ndarray)):
-            if not (other.all_values(copy=False) != 0).all():
+            if isinstance(other, TimeSeries):
+                other_vals = other.data_array(copy=False).values
+            elif isinstance(other, xr.DataArray):
+                other_vals = other.values
+            else:
+                other_vals = other
+            if not (other_vals != 0).all():
                 raise_log(
                     ZeroDivisionError("Cannot divide by a TimeSeries with a value 0."),
                     logger,
                 )
-            return self._combine_arrays(other, lambda s1, s2: s1 / s2)
+            return self._combine_arrays(other_vals, lambda s1, s2: s1 / s2)
         else:
             raise_log(
                 TypeError(

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4604,11 +4604,16 @@ class TimeSeries:
         else:
             other_vals = other
 
+        t, c, s = self._xa.values.shape
         raise_if_not(
-            # exact shape match
+            # can combine arrays if shapes are equal (t, c, s)
             self._xa.values.shape == other_vals.shape
-            # or broadcast [x, y, 1] onto [x, y, z]
-            or other_vals.shape == (*self._xa.values.shape[:2], 1),
+            # or broadcast [t, 1, 1] onto [t, c, s]
+            or other_vals.shape == (t, 1, 1)
+            # or broadcast [t, c, 1] onto [t, c, s]
+            or other_vals.shape == (t, c, 1)
+            # or broadcast [t, 1, s] onto [t, c, s]
+            or other_vals.shape == (t, 1, s),
             "Attempted to perform operation on two TimeSeries of unequal shapes.",
             logger,
         )

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4604,19 +4604,24 @@ class TimeSeries:
         else:
             other_vals = other
 
-        t, c, s = self._xa.values.shape
-        raise_if_not(
+        t, c, s = self._xa.shape
+        other_shape = other_vals.shape
+        if not (
             # can combine arrays if shapes are equal (t, c, s)
-            self._xa.values.shape == other_vals.shape
+            other_shape == (t, c, s)
             # or broadcast [t, 1, 1] onto [t, c, s]
-            or other_vals.shape == (t, 1, 1)
+            or other_shape == (t, 1, 1)
             # or broadcast [t, c, 1] onto [t, c, s]
-            or other_vals.shape == (t, c, 1)
+            or other_shape == (t, c, 1)
             # or broadcast [t, 1, s] onto [t, c, s]
-            or other_vals.shape == (t, 1, s),
-            "Attempted to perform operation on two TimeSeries of unequal shapes.",
-            logger,
-        )
+            or other_shape == (t, 1, s),
+        ):
+            raise_log(
+                ValueError(
+                    "Attempted to perform operation on two TimeSeries of unequal shapes."
+                ),
+                logger=logger,
+            )
         new_xa = self._xa.copy()
         new_xa.values = combine_fn(new_xa.values, other_vals)
         return self.__class__(new_xa)

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4605,7 +4605,10 @@ class TimeSeries:
             other_vals = other
 
         raise_if_not(
-            self._xa.values.shape == other_vals.shape,
+            # exact shape match
+            self._xa.values.shape == other_vals.shape
+            # or broadcast [x, y, 1] onto [x, y, z]
+            or other_vals.shape == (*self._xa.values.shape[:2], 1),
             "Attempted to perform operation on two TimeSeries of unequal shapes.",
             logger,
         )


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2475

### Summary

Allows broadcasting TimeSeries with a single sample onto TimeSeries with multiple samples for element-wise operations like addition, subtraction, etc. Note that the underlying implementation already supports broadcasting, this PR only relaxes the safeguard regarding the shape-compatibility when combining two TimeSeries. Depending on the other uses of the `_combine_arrays` method, there could also be an argument that allows broadcasting like this but given that I don't know the code base well enough to judge that, I implemented the simpler version (and made sure that all the tests still pass).

### Other Information

This PR is a draft because it's still up for discussion what other types of broadcasting might be interesting to allow.

I read the contribution guidelines but it's my first non-negligible contribution to Darts nonetheless, so I am more than happy to get notes or feedback :)

Tested to work before and after merging #2474, but working on this PR here is also where I found that minor bug in the tests.
