### PR TITLE
Fix the torch_metric shape error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed a bug when training a `TorchForecastingModel`, where using certain `torchmetrics` that require a 2D model output (e.g. R2Score) raised an error. [He Weilin](https://github.com/cnhwl).
+
 **Dependencies**
 
 ### For developers of the library:

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -409,9 +409,8 @@ class PLForecastingModule(pl.LightningModule, ABC):
             pred = output.squeeze(dim=-1)
 
         # torch metrics require 2D targets of shape (batch size * ocl, num targets)
-        if self.n_targets > 1:
-            target = target.reshape(-1, self.n_targets)
-            pred = pred.reshape(-1, self.n_targets)
+        target = target.reshape(-1, self.n_targets)
+        pred = pred.reshape(-1, self.n_targets)
 
         metrics.update(pred, target)
 

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -30,6 +30,7 @@ from torchmetrics import (
     MeanAbsolutePercentageError,
     Metric,
     MetricCollection,
+    R2Score,
 )
 
 from darts.models import (
@@ -1428,6 +1429,7 @@ class TestTorchForecastingModel:
         metric_collection = MetricCollection([
             MeanAbsolutePercentageError(),
             MeanAbsoluteError(),
+            R2Score(),
         ])
 
         model_kwargs = {
@@ -1476,6 +1478,7 @@ class TestTorchForecastingModel:
         metric_collection = MetricCollection([
             MeanAbsolutePercentageError(),
             MeanAbsoluteError(),
+            R2Score(),
         ])
         model_kwargs = {
             "logger": DummyLogger(),


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2785.

### Summary
Reshape the pred and target regardless of whether `self.n_targets > 1`, to satisfy some torch_metrics such as R2Score(`preds.ndim <= 2`)