### PR TITLE
Categorical forecasting for regression models

### DIFF
--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -17,7 +17,7 @@ from catboost import CatBoostClassifier, CatBoostRegressor, Pool
 from darts.logging import get_logger
 from darts.models.forecasting.categorical_model import CategoricalForecastingMixin
 from darts.models.forecasting.regression_model import (
-    RegressionModelWithCategoricalCovariates,
+    RegressionModelWithCategoricalFeatures,
     _LikelihoodMixin,
 )
 from darts.timeseries import TimeSeries
@@ -25,7 +25,7 @@ from darts.timeseries import TimeSeries
 logger = get_logger(__name__)
 
 
-class CatBoostModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
+class CatBoostModel(RegressionModelWithCategoricalFeatures, _LikelihoodMixin):
     def __init__(
         self,
         lags: Union[int, list] = None,
@@ -482,7 +482,21 @@ class CatBoostModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
         """
         return "cat_features", self._categorical_features
 
+    @property
+    def _is_categorical_forecasting(self) -> bool:
+        """
+        Returns True if the model forecasts categorical values.
+        """
+        return False
+
 
 class CatBoostCategoricalModel(CatBoostModel, CategoricalForecastingMixin):
     def _create_model(self, **kwargs):
         return CatBoostClassifier(**kwargs)
+
+    @property
+    def _is_categorical_forecasting(self) -> bool:
+        """
+        Returns True if the model forecasts categorical values.
+        """
+        return True

--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -502,3 +502,15 @@ class CatBoostCategoricalModel(CatBoostModel, CategoricalForecastingMixin):
         Returns the model's type of forecasting.
         """
         return ForecastingType.CATEGORICAL
+
+    def _format_samples(self, samples, labels=None):
+        """
+        CatBoost classifier
+        """
+        if labels is not None and np.any(labels % 1 != 0):
+            raise_log(
+                ValueError(
+                    "CatBoostCategoricalModel expects categorical labels, float are not supported."
+                )
+            )
+        return super()._format_samples(samples, labels)

--- a/darts/models/forecasting/catboost_model.py
+++ b/darts/models/forecasting/catboost_model.py
@@ -8,7 +8,7 @@ This implementation comes with the ability to produce probabilistic forecasts.
 """
 
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -424,7 +424,7 @@ class CatBoostModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
     def _format_samples(self, samples, labels=None):
         """
         CatBoost does not support categorical features to be typed as float (yet).
-        If categorical features are specified samples
+        If categorical features are specified, pandas DataFrame is used to cast the categorical columns to integer.
         """
         _, cat_param = self._categorical_fit_param
 
@@ -476,7 +476,7 @@ class CatBoostModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
         )
 
     @property
-    def _categorical_fit_param(self) -> tuple[str, Any]:
+    def _categorical_fit_param(self) -> tuple[Optional[str], Optional[str]]:
         """
         Returns the name, and default value of the categorical features parameter from model's `fit` method .
         """

--- a/darts/models/forecasting/categorical_model.py
+++ b/darts/models/forecasting/categorical_model.py
@@ -1,4 +1,5 @@
 from sklearn.base import is_classifier
+from sklearn.linear_model import LogisticRegression
 
 from darts.models.forecasting.forecasting_model import ForecastingModel
 from darts.models.forecasting.regression_model import (
@@ -22,7 +23,10 @@ class CategoricalModel(RegressionModel, CategoricalForecastingMixin):
         """
         TODO explain categorical input not supported yet
         supposed to use covariates as input and target as output
+
         """
+        if model is None:
+            model = LogisticRegression(n_jobs=-1)
         if not is_classifier(model):
             raise ValueError(
                 "CategoricalModel must be initialized with a classifier model"

--- a/darts/models/forecasting/categorical_model.py
+++ b/darts/models/forecasting/categorical_model.py
@@ -1,0 +1,31 @@
+from sklearn.base import is_classifier
+
+from darts.models.forecasting.forecasting_model import ForecastingModel
+from darts.models.forecasting.regression_model import (
+    RegressionModel,
+)
+
+
+class CategoricalForecastingMixin:
+    model: ForecastingModel
+
+    @property
+    def class_labels(self):
+        """Returns the classes of the classifier model if the model was previously trained."""
+        if not hasattr(self.model, "classes_"):
+            raise AttributeError("Model is not trained")
+        return self.model.classes_
+
+
+class CategoricalModel(RegressionModel, CategoricalForecastingMixin):
+    def __init__(self, model=None, **kwargs):
+        """
+        TODO explain categorical input not supported yet
+        supposed to use covariates as input and target as output
+        """
+        if not is_classifier(model):
+            raise ValueError(
+                "CategoricalModel must be initialized with a classifier model"
+            )
+
+        super().__init__(model=model, **kwargs)

--- a/darts/models/forecasting/categorical_model.py
+++ b/darts/models/forecasting/categorical_model.py
@@ -13,17 +13,16 @@ class CategoricalForecastingMixin:
     @property
     def class_labels(self):
         """Returns the classes of the classifier model if the model was previously trained."""
-        if not hasattr(self.model, "classes_"):
+        if not hasattr(self.model, "classes_") or self.model.classes_ is None:
             raise AttributeError("Model is not trained")
         return self.model.classes_
 
 
 class CategoricalModel(RegressionModel, CategoricalForecastingMixin):
     def __init__(self, model=None, **kwargs):
-        """
-        TODO explain categorical input not supported yet
-        supposed to use covariates as input and target as output
-
+        """Categorical Model
+        Can be used to fit any scikit-learn-like classifier class to predict
+        categorical target time series from lagged values."
         """
         if model is None:
             model = LogisticRegression(n_jobs=-1)
@@ -33,3 +32,5 @@ class CategoricalModel(RegressionModel, CategoricalForecastingMixin):
             )
 
         super().__init__(model=model, **kwargs)
