### PR TITLE
Fix the RegressionEnsembleModel error with output_chunk_shift > 0

### DIFF
--- a/darts/models/forecasting/ensemble_model.py
+++ b/darts/models/forecasting/ensemble_model.py
@@ -267,7 +267,9 @@ class EnsembleModel(GlobalForecastingModel):
         predictions = [
             model._predict_wrapper(
                 n=n,
-                series=series,
+                series=series[: -model.output_chunk_shift]
+                if model.output_chunk_shift
+                else series,
                 past_covariates=(
                     past_covariates if model.supports_past_covariates else None
                 ),


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2773

### Summary
When forecasting model `output_chunk_shift` > 0 and RegressionEnsembleModel `regression_train_n_points` == -1 or some large number, it would occur the forecasting model predict error:
```
        if self.output_chunk_shift and is_autoregression:
            raise_log(
                ValueError(
                    "Cannot perform auto-regression `(n > output_chunk_length)` with a model that uses a "
                    "shifted output chunk `(output_chunk_shift > 0)`."
                ),
                logger=logger,
            )
```
Therefore, I try to limit the RegressionEnsembleModel `regression_train_n_points` to be not bigger than the forecasting model `output_chunk_length`. Moreover, not bigger than ((the forecasting model `output_chunk_length`) minus (the max lag of the forecasting model)).