### PR TITLE
fix failing tfm load with pytorch>=2.6.0

### DIFF
--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1736,7 +1736,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         # load the base TorchForecastingModel (does not contain the actual PyTorch LightningModule)
         with open(path, "rb") as fin:
             model: TorchForecastingModel = torch.load(
-                fin, map_location=kwargs.get("map_location", None)
+                fin, weights_only=False, map_location=kwargs.get("map_location", None)
             )
 
         # if a checkpoint was saved, we also load the PyTorch LightningModule from checkpoint
@@ -1831,7 +1831,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             logger,
         )
         model: TorchForecastingModel = torch.load(
-            base_model_path, map_location=kwargs.get("map_location")
+            base_model_path, weights_only=False, map_location=kwargs.get("map_location")
         )
 
         # load PyTorch LightningModule from checkpoint
@@ -1965,7 +1965,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             tfm_save_file_name = file_name[:-5]
 
         ckpt_path = os.path.join(checkpoint_dir, file_name)
-        ckpt = torch.load(ckpt_path, **kwargs)
+        ckpt = torch.load(ckpt_path, weights_only=False, **kwargs)
 
         # indicate to the user than checkpoints generated with darts <= 0.23.1 are not supported
         raise_if_not(
@@ -2000,7 +2000,9 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             # updating model attributes before self._init_model() which create new tfm ckpt
             with open(tfm_save_file_path, "rb") as tfm_save_file:
                 tfm_save: TorchForecastingModel = torch.load(
-                    tfm_save_file, map_location=kwargs.get("map_location", None)
+                    tfm_save_file,
+                    weights_only=False,
+                    map_location=kwargs.get("map_location", None),
                 )
 
             # encoders are necessary for direct inference


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md) (not required).

### Summary
Fixes failing TorchForecastingModel load methods from pytorch>=2.6.0.
PyTorch changed the default value of `weights_only` from `False` to `True`.