+
+    # TODO settings lags should either probably raise a warning about how lags will be assumed to have ordinal meaning

--- a/darts/models/forecasting/lgbm.py
+++ b/darts/models/forecasting/lgbm.py
@@ -21,7 +21,7 @@ from darts.models.forecasting.categorical_model import CategoricalForecastingMix
 from darts.models.forecasting.regression_model import (
     FUTURE_LAGS_TYPE,
     LAGS_TYPE,
-    RegressionModelWithCategoricalCovariates,
+    RegressionModelWithCategoricalFeatures,
     _LikelihoodMixin,
 )
 from darts.timeseries import TimeSeries
@@ -29,7 +29,7 @@ from darts.timeseries import TimeSeries
 logger = get_logger(__name__)
 
 
-class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
+class LightGBMModel(RegressionModelWithCategoricalFeatures, _LikelihoodMixin):
     def __init__(
         self,
         lags: Optional[LAGS_TYPE] = None,
@@ -367,7 +367,21 @@ class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
         """
         return "categorical_feature", "auto"
 
+    @property
+    def _is_categorical_forecasting(self) -> bool:
+        """
+        Returns True if the model forecasts categorical values.
+        """
+        return False
+
 
 class LightGBMCategoricalModel(LightGBMModel, CategoricalForecastingMixin):
     def _create_model(self, **kwargs) -> lgb.LGBMClassifier:
         return lgb.LGBMClassifier(**kwargs)
+
+    @property
+    def _is_categorical_forecasting(self) -> bool:
+        """
+        Returns True if the model forecasts categorical values.
+        """
+        return True

--- a/darts/models/forecasting/lgbm.py
+++ b/darts/models/forecasting/lgbm.py
@@ -21,6 +21,7 @@ from darts.models.forecasting.categorical_model import CategoricalForecastingMix
 from darts.models.forecasting.regression_model import (
     FUTURE_LAGS_TYPE,
     LAGS_TYPE,
+    ForecastingType,
     RegressionModelWithCategoricalFeatures,
     _LikelihoodMixin,
 )
@@ -368,11 +369,11 @@ class LightGBMModel(RegressionModelWithCategoricalFeatures, _LikelihoodMixin):
         return "categorical_feature", "auto"
 
     @property
-    def _is_categorical_forecasting(self) -> bool:
+    def _forecasting_type(self) -> ForecastingType:
         """
-        Returns True if the model forecasts categorical values.
+        Returns the model's type of forecasting.
         """
-        return False
+        return ForecastingType.REGRESSION
 
 
 class LightGBMCategoricalModel(LightGBMModel, CategoricalForecastingMixin):
@@ -380,8 +381,8 @@ class LightGBMCategoricalModel(LightGBMModel, CategoricalForecastingMixin):
         return lgb.LGBMClassifier(**kwargs)
 
     @property
-    def _is_categorical_forecasting(self) -> bool:
+    def _forecasting_type(self) -> ForecastingType:
         """
-        Returns True if the model forecasts categorical values.
+        Returns the model's type of forecasting.
         """
-        return True
+        return ForecastingType.CATEGORICAL

--- a/darts/models/forecasting/lgbm.py
+++ b/darts/models/forecasting/lgbm.py
@@ -17,6 +17,7 @@ import lightgbm as lgb
 import numpy as np
 
 from darts.logging import get_logger
+from darts.models.forecasting.categorical_model import CategoricalForecastingMixin
 from darts.models.forecasting.regression_model import (
     FUTURE_LAGS_TYPE,
     LAGS_TYPE,
@@ -212,12 +213,15 @@ class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
             output_chunk_shift=output_chunk_shift,
             add_encoders=add_encoders,
             multi_models=multi_models,
-            model=lgb.LGBMRegressor(**self.kwargs),
+            model=self._create_model(**self.kwargs),
             use_static_covariates=use_static_covariates,
             categorical_past_covariates=categorical_past_covariates,
             categorical_future_covariates=categorical_future_covariates,
             categorical_static_covariates=categorical_static_covariates,
         )
+
+    def _create_model(self, **kwargs) -> lgb.LGBMRegressor:
+        return lgb.LGBMRegressor(**kwargs)
 
     def fit(
         self,
@@ -355,3 +359,8 @@ class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
                 else self.output_chunk_length
             ),
         )
+
+
+class LightGBMCategoricalModel(LightGBMModel, CategoricalForecastingMixin):
+    def _create_model(self, **kwargs) -> lgb.LGBMClassifier:
+        return lgb.LGBMClassifier(**kwargs)

--- a/darts/models/forecasting/lgbm.py
+++ b/darts/models/forecasting/lgbm.py
@@ -360,6 +360,13 @@ class LightGBMModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
             ),
         )
 
+    @property
+    def _categorical_fit_param(self) -> tuple[Optional[str], Optional[str]]:
+        """
+        Returns the name, and default value of the categorical features parameter from model's `fit` method .
+        """
+        return "categorical_feature", "auto"
+
 
 class LightGBMCategoricalModel(LightGBMModel, CategoricalForecastingMixin):
     def _create_model(self, **kwargs) -> lgb.LGBMClassifier:

--- a/darts/models/forecasting/regression_model.py
+++ b/darts/models/forecasting/regression_model.py
@@ -29,7 +29,7 @@ if their static covariates do not have the same size, the shorter ones are padde
 
 from collections import OrderedDict
 from collections.abc import Sequence
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Callable, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -1883,12 +1883,12 @@ class RegressionModelWithCategoricalCovariates(RegressionModel):
         )
 
     @property
-    def _categorical_fit_param(self) -> tuple[str, Any]:
+    def _categorical_fit_param(self) -> tuple[Optional[str], Optional[str]]:
         """
         Returns the name, and default value of the categorical features parameter from model's `fit` method .
-        Can be overridden in subclasses.
+        Should be overridden in subclasses.
         """
-        return "categorical_feature", "auto"
+        return None, None
 
     def _validate_categorical_covariates(
         self,
@@ -2049,13 +2049,17 @@ class RegressionModelWithCategoricalCovariates(RegressionModel):
         )
 
         self._categorical_features = None
+        # cat_param_name is None if no flag is available in the model's fit method
+        # cat_param_default is None if no default value is available in the model's fit method
         cat_param_name, cat_param_default = self._categorical_fit_param
         if cat_col_indices:
-            kwargs[cat_param_name] = cat_col_indices
+            if cat_param_name is not None:
+                kwargs[cat_param_name] = cat_col_indices
             self._categorical_features = cat_col_indices
         else:
             if cat_param_default is not None:
-                kwargs[cat_param_name] = cat_param_default
+                if cat_param_name is not None:
+                    kwargs[cat_param_name] = cat_param_default
                 self._categorical_features = cat_param_default
 
         super()._fit_model(

--- a/darts/models/forecasting/xgboost.py
+++ b/darts/models/forecasting/xgboost.py
@@ -425,5 +425,5 @@ class XGBModel(RegressionModelWithCategoricalCovariates, _LikelihoodMixin):
 
 
 class XGBClassifierModel(XGBModel, CategoricalForecastingMixin):
-    def _create_model(self, **kwargs):
-        return xgb.XGBClassifier(enable_categorical=True, **kwargs)
+    def _create_model(self, enable_categorical=False, **kwargs):
+        return xgb.XGBClassifier(enable_categorical=enable_categorical, **kwargs)

--- a/darts/models/forecasting/xgboost.py
+++ b/darts/models/forecasting/xgboost.py
@@ -14,6 +14,7 @@ import numpy as np
 import xgboost as xgb
 
 from darts.logging import get_logger, raise_if_not
+from darts.models.forecasting.categorical_model import CategoricalForecastingMixin
 from darts.models.forecasting.regression_model import (
     FUTURE_LAGS_TYPE,
     LAGS_TYPE,
@@ -214,9 +215,12 @@ class XGBModel(RegressionModel, _LikelihoodMixin):
             output_chunk_shift=output_chunk_shift,
             add_encoders=add_encoders,
             multi_models=multi_models,
-            model=xgb.XGBRegressor(**self.kwargs),
+            model=self._create_model(**self.kwargs),
             use_static_covariates=use_static_covariates,
         )
+
+    def _create_model(self, **kwargs):
+        return xgb.XGBRegressor(**kwargs)
 
     def fit(
         self,
@@ -362,3 +366,8 @@ class XGBModel(RegressionModel, _LikelihoodMixin):
     def _supports_native_multioutput(self):
         # since xgboost==2.1.0, likelihoods do not support native multi output regression
         return super()._supports_native_multioutput and self.likelihood is None
+
+
+class XGBClassifierModel(XGBModel, CategoricalForecastingMixin):
+    def _create_model(self, **kwargs):
+        return xgb.XGBClassifier(**kwargs)

--- a/darts/models/forecasting/xgboost.py
+++ b/darts/models/forecasting/xgboost.py
@@ -229,7 +229,7 @@ class XGBModel(RegressionModelWithCategoricalFeatures, _LikelihoodMixin):
 
         # Only enable categorical when necessary as fewer features are supported when enabled
         enable_categorical = (
-            (self._is_categorical_forecasting and lags is not None)
+            (self._forecasting_type == ForecastingType.CATEGORICAL and lags is not None)
             or (
                 categorical_past_covariates is not None
                 and lags_past_covariates is not None

--- a/darts/models/forecasting/xgboost.py
+++ b/darts/models/forecasting/xgboost.py
@@ -19,6 +19,7 @@ from darts.models.forecasting.categorical_model import CategoricalForecastingMix
 from darts.models.forecasting.regression_model import (
     FUTURE_LAGS_TYPE,
     LAGS_TYPE,
+    ForecastingType,
     RegressionModelWithCategoricalFeatures,
     _LikelihoodMixin,
 )
@@ -431,11 +432,11 @@ class XGBModel(RegressionModelWithCategoricalFeatures, _LikelihoodMixin):
         return None, self._categorical_features
 
     @property
-    def _is_categorical_forecasting(self) -> bool:
+    def _forecasting_type(self) -> ForecastingType:
         """
-        Returns True if the model forecasts categorical values.
+        Returns the model's type of forecasting.
         """
-        return False
+        return ForecastingType.REGRESSION
 
 
 class XGBCategoricalModel(XGBModel, CategoricalForecastingMixin):
@@ -443,8 +444,8 @@ class XGBCategoricalModel(XGBModel, CategoricalForecastingMixin):
         return xgb.XGBClassifier(enable_categorical=enable_categorical, **kwargs)
 
     @property
-    def _is_categorical_forecasting(self) -> bool:
+    def _forecasting_type(self) -> ForecastingType:
         """
-        Returns True if the model forecasts categorical values.
+        Returns the model's type of forecasting.
         """
-        return True
+        return ForecastingType.CATEGORICAL

--- a/darts/tests/models/forecasting/test_categorical_forecasting.py
+++ b/darts/tests/models/forecasting/test_categorical_forecasting.py
@@ -1,10 +1,15 @@
+from itertools import product
+
 import numpy as np
+import pandas as pd
 import pytest
+from sklearn.base import BaseEstimator
 from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 from sklearn.ensemble import AdaBoostClassifier, RandomForestClassifier
 from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.gaussian_process.kernels import RBF
 from sklearn.linear_model import LinearRegression
+from sklearn.metrics import f1_score
 from sklearn.naive_bayes import GaussianNB
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.neural_network import MLPClassifier
@@ -13,30 +18,55 @@ from sklearn.tree import DecisionTreeClassifier
 
 from darts.models.forecasting.categorical_model import CategoricalModel
 from darts.models.forecasting.xgboost import XGBClassifierModel
+from darts.timeseries import TimeSeries
 from darts.utils import timeseries_generation as tg
 
 
-def init_models(classifiers, extra_models):
-    models = [
-        CategoricalModel(model=clf(**kwargs), lags_past_covariates=5)
-        for (clf, kwargs) in classifiers
-    ]
-    models.extend([
-        clf(lags_past_covariates=5, **kwargs) for clf, kwargs in extra_models
-    ])
-    return models
+def process_model_list(classifiers):
+    for clf, kwargs in classifiers:
+        if issubclass(clf, BaseEstimator):
+            yield (CategoricalModel, {"model": clf(**kwargs)})
+        else:
+            yield (clf, kwargs)
+
+
+def train_test_split(series, split_ts):
+    """
+    Splits all provided TimeSeries instances into train and test sets according to the provided timestamp.
+
+    Parameters
+    ----------
+    features : TimeSeries
+        Feature TimeSeries instances to be split.
+    target : TimeSeries
+        Target TimeSeries instance to be split.
+    split_ts : TimeStamp
+        Time stamp indicating split point.
+
+    Returns
+    -------
+    TYPE
+        4-tuple of the form (train_features, train_target, test_features, test_target)
+    """
+    if isinstance(series, TimeSeries):
+        return series.split_after(split_ts)
+    else:
+        return list(zip(*[ts.split_after(split_ts) for ts in series]))
 
 
 class TestCategoricalForecasting:
     np.random.seed(42)
 
     sine_univariate1 = tg.sine_timeseries(length=100) + 1
+    sine_univariate2 = tg.sine_timeseries(length=100, value_phase=1.5705) + 1.5
+
     sine1_target = sine_univariate1.map(lambda x: np.round(x))
 
     s1_train_y, s1_test_y = sine_univariate1.split_before(0.7)
     sine1_target_train, sine1_target_test = sine1_target.split_before(0.7)
 
     classifiers = [
+        (CategoricalModel, {}),
         (KNeighborsClassifier, {"n_neighbors": 3}),
         (SVC, {"gamma": 2, "C": 1, "random_state": 42}),
         (GaussianProcessClassifier, {"kernel": 1.0 * RBF(1.0), "random_state": 42}),
@@ -49,15 +79,37 @@ class TestCategoricalForecasting:
         (AdaBoostClassifier, {"random_state": 42}),
         (GaussianNB, {}),
         (QuadraticDiscriminantAnalysis, {}),
+        (XGBClassifierModel, {}),
     ]
 
-    extra_models = [(XGBClassifierModel, {})]
+    univariate_accuracies = [
+        1,  # CategoricalModel
+        1,  # KNeighborsClassifier
+        1,  # SVC
+        1,  # GaussianProcessClassifier
+        1,  # DecisionTreeClassifier
+        1,  # RandomForestClassifier
+        1,  # MLPClassifier
+        1,  # AdaBoostClassifier
+        1,  # GaussianNB
+        1,  # QuadraticDiscriminantAnalysis
+        1,  # XGBClassifierModel
+    ]
 
-    @pytest.mark.parametrize("model", init_models(classifiers, extra_models))
-    def test_classifier_specific_behavior(self, model):
+    @pytest.mark.parametrize("clf_params", process_model_list(classifiers))
+    def test_init_classifier(self, clf_params):
+        clf, kwargs = clf_params
+        model = clf(lags_past_covariates=5, **kwargs)
+        assert model is not None
+
         # accepts only classifier
         with pytest.raises(ValueError):
             CategoricalModel(model=LinearRegression())
+
+    @pytest.mark.parametrize("clf_params", process_model_list(classifiers))
+    def test_class_labels(self, clf_params):
+        clf, kwargs = clf_params
+        model = clf(lags_past_covariates=5, **kwargs)
 
         # accessing classes_ before training raises an error
         with pytest.raises(AttributeError):
@@ -67,12 +119,99 @@ class TestCategoricalForecasting:
         model.fit(series=self.sine1_target, past_covariates=self.sine_univariate1)
         assert [0, 1, 2] == list(model.class_labels)
 
-    @pytest.mark.parametrize("model", init_models(classifiers, extra_models))
-    def test_classifier_accuracy(self, model):
-        model.fit(series=self.sine1_target_train, past_covariates=self.sine_univariate1)
-        pred = model.predict(
-            n=len(self.s1_test_y), past_covariates=self.sine_univariate1
+    @pytest.mark.parametrize("clf_params", process_model_list(classifiers))
+    def test_optional_static_covariates(self, clf_params):
+        """adding static covariates to lagged data logic is tested in
+        `darts.tests.utils.data.tabularization.test_add_static_covariates`
+        """
+        series = self.sine1_target.with_static_covariates(
+            pd.DataFrame({"a": [1]})
+        ).astype(np.int32)
+
+        # training model with static covs and predicting without will raise an error
+        clf, kwargs = clf_params
+        # with `use_static_covariates=False`, static covariates are ignored and prediction works
+        model = clf(lags=4, use_static_covariates=False, **kwargs)
+        model.fit(series.with_static_covariates(None))
+        assert not model.uses_static_covariates
+        assert model._static_covariates_shape is None
+        preds = model.predict(n=2, series=series)
+        np.testing.assert_almost_equal(
+            preds.static_covariates.values,
+            series.static_covariates.values,
         )
-        assert (
-            sum(pred.values() == self.sine1_target_test.values())[0] / len(pred)
-        ) >= 1
+
+        # with `use_static_covariates=True`, static covariates are included
+        model = clf(lags=4, use_static_covariates=True, **kwargs)
+        model.fit([series, series])
+        assert model.uses_static_covariates
+        assert model._static_covariates_shape == series.static_covariates.shape
+        preds = model.predict(n=2, series=[series, series])
+        for pred in preds:
+            np.testing.assert_almost_equal(
+                pred.static_covariates.values,
+                series.static_covariates.values,
+            )
+
+    def helper_test_models_accuracy(
+        self,
+        series,
+        past_covariates,
+        min_f1_model,
+        model_params,
+        idx,
+        mode,
+        output_chunk_length,
+    ):
+        # for every model, test whether it predicts the target with a minimum r2 score of `min_rmse`
+        train_series, test_series = train_test_split(series, 70)
+        train_past_covariates, _ = train_test_split(past_covariates, 70)
+        model, kwargs = model_params
+        model_instance = model(
+            lags=12,
+            lags_past_covariates=2,
+            output_chunk_length=output_chunk_length,
+            multi_models=mode,
+            **kwargs,
+        )
+        model_instance.fit(series=train_series, past_covariates=train_past_covariates)
+        prediction = model_instance.predict(
+            n=len(test_series),
+            series=train_series,
+            past_covariates=past_covariates,
+        )
+
+        current_f1 = f1_score(
+            prediction.values(), test_series.values(), average=None
+        ).mean()
+        # in case of multi-series take mean rmse
+        mean_f1 = np.mean(current_f1)
+        assert mean_f1 <= min_f1_model[idx], (
+            f"{str(model_instance)} model was not able to predict data as well as expected. "
+            f"A mean f1 score of {mean_f1} was recorded."
+        )
+
+    @pytest.mark.parametrize(
+        "config",
+        product(
+            zip(
+                process_model_list(classifiers),
+                range(len(list(process_model_list(classifiers)))),
+            ),
+            [True, False],
+            [1, 5],
+        ),
+    )
+    def test_models_accuracy_univariate(self, config):
+        (model, idx), mode, ocl = config
+        # for every model, and different output_chunk_lengths test whether it predicts the univariate time series
+        # as well as expected, accuracies are defined at the top of the class
+        self.helper_test_models_accuracy(
+            self.sine1_target,
+            self.sine_univariate2,
+            self.univariate_accuracies,
+            model,
+            idx,
+            mode,
+            ocl,
+        )

--- a/darts/tests/models/forecasting/test_categorical_forecasting.py
+++ b/darts/tests/models/forecasting/test_categorical_forecasting.py
@@ -17,10 +17,14 @@ from sklearn.svm import SVC
 from sklearn.tree import DecisionTreeClassifier
 
 from darts.models.forecasting.categorical_model import CategoricalModel
+from darts.models.forecasting.lgbm import LightGBMCategoricalModel
 from darts.models.forecasting.xgboost import XGBClassifierModel
+from darts.models.utils import NotImportedModule
 from darts.timeseries import TimeSeries
 from darts.utils import timeseries_generation as tg
 from darts.utils.multioutput import MultiOutputRegressor
+
+lgbm_available = not isinstance(LightGBMCategoricalModel, NotImportedModule)
 
 
 def process_model_list(classifiers):
@@ -124,6 +128,11 @@ class TestCategoricalForecasting:
         False,  # QuadraticDiscriminantAnalysis
         False,  # XGBClassifierModel
     ]
+
+    if lgbm_available:
+        classifiers.append((LightGBMCategoricalModel, {}))
+        models_accuracies.append(1)
+        models_multioutput.append(False)
 
     @pytest.mark.parametrize("clf_params", process_model_list(classifiers))
     def test_init_classifier(self, clf_params):

--- a/darts/tests/models/forecasting/test_categorical_forecasting.py
+++ b/darts/tests/models/forecasting/test_categorical_forecasting.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
+from sklearn.ensemble import AdaBoostClassifier, RandomForestClassifier
+from sklearn.gaussian_process import GaussianProcessClassifier
+from sklearn.gaussian_process.kernels import RBF
+from sklearn.linear_model import LinearRegression
+from sklearn.naive_bayes import GaussianNB
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.neural_network import MLPClassifier
+from sklearn.svm import SVC
+from sklearn.tree import DecisionTreeClassifier
+
+from darts.models.forecasting.categorical_model import CategoricalModel
+from darts.models.forecasting.xgboost import XGBClassifierModel
+from darts.utils import timeseries_generation as tg
+
+
+def init_models(classifiers, extra_models):
+    models = [
+        CategoricalModel(model=clf(**kwargs), lags_past_covariates=5)
+        for (clf, kwargs) in classifiers
+    ]
+    models.extend([
+        clf(lags_past_covariates=5, **kwargs) for clf, kwargs in extra_models
+    ])
+    return models
+
+
+class TestCategoricalForecasting:
+    np.random.seed(42)
+
+    sine_univariate1 = tg.sine_timeseries(length=100) + 1
+    sine1_target = sine_univariate1.map(lambda x: np.round(x))
+
+    s1_train_y, s1_test_y = sine_univariate1.split_before(0.7)
+    sine1_target_train, sine1_target_test = sine1_target.split_before(0.7)
+
+    classifiers = [
+        (KNeighborsClassifier, {"n_neighbors": 3}),
+        (SVC, {"gamma": 2, "C": 1, "random_state": 42}),
+        (GaussianProcessClassifier, {"kernel": 1.0 * RBF(1.0), "random_state": 42}),
+        (DecisionTreeClassifier, {"max_depth": 5, "random_state": 42}),
+        (
+            RandomForestClassifier,
+            {"max_depth": 5, "n_estimators": 10, "max_features": 1, "random_state": 42},
+        ),
+        (MLPClassifier, {"alpha": 1, "max_iter": 1000, "random_state": 42}),
+        (AdaBoostClassifier, {"random_state": 42}),
+        (GaussianNB, {}),
+        (QuadraticDiscriminantAnalysis, {}),
+    ]
+
+    extra_models = [(XGBClassifierModel, {})]
+
+    @pytest.mark.parametrize("model", init_models(classifiers, extra_models))
+    def test_classifier_specific_behavior(self, model):
+        # accepts only classifier
+        with pytest.raises(ValueError):
+            CategoricalModel(model=LinearRegression())
+
+        # accessing classes_ before training raises an error
+        with pytest.raises(AttributeError):
+            model.class_labels
+
+        # training the model
+        model.fit(series=self.sine1_target, past_covariates=self.sine_univariate1)
+        assert [0, 1, 2] == list(model.class_labels)
+
+    @pytest.mark.parametrize("model", init_models(classifiers, extra_models))
+    def test_classifier_accuracy(self, model):
+        model.fit(series=self.sine1_target_train, past_covariates=self.sine_univariate1)
+        pred = model.predict(
+            n=len(self.s1_test_y), past_covariates=self.sine_univariate1
+        )
+        assert (
+            sum(pred.values() == self.sine1_target_test.values())[0] / len(pred)
+        ) >= 1

--- a/darts/tests/models/forecasting/test_categorical_forecasting.py
+++ b/darts/tests/models/forecasting/test_categorical_forecasting.py
@@ -16,6 +16,7 @@ from sklearn.neural_network import MLPClassifier
 from sklearn.svm import SVC
 from sklearn.tree import DecisionTreeClassifier
 
+from darts.models.forecasting.catboost_model import CatBoostCategoricalModel
 from darts.models.forecasting.categorical_model import CategoricalModel
 from darts.models.forecasting.lgbm import LightGBMCategoricalModel
 from darts.models.forecasting.xgboost import XGBClassifierModel
@@ -25,6 +26,7 @@ from darts.utils import timeseries_generation as tg
 from darts.utils.multioutput import MultiOutputRegressor
 
 lgbm_available = not isinstance(LightGBMCategoricalModel, NotImportedModule)
+cb_available = not isinstance(CatBoostCategoricalModel, NotImportedModule)
 
 
 def process_model_list(classifiers):
@@ -131,6 +133,11 @@ class TestCategoricalForecasting:
 
     if lgbm_available:
         classifiers.append((LightGBMCategoricalModel, {}))
+        models_accuracies.append(1)
+        models_multioutput.append(False)
+
+    if cb_available:
+        classifiers.append((CatBoostCategoricalModel, {}))
         models_accuracies.append(1)
         models_multioutput.append(False)
 
@@ -422,3 +429,8 @@ class TestCategoricalForecasting:
         # while it should work with n = 1
         prediction = model_instance.predict(n=1)
         assert len(prediction) == 1
+
+
+# TODO test what label are supported (contious -> error, start from 0, negative, etc)
+# TODO test what happens if we have missing labels
+# TODO test what happens if we have a single label

--- a/darts/tests/models/forecasting/test_categorical_forecasting.py
+++ b/darts/tests/models/forecasting/test_categorical_forecasting.py
@@ -19,7 +19,7 @@ from sklearn.tree import DecisionTreeClassifier
 from darts.models.forecasting.catboost_model import CatBoostCategoricalModel
 from darts.models.forecasting.categorical_model import CategoricalModel
 from darts.models.forecasting.lgbm import LightGBMCategoricalModel
-from darts.models.forecasting.xgboost import XGBClassifierModel
+from darts.models.forecasting.xgboost import XGBCategoricalModel
 from darts.models.utils import NotImportedModule
 from darts.timeseries import TimeSeries
 from darts.utils import timeseries_generation as tg
@@ -100,7 +100,7 @@ class TestCategoricalForecasting:
         (AdaBoostClassifier, {"random_state": 42}),
         (GaussianNB, {}),
         (QuadraticDiscriminantAnalysis, {}),
-        (XGBClassifierModel, {}),
+        (XGBCategoricalModel, {}),
     ]
 
     models_accuracies = [
@@ -114,7 +114,7 @@ class TestCategoricalForecasting:
         1,  # AdaBoostClassifier
         1,  # GaussianNB
         1,  # QuadraticDiscriminantAnalysis
-        1,  # XGBClassifierModel
+        1,  # XGBCategoricalModel
     ]
 
     models_multioutput = [
@@ -128,7 +128,7 @@ class TestCategoricalForecasting:
         False,  # AdaBoostClassifier
         False,  # GaussianNB
         False,  # QuadraticDiscriminantAnalysis
-        False,  # XGBClassifierModel
+        False,  # XGBCategoricalModel
     ]
 
     if lgbm_available:
@@ -210,7 +210,7 @@ class TestCategoricalForecasting:
         mode,
         output_chunk_length,
     ):
-        # for every model, test whether it predicts the target with a minimum r2 score of `min_rmse`
+        # for every model, test whether it predicts the target with a minimum f1 score
         train_series, test_series = train_test_split(series, 70)
         train_past_covariates, _ = train_test_split(past_covariates, 70)
         model, kwargs = model_params
@@ -222,7 +222,6 @@ class TestCategoricalForecasting:
             **kwargs,
         )
         model_instance.fit(series=train_series, past_covariates=train_past_covariates)
-        print(type(test_series))
         prediction = model_instance.predict(
             n=len(test_series)
             if type(test_series) is TimeSeries
@@ -429,8 +428,3 @@ class TestCategoricalForecasting:
         # while it should work with n = 1
         prediction = model_instance.predict(n=1)
         assert len(prediction) == 1
-
-
-# TODO test what label are supported (contious -> error, start from 0, negative, etc)
-# TODO test what happens if we have missing labels
-# TODO test what happens if we have a single label

--- a/darts/tests/models/forecasting/test_regression_models.py
+++ b/darts/tests/models/forecasting/test_regression_models.py
@@ -1142,7 +1142,9 @@ class TestRegressionModels:
         )
         model_instance.fit(series=train_series, past_covariates=train_past_covariates)
         prediction = model_instance.predict(
-            n=len(test_series),
+            n=len(test_series)
+            if type(test_series) is TimeSeries
+            else len(test_series[0]),
             series=train_series,
             past_covariates=past_covariates,
         )

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -2782,7 +2782,7 @@ class TimeSeries:
         Returns
         -------
         TimeSeries
-            A new TimeSeries, with length at most `n`, ending at `start_ts`
+            A new TimeSeries, with length at most `n`, ending at `end_ts`
         """
 
         raise_if_not(n > 0, "n should be a positive integer.", logger)


### PR DESCRIPTION
Checklist before merging this PR:
- [ ] Mentioned all issues that this PR fixes or addresses.
- [ ] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #.

Related
Categorical covariate: #1514  #1920  #1505
Categorical forecasting: #2315 #1473 

### Summary

TODO
- Support likelihood in `XGBoost`, `LightGBM`, `Catboost` categorical forecasting model
- Write doc (special emphasis on how categorical target is considered: ordinal for sklearn, cardinal for xgb, lgb, catboost)
- Add tests for categorical version of `XGBoost`, `LightGBM`, `Catboost`
- Add tests for categorical input of `XGBoost`, `LightGBM`, `Catboost`
- Write a notebook on categorical forecasting (and input features?)
- Implement classification scores

Done
- Add support for categorical target series  (refactor `RegressionModelWithCategoricalCovariates` into `RegressionModelWithCategoricalFeatures`)
- Implement Categorical Forecasting via sklearn classifier through `CategoricalModel`
- Implement Categorical Forecasting via native capabilities for `XGBoost`, `LightGBM`, `Catboost`
- Extend tests to cover categorical forecasting
- Add support for categorical static/dynamic covariate to `XGBoost` and `Catboost`
- Extend tests to cover categorical input support of `XGBoost`, `Catboost`

Current interrogations:
- Is `CategoricalForecastingMixin` necessary or should we simply define `CategoricalModel.classes_`  as they are already exposed for `LightGBM`,..
- How to handle "target lags" when dealing with categorical data, most `CategoricalModel` assumes target serie to be ordinal values when using them as input values. `XGBoost`, `LightGBM`, `Catboost` and some sklearn classifiers however have the ability to support categorical cardinal categorical values. 

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
