### PR TITLE
Fix global naive models cannot be used in ensemble models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - Fixed a bug when performing optimized historical forecasts with `stride=1` using a `RegressionModel` with `output_chunk_shift>=1` and `output_chunk_length=1`, where the forecast time index was not properly shifted. [#2634](https://github.com/unit8co/darts/pull/2634) by [Mattias De Charleroy](https://github.com/MattiasDC).
 - Fixed the `ShapExplainer` `summary_plot` title where Horizon does not include `output_chunk_shift`. [#2647](https://github.com/unit8co/darts/pull/2647) by [He Weilin](https://github.com/cnhwl).
+- Fixed a bug where global naive models could not be used in ensemble models. [#2666](https://github.com/unit8co/darts/pull/2666) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a bug with global naive models where some `supports_*` properties were wrongly defined as methods. [#2666](https://github.com/unit8co/darts/pull/2666) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 

--- a/darts/models/forecasting/global_baseline_models.py
+++ b/darts/models/forecasting/global_baseline_models.py
@@ -230,9 +230,11 @@ class _GlobalNaiveModel(MixedCovariatesTorchModel, ABC):
         # have to match the training sample
         pass
 
+    @property
     def supports_likelihood_parameter_prediction(self) -> bool:
         return False
 
+    @property
     def supports_probabilistic_prediction(self) -> bool:
         return False
 

--- a/darts/tests/models/forecasting/test_baseline_models.py
+++ b/darts/tests/models/forecasting/test_baseline_models.py
@@ -95,6 +95,8 @@ class TestBaselineModels:
             series.stack(series + 100)
 
         model = model_cls(**model_kwargs)
+        assert not model.supports_probabilistic_prediction
+        assert not model.supports_likelihood_parameter_prediction
 
         # calling predict before fit
         with pytest.raises(ValueError):


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes an issue mentioned on gitter where Global Naive models could not be used in ensemble models.

Code to reproduce below.

### Summary

- Fixed a bug where global naive models could not be used in ensemble models
- Fixed a bug with global naive models where some `supports_*` properties were wrongly defined as methods.

#### Additional Info

Code to reproduce the issue:

```
import numpy as np

from darts.datasets import AirPassengersDataset
from darts.models import NaiveEnsembleModel, GlobalNaiveDrift

series = AirPassengersDataset().load().astype(np.float32)

model = NaiveEnsembleModel(
    forecasting_models=[
        GlobalNaiveDrift(input_chunk_length=12, output_chunk_length=12).fit(series)
    ],
    train_forecasting_models=False,
)
pred_kwargs = {"predict_likelihood_parameters": True, "verbose": True}
model.predict(n=12, series=series, **pred_kwargs)
```