### PR TITLE
feat: allow stride=forecast_horizon for anomaly forecasting model

### DIFF
--- a/darts/ad/anomaly_model/anomaly_model.py
+++ b/darts/ad/anomaly_model/anomaly_model.py
@@ -50,7 +50,7 @@ class AnomalyModel(ABC):
         if not allow_model_training and not self.scorers_are_trainable:
             return self
 
-        # check input series and covert to sequences
+        # check input series and convert to sequences
         series, kwargs = self._process_input_series(series, **kwargs)
         self._fit_core(
             series=series, allow_model_training=allow_model_training, **kwargs


### PR DESCRIPTION
Checklist before merging this PR:
- [ ] Mentioned all issues that this PR fixes or addresses.
- [ ] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #2673.

### Summary

- Expose the `stride` argument in `ForecastingAnomalyModel.predict_series`, it must be equal to 1 or `forecast horizon`
- Add the corresponding tests

### Other Information

Using `stride=forecast_horizon` should speed up the forecasts at the cost of accuracy, not sure if we should also test this aspect?
