### PR TITLE
fixes bug when plotting multivariate probabilistic series where the c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed bug when plotting a probabilistic multivariate series, where all confidence intervals (starting from 2nd component) had the same color as the median line. [#2532](https://github.com/unit8co/darts/pull/2532) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when passing an empty array to `TimeSeries.prepend/append_values()` raised an error. [#2522](https://github.com/unit8co/darts/pull/2522) by [Alessio Pellegrini](https://github.com/AlessiopSymplectic)
 - Fixed a bug with `TimeSeries.prepend/append_values()`, where the name of the (time) index was lost. [#2522](https://github.com/unit8co/darts/pull/2522) by [Alessio Pellegrini](https://github.com/AlessiopSymplectic)
 - Fixed a bug when using `from_group_dataframe()` with a `time_col` of type integer, where the resulting time index was wrongly converted to a DatetimeIndex. [#2512](https://github.com/unit8co/darts/pull/2512) by [Alessio Pellegrini](https://github.com/AlessiopSymplectic)

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4191,9 +4191,6 @@ class TimeSeries:
                 central_series = comp.mean(dim=DIMS[2])
 
             alpha = kwargs["alpha"] if "alpha" in kwargs else None
-            kwargs_central = deepcopy(kwargs)
-            if not self.is_deterministic:
-                kwargs_central["alpha"] = 1
             if custom_labels:
                 label_to_use = label[i]
             else:
@@ -4205,6 +4202,9 @@ class TimeSeries:
                     label_to_use = f"{label}_{comp_name}"
             kwargs["label"] = label_to_use
 
+            kwargs_central = deepcopy(kwargs)
+            if not self.is_deterministic:
+                kwargs_central["alpha"] = 1
             if central_series.shape[0] > 1:
                 p = central_series.plot(*args, ax=ax, **kwargs_central)
             # empty TimeSeries

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4191,8 +4191,9 @@ class TimeSeries:
                 central_series = comp.mean(dim=DIMS[2])
 
             alpha = kwargs["alpha"] if "alpha" in kwargs else None
+            kwargs_central = deepcopy(kwargs)
             if not self.is_deterministic:
-                kwargs["alpha"] = 1
+                kwargs_central["alpha"] = 1
             if custom_labels:
                 label_to_use = label[i]
             else:
@@ -4205,14 +4206,14 @@ class TimeSeries:
             kwargs["label"] = label_to_use
 
             if central_series.shape[0] > 1:
-                p = central_series.plot(*args, ax=ax, **kwargs)
+                p = central_series.plot(*args, ax=ax, **kwargs_central)
             # empty TimeSeries
             elif central_series.shape[0] == 0:
                 p = ax.plot(
                     [],
                     [],
                     *args,
-                    **kwargs,
+                    **kwargs_central,
                 )
                 ax.set_xlabel(self.time_index.name)
             else:
@@ -4221,7 +4222,7 @@ class TimeSeries:
                     central_series.values[0],
                     "o",
                     *args,
-                    **kwargs,
+                    **kwargs_central,
                 )
             color_used = p[0].get_color() if default_formatting else None
 


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #2533.

### Summary
- Fixes bug when plotting a probabilistic multivariate series, where all confidence intervals (starting from 2nd component) had the same color as the median line.

### Other Information

Before:
<img width="579" alt="image" src="https://github.com/user-attachments/assets/54a77cc4-a9a0-43f7-b2e7-2748b33fb14d">


Now:
<img width="579" alt="image" src="https://github.com/user-attachments/assets/d559016c-7c4d-4243-bc21-0e46bb5b89f9">
