### PR TITLE
Fix/ShapExplainer-summary_plot-Horizon-does-not-include-output_chunk_shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 - Fixed a bug when performing optimized historical forecasts with `stride=1` using a `RegressionModel` with `output_chunk_shift>=1` and `output_chunk_length=1`, where the forecast time index was not properly shifted. [#2634](https://github.com/unit8co/darts/pull/2634) by [Mattias De Charleroy](https://github.com/MattiasDC).
+- Fixed the `ShapExplainer` `summary_plot` title where Horizon does not include `output_chunk_shift`. [#2647](https://github.com/unit8co/darts/pull/2647) by [He Weilin](https://github.com/cnhwl).
 
 **Dependencies**
 

--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -422,7 +422,7 @@ class ShapExplainer(_ForecastingModelExplainer):
             for h in horizons:
                 plt.title(
                     "Target: `{}` - Horizon: {}".format(
-                        t, "t+" + str(h + self.explainers.model.output_chunk_shift)
+                        t, "t+" + str(h + self.model.output_chunk_shift)
                     )
                 )
                 shap.summary_plot(

--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -420,7 +420,11 @@ class ShapExplainer(_ForecastingModelExplainer):
 
         for t in target_components:
             for h in horizons:
-                plt.title("Target: `{}` - Horizon: {}".format(t, "t+" + str(h)))
+                plt.title(
+                    "Target: `{}` - Horizon: {}".format(
+                        t, "t+" + str(h + self.explainers.model.output_chunk_shift)
+                    )
+                )
                 shap.summary_plot(
                     shaps_[h][t],
                     foreground_X_sampled,


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #2646.

### Summary
Fixed the `ShapExplainer` `summary_plot` title where Horizon does not include `output_chunk_shift`.