### PR TITLE
fix lags_past_covariates dict type breaks lags_future_covariates when output_chunk_shift>0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
-- Fixed a bug when initiating a `RegressionModel` with `lags_past_covariates` as dict and `lags_future_covariates` as some other type (not dict) and `output_chunk_shift>0`, [#2652
-](https://github.com/unit8co/darts/issues/2652) by [Jules Authier](https://github.com/authierj).
 - New model: `StatsForecastAutoTBATS`. This model offers the [AutoTBATS](https://nixtlaverse.nixtla.io/statsforecast/src/core/models.html#autotbats) model from Nixtla's `statsforecasts` library. [#2611](https://github.com/unit8co/darts/pull/2611) by [He Weilin](https://github.com/cnhwl).
 - Added the `title` attribute to `TimeSeries.plot()`. This allows to set a title for the plot. [#2639](https://github.com/unit8co/darts/pull/2639) by [Jonathan Koch](https://github.com/jonathankoch99).
 - Added parameter `component_wise` to `show_anomalies()` to separately plot each component in multivariate series. [#2544](https://github.com/unit8co/darts/pull/2544) by [He Weilin](https://github.com/cnhwl).
@@ -60,6 +58,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed a bug when initiating a `RegressionModel` with `lags_past_covariates` as dict and `lags_future_covariates` as some other type (not dict) and `output_chunk_shift>0`, [#2652](https://github.com/unit8co/darts/issues/2652) by [Jules Authier](https://github.com/authierj).
 - Fixed a bug which raised an error when computing residuals (or backtest with "per time step" metrics) on multiple series with corresponding historical forecasts of different lengths. [#2604](https://github.com/unit8co/darts/pull/2604) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `darts.utils.data.tabularization.create_lagged_component_names()` with target `lags=None`, that did not return any lagged target label component names. [#2576](https://github.com/unit8co/darts/pull/2576) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug when using `num_samples > 1` with a deterministic regression model and the optimized `historical_forecasts()` method, which did not raise an exception. [#2576](https://github.com/unit8co/darts/pull/2588) by [Antoine Madrona](https://github.com/madtoinou).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- Fixed a bug when initiating a `RegressionModel` with `lags_past_covariates` as dict and `lags_future_covariates` as some other type (not dict) and `output_chunk_shift>0`, [#2652
+](https://github.com/unit8co/darts/issues/2652) by [Jules Authier](https://github.com/authierj).
 - New model: `StatsForecastAutoTBATS`. This model offers the [AutoTBATS](https://nixtlaverse.nixtla.io/statsforecast/src/core/models.html#autotbats) model from Nixtla's `statsforecasts` library. [#2611](https://github.com/unit8co/darts/pull/2611) by [He Weilin](https://github.com/cnhwl).
 - Added the `title` attribute to `TimeSeries.plot()`. This allows to set a title for the plot. [#2639](https://github.com/unit8co/darts/pull/2639) by [Jonathan Koch](https://github.com/jonathankoch99).
 - Added parameter `component_wise` to `show_anomalies()` to separately plot each component in multivariate series. [#2544](https://github.com/unit8co/darts/pull/2544) by [He Weilin](https://github.com/cnhwl).

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -381,8 +381,11 @@ class RegressionModel(GlobalForecastingModel):
                 else:
                     max_lags = max(max_lags, tmp_components_lags[comp_name][-1])
 
+            # Check if only default lags are provided
+            has_default_lags = list(tmp_components_lags.keys()) == ["default_lags"]
+
             # revert to shared lags logic when applicable
-            if list(tmp_components_lags.keys()) == ["default_lags"]:
+            if has_default_lags:
                 processed_lags[lags_abbrev] = tmp_components_lags["default_lags"]
             else:
                 processed_lags[lags_abbrev] = [min_lags, max_lags]
@@ -393,9 +396,7 @@ class RegressionModel(GlobalForecastingModel):
                 processed_lags[lags_abbrev] = [
                     lag_ + output_chunk_shift for lag_ in processed_lags[lags_abbrev]
                 ]
-                if processed_component_lags and list(tmp_components_lags.keys()) != [
-                    "default_lags"
-                ]:
+                if processed_component_lags and not has_default_lags:
                     processed_component_lags[lags_abbrev] = {
                         comp_: [lag_ + output_chunk_shift for lag_ in lags_]
                         for comp_, lags_ in processed_component_lags[

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -393,7 +393,9 @@ class RegressionModel(GlobalForecastingModel):
                 processed_lags[lags_abbrev] = [
                     lag_ + output_chunk_shift for lag_ in processed_lags[lags_abbrev]
                 ]
-                if processed_component_lags:
+                if processed_component_lags and list(tmp_components_lags.keys()) != [
+                    "default_lags"
+                ]:
                     processed_component_lags[lags_abbrev] = {
                         comp_: [lag_ + output_chunk_shift for lag_ in lags_]
                         for comp_, lags_ in processed_component_lags[

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -2390,6 +2390,20 @@ class TestRegressionModels:
                     "lags_past_covariates": 4,
                     "lags_future_covariates": [-3, 1],
                 },
+                # check that component-specific lags with output_chunk_shift works
+                {
+                    "lags_past_covariates": {"lin_past": [-3, -1]},
+                    "lags_future_covariates": [1, 2],
+                },
+                {
+                    "lags_past_covariates": [-3, -1],
+                    "lags_future_covariates": {"lin_future": [1, 2]},
+                },
+                {
+                    "lags": {"gaussian": 5},
+                    "lags_past_covariates": [-3, -1],
+                    "lags_future_covariates": [1, 2],
+                },
             ],
             [True, False],
             [3, 5],
@@ -2431,11 +2445,19 @@ class TestRegressionModels:
         )
         # adjusting the future lags should give identical models to non-shifted
         list_lags_adj = deepcopy(list_lags)
+        # this loop works for both component-specific and non-component-specific future lags
         if "lags_future_covariates" in list_lags_adj:
-            list_lags_adj["lags_future_covariates"] = [
-                lag_ - output_chunk_shift
-                for lag_ in list_lags_adj["lags_future_covariates"]
-            ]
+            if isinstance(list_lags_adj["lags_future_covariates"], dict):
+                for key in list_lags_adj["lags_future_covariates"]:
+                    list_lags_adj["lags_future_covariates"][key] = [
+                        lag_ - output_chunk_shift
+                        for lag_ in list_lags_adj["lags_future_covariates"][key]
+                    ]
+            else:
+                list_lags_adj["lags_future_covariates"] = [
+                    lag_ - output_chunk_shift
+                    for lag_ in list_lags_adj["lags_future_covariates"]
+                ]
         model_shift_adj = LinearRegressionModel(
             **list_lags_adj,
             output_chunk_shift=output_chunk_shift,


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes [#2652](https://github.com/unit8co/darts/issues/2652#issue-2807058011)

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

- When initiating a `RegressionModel` with `lags_past_covariates` as dict and `lags_future_covariates` as some other type (not dict) and `output_chunk_shift>0`, an error occurred. 
- This was because `lags_future_covariate` is not a component lag and should therefore not be handled at any point by `processed_component_lags`.
- Adjusting the `if` statement in line 396 of `regression_model.py` fixes the bug.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

None

<!--Thank you for contributing to darts! -->
