### PR TITLE
Remove deprecated `pd_dataframe()` and `pd_series()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+**Removed**
+- 🔴 Removed deprecated method `TimeSeries.pd_dataframe()`. Use `TimeSeries.to_dataframe()` instead. [#2733](https://github.com/unit8co/darts/pull/2733) by [Dennis Bader](https://github.com/dennisbader).
+- 🔴 Removed deprecated method `TimeSeries.pd_serise()`. Use `TimeSeries.to_series()` instead. [#2733](https://github.com/unit8co/darts/pull/2733) by [Dennis Bader](https://github.com/dennisbader).
+
 **Fixed**
 
 **Dependencies**

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -2077,7 +2077,7 @@ class TestTimeSeries:
         ts.to_csv("test.csv")
         pddf_mock.assert_called_once()
 
-    @patch("darts.timeseries.TimeSeries.pd_dataframe")
+    @patch("darts.timeseries.TimeSeries.to_dataframe")
     def test_to_csv_stochastic(self, pddf_mock):
         ts = TimeSeries(
             xr.DataArray(

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -59,7 +59,6 @@ from scipy.stats import kurtosis, skew
 
 from darts.logging import (
     get_logger,
-    raise_deprecation_warning,
     raise_if,
     raise_if_not,
     raise_log,
@@ -1823,29 +1822,6 @@ class TimeSeries:
 
         return pd.Series(data=data, index=index, name=name)
 
-    def pd_series(self, copy: bool = True) -> pd.Series:
-        """
-        Return a Pandas Series representation of this time series.
-
-        Works only for univariate series that are deterministic (i.e., made of 1 sample).
-
-        Parameters
-        ----------
-        copy
-            Whether to return a copy of the series. Leave it to True unless you know what you are doing.
-
-        Returns
-        -------
-        pandas.Series
-            A Pandas Series representation of this univariate time series.
-        """
-        raise_deprecation_warning(
-            "`TimeSeries.pd_series()` is deprecated and will be removed in Darts version 0.35.0. Use "
-            "`TimeSeries.to_series()` instead",
-            logger,
-        )
-        return self.to_series(copy=copy)
-
     def to_dataframe(
         self,
         copy: bool = True,
@@ -1925,35 +1901,6 @@ class TimeSeries:
         }
 
         return nw.from_dict(data, backend=backend).to_native()
-
-    def pd_dataframe(self, copy=True, suppress_warnings=False) -> pd.DataFrame:
-        """
-        Return a Pandas DataFrame representation of this time series.
-
-        Each of the series components will appear as a column in the DataFrame.
-        If the series is stochastic, the samples are returned as columns of the dataframe with column names
-        as 'component_s#' (e.g. with two components and two samples:
-        'comp0_s0', 'comp0_s1' 'comp1_s0' 'comp1_s1').
-
-        Parameters
-        ----------
-        copy
-            Whether to return a copy of the dataframe. Leave it to True unless you know what you are doing.
-        suppress_warnings
-            Whether to suppress the warnings for the `DataFrame` creation.
-
-        Returns
-        -------
-        pandas.DataFrame
-            The Pandas DataFrame representation of this time series
-        """
-
-        raise_deprecation_warning(
-            "`TimeSeries.pd_dataframe()` is deprecated, and will be removed in Darts version 0.35.0. Use "
-            "`TimeSeries.to_dataframe()` instead",
-            logger,
-        )
-        return self.to_dataframe(copy=copy, suppress_warnings=suppress_warnings)
 
     def quantile_df(self, quantile=0.5) -> pd.DataFrame:
         """

--- a/examples/05-TCN-examples.ipynb
+++ b/examples/05-TCN-examples.ipynb
@@ -437,7 +437,7 @@
     }
    ],
    "source": [
-    "df3 = EnergyDataset().load().pd_dataframe()\n",
+    "df3 = EnergyDataset().load().to_dataframe()\n",
     "df3_day_avg = (\n",
     "    df3.groupby(df3.index.astype(str).str.split(\" \").str[0]).mean().reset_index()\n",
     ")\n",

--- a/examples/07-NBEATS-examples.ipynb
+++ b/examples/07-NBEATS-examples.ipynb
@@ -115,7 +115,7 @@
     }
    ],
    "source": [
-    "df = EnergyDataset().load().pd_dataframe()\n",
+    "df = EnergyDataset().load().to_dataframe()\n",
     "df[\"generation hydro run-of-river and poundage\"].plot()\n",
     "plt.title(\"Hourly generation hydro run-of-river and poundage\")"
    ]

--- a/examples/08-DeepAR-examples.ipynb
+++ b/examples/08-DeepAR-examples.ipynb
@@ -261,7 +261,7 @@
     }
    ],
    "source": [
-    "df3 = EnergyDataset().load().pd_dataframe()\n",
+    "df3 = EnergyDataset().load().to_dataframe()\n",
     "df3_day_avg = (\n",
     "    df3.groupby(df3.index.astype(str).str.split(\" \").str[0]).mean().reset_index()\n",
     ")\n",

--- a/examples/09-DeepTCN-examples.ipynb
+++ b/examples/09-DeepTCN-examples.ipynb
@@ -231,7 +231,7 @@
     }
    ],
    "source": [
-    "df3 = EnergyDataset().load().pd_dataframe()\n",
+    "df3 = EnergyDataset().load().to_dataframe()\n",
     "df3_day_avg = (\n",
     "    df3.groupby(df3.index.astype(str).str.split(\" \").str[0]).mean().reset_index()\n",
     ")\n",

--- a/examples/21-TSMixer-examples.ipynb
+++ b/examples/21-TSMixer-examples.ipynb
@@ -274,7 +274,7 @@
     "    trafo = ds().load().astype(np.float32)\n",
     "    trafo = trafo.with_static_covariates(pd.DataFrame({\"transformer_id\": [idx]}))\n",
     "    series.append(trafo)\n",
-    "series[0].pd_dataframe()"
+    "series[0].to_dataframe()"
    ]
   },
   {


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- 🔴 Removed deprecated method `TimeSeries.pd_dataframe()`.
- 🔴 Removed deprecated method `TimeSeries.pd_serise()`.