### PR TITLE
fix plkl param prediction with multi_models=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed a bug when predicting with `predict_likelihood_parameters=True`, `n > 1` and a `RegressionModel` with `multi_models=False` that uses a `likelihood`. The prediction now works without raising an exception. [#2545](https://github.com/unit8co/darts/pull/2545) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when performing probabilistic optimized historical forecasts (`num_samples>1, retrain=False, enable_optimization=True`) with regression models, where reshaping the array resulted in a wrong order of samples across components and forecasts. [#2534](https://github.com/unit8co/darts/pull/2534) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed bug when plotting a probabilistic multivariate series, where all confidence intervals (starting from 2nd component) had the same color as the median line. [#2532](https://github.com/unit8co/darts/pull/2532) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when passing an empty array to `TimeSeries.prepend/append_values()` raised an error. [#2522](https://github.com/unit8co/darts/pull/2522) by [Alessio Pellegrini](https://github.com/AlessiopSymplectic)

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -94,6 +94,23 @@ models_cls_kwargs_errs += [
     ),
 ]
 
+xgb_test_params = {
+    "n_estimators": 1,
+    "max_depth": 1,
+    "max_leaves": 1,
+}
+lgbm_test_params = {
+    "n_estimators": 1,
+    "max_depth": 1,
+    "num_leaves": 2,
+    "verbosity": -1,
+}
+cb_test_params = {
+    "iterations": 1,
+    "depth": 1,
+    "verbose": -1,
+}
+
 if TORCH_AVAILABLE:
     models_cls_kwargs_errs += [
         (
@@ -294,15 +311,17 @@ class TestProbabilisticModels:
     @pytest.mark.parametrize(
         "config",
         itertools.product(
-            [(LinearRegressionModel, False), (XGBModel, False)]
-            + ([(LightGBMModel, False)] if lgbm_available else [])
-            + ([(CatBoostModel, True)] if cb_available else []),
-            [1, 3],
+            [(LinearRegressionModel, False, {}), (XGBModel, False, xgb_test_params)]
+            + ([(LightGBMModel, False, lgbm_test_params)] if lgbm_available else [])
+            + ([(CatBoostModel, True, cb_test_params)] if cb_available else []),
+            [1, 3],  # n components
             [
                 "quantile",
                 "poisson",
                 "gaussian",
-            ],
+            ],  # likelihood
+            [True, False],  # multi models
+            [1, 2],  # horizon
         ),
     )
     def test_predict_likelihood_parameters_regression_models(self, config):
@@ -312,7 +331,13 @@ class TestProbabilisticModels:
 
         Note: values are not tested as it would be too time consuming
         """
-        (model_cls, supports_gaussian), n_comp, likelihood = config
+        (
+            (model_cls, supports_gaussian, model_kwargs),
+            n_comp,
+            likelihood,
+            multi_models,
+            horizon,
+        ) = config
 
         seed = 142857
         n_times, n_samples = 100, 1
@@ -340,10 +365,17 @@ class TestProbabilisticModels:
         else:
             assert False, f"unknown likelihood {likelihood}"
 
-        model = model_cls(lags=3, random_state=seed, **lkl["kwargs"])
+        model = model_cls(
+            lags=3,
+            output_chunk_length=horizon,
+            random_state=seed,
+            **lkl["kwargs"],
+            multi_models=multi_models,
+            **model_kwargs,
+        )
         model.fit(lkl["ts"])
         pred_lkl_params = model.predict(
-            n=1, num_samples=1, predict_likelihood_parameters=True
+            n=horizon, num_samples=1, predict_likelihood_parameters=True
         )
         if n_comp == 1:
             assert lkl["expected"].shape == pred_lkl_params.values()[0].shape, (
@@ -352,7 +384,7 @@ class TestProbabilisticModels:
             )
         else:
             assert (
-                1,
+                horizon,
                 len(lkl["expected"]) * n_comp,
                 1,
             ) == pred_lkl_params.all_values().shape, (

--- a/darts/tests/models/forecasting/test_probabilistic_models.py
+++ b/darts/tests/models/forecasting/test_probabilistic_models.py
@@ -367,7 +367,7 @@ class TestProbabilisticModels:
 
         model = model_cls(
             lags=3,
-            output_chunk_length=horizon,
+            output_chunk_length=2,
             random_state=seed,
             **lkl["kwargs"],
             multi_models=multi_models,


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary
- Fixes a bug when predicting with `predict_likelihood_parameters=True`, `n > 1` and a `RegressionModel` with `multi_models=False` that uses a `likelihood`. The prediction now works without raising an exception.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
