### PR TITLE
add public function untrained_model() in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- Made method `ForecastingModel.untrained_model()` public. Use this method to get a new (untrained) model instance created with the same parameters. [#2684](https://github.com/unit8co/darts/pull/2684) by [Timon Erhart](https://github.com/turbotimon)
+
 **Fixed**
 
 **Dependencies**

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -2601,7 +2601,7 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         return model_params
 
     def untrained_model(self):
-        """Returns a new (untrained) model instance create with the same parameters."""
+        """Returns a new (untrained) model instance created with the same parameters."""
         return self.__class__(**copy.deepcopy(self.model_params))
 
     @property

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ autodoc_default_options = {
     + "PastCovariatesTorchModel,FutureCovariatesTorchModel,DualCovariatesTorchModel,MixedCovariatesTorchModel,"
     + "SplitCovariatesTorchModel,"
     + "min_train_series_length,"
-    + "untrained_model,first_prediction_index,future_covariate_series,past_covariate_series,"
+    + "first_prediction_index,future_covariate_series,past_covariate_series,"
     + "initialize_encoders,register_datapipe_as_function,register_function,functions,"
     + "SplitTimeSeriesSequence,randint,AnomalyModel",
 }


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2677 

### Summary

Public function `ForecastingModel.untrained_model()` is no in docs
