### PR TITLE
Improve TorchForecastingModel prediction efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - 🟠 Renamed `RegressionModel` to `SKLearnModel`. Using `RegressionModel` will raise a depraction warning.
   - 🟠 Renamed `RandomForest` to `RandomForestModel`. Using `RandomForest` will raise a depraction warning.
   - 🔴 Renamed `RegressionModelWithCategoricalCovariates` to `SKLearnModelWithCategoricalCovariates`. Removed `RegressionModelWithCategoricalCovariates`
+- Improvements to `TorchForecastingModel`: [#2802](https://github.com/unit8co/darts/pull/2802) by [Dennis Bader](https://github.com/dennisbader).
+  - Drastically improved prediction speed which is now up to 5.4 times as fast before. Using `n_jobs>1` now significantly boosts efficiency. This affects `predict()`, `historcial_forecasts()`, `backtest()`, `gridsearch()` and `residuals()`. The highest boost can be observed when calling historical forecasts, backtest, or residuals with `last_points_only=False`.
+  - Added parameter `values_only` to method `predict_from_dataset()` which will return a tuple of (prediction `np.ndarray`, target series schema, prediction start time) instead of `TimeSeries` objects.
 - 🔴 Improvements to `TorchForecastingModel` datasets: [#2798](https://github.com/unit8co/darts/pull/2798) by [Dennis Bader](https://github.com/dennisbader).
   - We simplified the training and inference datasets. Instead of having covariates specific datasets, the new datasets now support all combinations of covariates natively:
     - `ShiftedTorchTrainingDataset` (replaces all `*ShiftedDataset`)
@@ -25,9 +28,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
     - `SequentialTorchInferenceDataset` (replaces all `*InferenceDataset`)
   - All datasets now have uniform output:
     - Training datasets: Tuple[past target, past cov, historic future cov, future cov, static cov, sample weight, future target].
-    - Inference datasets: Tuple[past target, past cov, future past cov, historic future cov, future cov, static cov, target TimeSeries, pred start time]
+    - Inference datasets: Tuple[past target, past cov, future past cov, historic future cov, future cov, static cov, target series schema, pred start time]
   - `HorizonBasedTorchTrainingDataset` now also supports future covariates.
   - Added parameter `stride` to `*TorchTrainingDatset` to apply a stride between two consecutive training samples.  [#2624](https://github.com/unit8co/darts/pull/2529) by [Antoine Madrona](https://github.com/madtoinou)
+- Added method `schema()` to `TimeSeries` to extract the schema from a series. It contains information about the time index, columns, static covariates, hierarchy, and metadata. [#2802](https://github.com/unit8co/darts/pull/2802) by [Dennis Bader](https://github.com/dennisbader).
 
 **Fixed**
 

--- a/darts/models/forecasting/conformal_models.py
+++ b/darts/models/forecasting/conformal_models.py
@@ -1258,7 +1258,7 @@ class ConformalModel(GlobalForecastingModel, ABC):
                 inner_iterator = enumerate(s_hfcs[first_fc_idx:last_fc_idx:rel_stride])
 
             comp_names_out = (
-                self.likelihood.component_names(series_)
+                self.likelihood.component_names(series=series_)
                 if predict_likelihood_parameters
                 else None
             )

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -330,7 +330,7 @@ class PLForecastingModule(pl.LightningModule, ABC):
 
         batch
             output of Darts' :class:`TorchInferenceDataset` - tuple of ``(past target, past cov,
-            future past cov, historic future cov, future cov, static cov, input `TimeSeries`,
+            future past cov, historic future cov, future cov, static cov, target series schema,
             prediction start time step)``
         batch_idx
             the batch index of the current batch
@@ -338,7 +338,7 @@ class PLForecastingModule(pl.LightningModule, ABC):
             the dataloader index
         """
         # batch has elements (past target, past cov, future past cov, historic future cov, future cov,
-        # static cov, target `TimeSeries`, pred start time)
+        # static cov, target series schema, pred start time)
         input_data_tuple, batch_series_schemas, batch_pred_starts = (
             batch[:-2],
             batch[-2],

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -12,7 +12,6 @@ import pytorch_lightning as pl
 import torch
 import torch.nn as nn
 import torchmetrics
-from joblib import Parallel, delayed
 
 from darts.logging import get_logger, raise_if, raise_log
 from darts.models.components.layer_norm_variants import RINorm
@@ -24,7 +23,6 @@ from darts.utils.data.torch_datasets.utils import (
     TorchTrainingBatch,
 )
 from darts.utils.likelihood_models.torch import TorchLikelihood
-from darts.utils.timeseries_generation import _build_forecast_series
 from darts.utils.torch import MonteCarloDropout
 
 logger = get_logger(__name__)
@@ -210,7 +208,6 @@ class PLForecastingModule(pl.LightningModule, ABC):
         self.pred_num_samples: Optional[int] = None
         self.pred_roll_size: Optional[int] = None
         self.pred_batch_size: Optional[int] = None
-        self.pred_n_jobs: Optional[int] = None
         self.predict_likelihood_parameters: Optional[bool] = None
         self.pred_mc_dropout: Optional[bool] = None
 
@@ -342,7 +339,7 @@ class PLForecastingModule(pl.LightningModule, ABC):
         """
         # batch has elements (past target, past cov, future past cov, historic future cov, future cov,
         # static cov, target `TimeSeries`, pred start time)
-        input_data_tuple, batch_input_series, batch_pred_starts = (
+        input_data_tuple, batch_series_schemas, batch_pred_starts = (
             batch[:-2],
             batch[-2],
             batch[-1],
@@ -397,25 +394,11 @@ class PLForecastingModule(pl.LightningModule, ABC):
         # concatenate the batch of samples, to form self.pred_num_samples samples
         batch_predictions = torch.cat(batch_predictions, dim=0)
         batch_predictions = batch_predictions.cpu().detach().numpy()
-
-        ts_forecasts = Parallel(n_jobs=self.pred_n_jobs)(
-            delayed(_build_forecast_series)(
-                [batch_prediction[batch_idx] for batch_prediction in batch_predictions],
-                input_series,
-                custom_columns=(
-                    self.likelihood.component_names(input_series)
-                    if self.predict_likelihood_parameters
-                    else None
-                ),
-                with_static_covs=False if self.predict_likelihood_parameters else True,
-                with_hierarchy=False if self.predict_likelihood_parameters else True,
-                pred_start=pred_start,
-            )
-            for batch_idx, (input_series, pred_start) in enumerate(
-                zip(batch_input_series, batch_pred_starts)
-            )
+        return (
+            batch_predictions,
+            batch_series_schemas,
+            batch_pred_starts,
         )
-        return ts_forecasts
 
     def set_predict_parameters(
         self,
@@ -423,7 +406,6 @@ class PLForecastingModule(pl.LightningModule, ABC):
         num_samples: int,
         roll_size: int,
         batch_size: int,
-        n_jobs: int,
         predict_likelihood_parameters: bool,
         mc_dropout: bool,
     ) -> None:
@@ -432,7 +414,6 @@ class PLForecastingModule(pl.LightningModule, ABC):
         self.pred_num_samples = num_samples
         self.pred_roll_size = roll_size
         self.pred_batch_size = batch_size
-        self.pred_n_jobs = n_jobs
         self.predict_likelihood_parameters = predict_likelihood_parameters
         self.pred_mc_dropout = mc_dropout
 

--- a/darts/models/forecasting/sf_model.py
+++ b/darts/models/forecasting/sf_model.py
@@ -225,7 +225,7 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
 
         comp_names_out = None
         if predict_likelihood_parameters:
-            comp_names_out = self.likelihood.component_names(series)
+            comp_names_out = self.likelihood.component_names(series=series)
 
         return _build_forecast_series(
             points_preds=pred_vals,

--- a/darts/models/forecasting/sklearn_model.py
+++ b/darts/models/forecasting/sklearn_model.py
@@ -1236,7 +1236,7 @@ class SKLearnModel(GlobalForecastingModel):
                 points_preds=row,
                 input_series=input_tgt,
                 custom_components=(
-                    self.likelihood.component_names(input_tgt)
+                    self.likelihood.component_names(series=input_tgt)
                     if predict_likelihood_parameters
                     else None
                 ),

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1814,6 +1814,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             iterable=zip(predictions, series_schemas, pred_starts),
             verbose=verbose,
             total=len(predictions),
+            desc="Generating TimeSeries",
         )
         ts_forecasts = _parallel_apply(
             iterator=iterator,

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -628,13 +628,13 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         Parameters
         ----------
         train_sample
-            (past_target, past_covariates, historic_future_covariates, future_covariates, static covariates,
-            future_target)
+            (past target, past covariates, historic future covariates, future covariates, static covariates,
+            future target)
         predict_sample
-            (past_target, past_covariates, future_past_covariates, historic_future_covariates, future_covariates,
-            static_covariates, target series, prediction start time)
+            (past target, past covariates, future past covariates, historic future covariates, future covariates,
+            static covariates, target series schema, prediction start time)
         """
-        # datasets; we skip future_target for train and predict, and skip future_past_covariates for predict datasets
+        # datasets; we skip future target for train and predict, and skip future past covariates for predict datasets
         ds_names = [
             "series",
             "past_covariates",
@@ -643,11 +643,11 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             "static_covariates",
         ]
 
-        # ignore `sample_weight` and `future_target` from train sample
+        # ignore sample weight and future target from train sample
         train_features = train_sample[:-1]
         train_has_ds = [ds is not None for ds in train_features]
 
-        # ignore `future_past_covariates` and `ts_target` from predict sample
+        # ignore future past covariates, target schema, and prediction start time from predict sample
         predict_features = predict_sample[:2] + predict_sample[3:-2]
         predict_has_ds = [ds is not None for ds in predict_features]
 

--- a/darts/tests/utils/test_likelihood_models/test_likelihoods.py
+++ b/darts/tests/utils/test_likelihood_models/test_likelihoods.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from darts import TimeSeries
+from darts.utils.likelihood_models.base import Likelihood, LikelihoodType
+
+
+class TestLikelihoodModel:
+    def test_likelihood_component_names(self):
+        lkl = Likelihood(
+            likelihood_type=LikelihoodType.Gaussian, parameter_names=["mu", "sigma"]
+        )
+
+        components = ["a", "b"]
+        series = TimeSeries.from_values(
+            values=np.zeros((3, len(components))), columns=components
+        )
+        # cannot give series and components at the same time
+        with pytest.raises(ValueError):
+            _ = lkl.component_names(series=series, components=components)
+
+        names_expected = ["a_mu", "a_sigma", "b_mu", "b_sigma"]
+        names_1 = lkl.component_names(series=series)
+        names_2 = lkl.component_names(components=components)
+        assert names_1 == names_2 == names_expected

--- a/darts/tests/utils/test_likelihood_models/test_torch_likelihoods.py
+++ b/darts/tests/utils/test_likelihood_models/test_torch_likelihoods.py
@@ -49,7 +49,7 @@ likelihood_models = {
 }
 
 
-class TestLikelihoodModel:
+class TestTorchLikelihoodModel:
     def test_intra_class_equality(self):
         for _, model_pair in likelihood_models.items():
             assert model_pair[0] == model_pair[0]

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1902,6 +1902,20 @@ class TimeSeries:
 
         return nw.from_dict(data, backend=backend).to_native()
 
+    def _schema(self, copy: bool = True) -> dict[str, Any]:
+        """"""
+        schema = {
+            "time_freq": self._freq,
+            "time_name": self._time_index.name,
+            "columns": self._xa.get_index(DIMS[1]),
+            STATIC_COV_TAG: self.static_covariates,
+            HIERARCHY_TAG: self.hierarchy,
+            METADATA_TAG: self.metadata,
+        }
+        if copy:
+            schema = {k: deepcopy(v) for k, v in schema.items()}
+        return schema
+
     def quantile_df(self, quantile=0.5) -> pd.DataFrame:
         """
         Return a Pandas DataFrame containing the single desired quantile of each component (over the samples).

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1902,8 +1902,20 @@ class TimeSeries:
 
         return nw.from_dict(data, backend=backend).to_native()
 
-    def _schema(self, copy: bool = True) -> dict[str, Any]:
-        """"""
+    def schema(self, copy: bool = True) -> dict[str, Any]:
+        """Returns the schema of the time series as a dictionary.
+
+        Can be used to create new `TimeSeries` with the same schema.
+
+        The keys and values are:
+
+        - "time_freq": the frequency (or step size) of the time (or range) index
+        - "time_name": the name of the time index
+        - "columns": the columns / components
+        - "static_covariates": the static covariates
+        - "hierarchy": the hierarchy
+        - "metadata": the metadata
+        """
         schema = {
             "time_freq": self._freq,
             "time_name": self._time_index.name,

--- a/darts/utils/data/torch_datasets/inference_dataset.py
+++ b/darts/utils/data/torch_datasets/inference_dataset.py
@@ -327,6 +327,6 @@ class SequentialTorchInferenceDataset(TorchInferenceDataset):
             hfc,
             fc,
             sc,
-            series,
+            series._schema(copy=False),
             pred_start,
         )

--- a/darts/utils/data/torch_datasets/inference_dataset.py
+++ b/darts/utils/data/torch_datasets/inference_dataset.py
@@ -327,6 +327,6 @@ class SequentialTorchInferenceDataset(TorchInferenceDataset):
             hfc,
             fc,
             sc,
-            series._schema(copy=False),
+            series.schema(copy=False),
             pred_start,
         )

--- a/darts/utils/data/torch_datasets/inference_dataset.py
+++ b/darts/utils/data/torch_datasets/inference_dataset.py
@@ -317,7 +317,7 @@ class SequentialTorchInferenceDataset(TorchInferenceDataset):
         #     historic future cov,
         #     future cov,
         #     static cov,
-        #     target series,
+        #     target series schema,
         #     prediction start time,
         # )
         return (

--- a/darts/utils/data/torch_datasets/utils.py
+++ b/darts/utils/data/torch_datasets/utils.py
@@ -1,11 +1,9 @@
 from collections.abc import Sequence
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
 import torch
-
-from darts import TimeSeries
 
 # `TorchTrainingDataset` output
 # (past target, past cov, historic future cov, future cov, static cov, sample weight, future target)
@@ -41,7 +39,7 @@ TorchTrainingSample = tuple[
 
 
 # `TorchInferenceDataset` output
-# (past target, past cov, future past cov, historic future cov, future cov, static cov, target series, pred time)
+# (past target, past cov, future past cov, historic future cov, future cov, static cov, target series schema, pred time)
 TorchInferenceDatasetOutput = tuple[
     Optional[np.ndarray],
     Optional[np.ndarray],
@@ -49,7 +47,7 @@ TorchInferenceDatasetOutput = tuple[
     Optional[np.ndarray],
     Optional[np.ndarray],
     Optional[np.ndarray],
-    TimeSeries,
+    dict[str, Any],
     Union[pd.Timestamp, int],
 ]
 # `TorchInferenceDataset` output converted to batch with `torch.Tensor`
@@ -60,7 +58,7 @@ TorchInferenceBatch = tuple[
     Optional[torch.Tensor],
     Optional[torch.Tensor],
     Optional[torch.Tensor],
-    Sequence[TimeSeries],
+    Sequence[dict[str, Any]],
     Union[Sequence[pd.Timestamp], Sequence[int]],
 ]
 

--- a/darts/utils/historical_forecasts/optimized_historical_forecasts_regression.py
+++ b/darts/utils/historical_forecasts/optimized_historical_forecasts_regression.py
@@ -51,7 +51,7 @@ def _optimized_historical_forecasts_last_points_only(
         )
         freq = series_.freq
         forecast_components = (
-            model.likelihood.component_names(series_)
+            model.likelihood.component_names(series=series_)
             if predict_likelihood_parameters
             else series_.columns
         )
@@ -222,7 +222,7 @@ def _optimized_historical_forecasts_all_points(
         )
         freq = series_.freq
         forecast_components = (
-            model.likelihood.component_names(series_)
+            model.likelihood.component_names(series=series_)
             if predict_likelihood_parameters
             else series_.columns
         )

--- a/darts/utils/historical_forecasts/optimized_historical_forecasts_torch.py
+++ b/darts/utils/historical_forecasts/optimized_historical_forecasts_torch.py
@@ -11,7 +11,7 @@ from darts.utils.historical_forecasts.utils import (
     _get_historical_forecast_boundaries,
     _process_predict_start_points_bounds,
 )
-from darts.utils.utils import generate_index
+from darts.utils.timeseries_generation import _build_forecast_series_from_schema
 
 logger = get_logger(__name__)
 
@@ -112,36 +112,50 @@ def _optimized_historical_forecasts(
         bounds=bounds,
     )
 
-    predictions = model.predict_from_dataset(
+    # to avoid having to generate `TimeSeries` twice when `last_points_only=True`, we only
+    # return the values in that case
+    model_out = model.predict_from_dataset(
         n=forecast_horizon,
         dataset=dataset,
         verbose=verbose,
         num_samples=num_samples,
         predict_likelihood_parameters=predict_likelihood_parameters,
+        values_only=last_points_only,
         **kwargs,
     )
 
-    # torch models return list of time series in order of historical forecasts: we reorder per time series
+    # torch model returns output in the order of the historical forecasts: we reorder per time series
     forecasts_list = []
+    likelihood_component_names_fn = (
+        model.likelihood.component_names if predict_likelihood_parameters else None
+    )
     for series_idx in range(len(series)):
         pred_idx_start = 0 if not series_idx else cum_lengths[series_idx - 1]
         pred_idx_end = cum_lengths[series_idx]
-        preds = predictions[pred_idx_start:pred_idx_end]
+
         if last_points_only:
-            # torch predictions come with the entire horizon: we extract last values
-            preds = TimeSeries.from_times_and_values(
-                times=generate_index(
-                    start=preds[0].end_time(),
-                    length=len(preds),
-                    freq=preds[0].freq * stride,
-                ),
-                values=np.concatenate(
-                    [p.all_values(copy=False)[-1:, :, :] for p in preds], axis=0
-                ),
-                columns=preds[0].columns,
-                static_covariates=preds[0].static_covariates,
-                hierarchy=preds[0].hierarchy,
-                metadata=preds[0].metadata,
+            # model output is tuple of (np.ndarray of predictions, series schemas, pred start times)
+            preds = model_out[0][pred_idx_start:pred_idx_end]
+            schema = model_out[1][pred_idx_start]
+            pred_start = model_out[2][pred_idx_start]
+
+            # predictions come with the entire horizon: we extract last values
+            preds = preds[:, -1]
+            pred_start += (forecast_horizon - 1) * schema["time_freq"]
+
+            # adjust frequency with stride
+            schema["time_freq"] *= stride
+
+            # predictions come with the entire horizon: we extract last values
+            preds = _build_forecast_series_from_schema(
+                values=preds,
+                schema=schema,
+                pred_start=pred_start,
+                predict_likelihood_parameters=predict_likelihood_parameters,
+                likelihood_component_names_fn=likelihood_component_names_fn,
             )
+        else:
+            # model output is already a sequence of forecasted `TimeSeries`
+            preds = model_out[pred_idx_start:pred_idx_end]
         forecasts_list.append(preds)
     return forecasts_list

--- a/darts/utils/likelihood_models/base.py
+++ b/darts/utils/likelihood_models/base.py
@@ -5,6 +5,9 @@ from typing import Optional, Union
 import pandas as pd
 
 from darts import TimeSeries
+from darts.logging import get_logger, raise_log
+
+logger = get_logger(__name__)
 
 
 class LikelihoodType(Enum):
@@ -56,10 +59,21 @@ class Likelihood:
             "ignore_attrs_equality",
         ]
 
-    def component_names(self, input_series: TimeSeries) -> list[str]:
+    def component_names(
+        self,
+        series: Optional[TimeSeries] = None,
+        components: Optional[Sequence] = None,
+    ) -> list[str]:
         """Generates names for the parameters of the Likelihood."""
+        if (series is not None) == (components is not None):
+            raise_log(
+                ValueError("Only one of `series` or `components` must be specified."),
+                logger=logger,
+            )
+        if series is not None:
+            components = series.components
         return likelihood_component_names(
-            components=input_series.components, parameter_names=self.parameter_names
+            components=components, parameter_names=self.parameter_names
         )
 
     @property

--- a/darts/utils/timeseries_generation.py
+++ b/darts/utils/timeseries_generation.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from darts import TimeSeries
 from darts.logging import get_logger, raise_if, raise_if_not, raise_log
+from darts.timeseries import HIERARCHY_TAG, METADATA_TAG, STATIC_COV_TAG
 from darts.utils.utils import generate_index
 
 logger = get_logger(__name__)
@@ -823,7 +824,7 @@ def _build_forecast_series_from_schema(
     predict_likelihood_parameters
         Whether the values represent predicted likelihood parameters.
     likelihood_component_names_fn
-        A function to compute the likelihood parameter component names. Only effictive with
+        A function to compute the likelihood parameter component names. Only effective when
         `predict_likelihood_parameters=True`.
 
     Returns
@@ -851,8 +852,8 @@ def _build_forecast_series_from_schema(
         hierarchy = None
     else:
         columns = schema["columns"]
-        static_covariates = schema["static_covariates"]
-        hierarchy = schema["hierarchy"]
+        static_covariates = schema[STATIC_COV_TAG]
+        hierarchy = schema[HIERARCHY_TAG]
 
     return TimeSeries.from_times_and_values(
         times=time_index,
@@ -860,7 +861,7 @@ def _build_forecast_series_from_schema(
         columns=columns,
         static_covariates=static_covariates,
         hierarchy=hierarchy,
-        metadata=schema["metadata"],
+        metadata=schema[METADATA_TAG],
     )
 
 

--- a/darts/utils/timeseries_generation.py
+++ b/darts/utils/timeseries_generation.py
@@ -5,7 +5,7 @@ Utils for time series generation
 
 import math
 from collections.abc import Sequence
-from typing import Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import holidays
 import numpy as np
@@ -799,6 +799,68 @@ def _build_forecast_series(
         static_covariates=input_series.static_covariates if with_static_covs else None,
         hierarchy=input_series.hierarchy if with_hierarchy else None,
         metadata=input_series.metadata,
+    )
+
+
+def _build_forecast_series_from_schema(
+    values: np.ndarray,
+    schema: dict[str, Any],
+    pred_start: Union[pd.Timestamp, int],
+    predict_likelihood_parameters: bool,
+    likelihood_component_names_fn: Optional[Callable] = None,
+) -> TimeSeries:
+    """
+    Builds a forecast time series from predicted values and `TimeSeries` schema starting at `pred_start`.
+
+    Parameters
+    ----------
+    values
+        Forecasted values, can be either the target(s) or parameters of the likelihood model
+    schema
+        Schema of the predicted target `TimeSeries`.
+    pred_start
+        The prediction start time.
+    predict_likelihood_parameters
+        Whether the values represent predicted likelihood parameters.
+    likelihood_component_names_fn
+        A function to compute the likelihood parameter component names. Only effictive with
+        `predict_likelihood_parameters=True`.
+
+    Returns
+    -------
+    TimeSeries
+        A new TimeSeries instance.
+    """
+    time_index = generate_index(
+        start=pred_start,
+        freq=schema["time_freq"],
+        length=len(values),
+        name=schema["time_name"],
+    )
+    if predict_likelihood_parameters:
+        if likelihood_component_names_fn is None:
+            raise_log(
+                ValueError(
+                    "Must pass `likelihood_component_names_fn` with "
+                    "`predict_likelihood_parameters=True`"
+                ),
+                logger=logger,
+            )
+        columns = likelihood_component_names_fn(components=schema["columns"])
+        static_covariates = None
+        hierarchy = None
+    else:
+        columns = schema["columns"]
+        static_covariates = schema["static_covariates"]
+        hierarchy = schema["hierarchy"]
+
+    return TimeSeries.from_times_and_values(
+        times=time_index,
+        values=values,
+        columns=columns,
+        static_covariates=static_covariates,
+        hierarchy=hierarchy,
+        metadata=schema["metadata"],
     )
 
 


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2780.

### Summary

- Drastically improves prediction efficiency of `TorchForecastingModel`.
  - Moved forecast TimeSeries creation out of the batch prediction process and instead apply it once on the total predictions. Using multi-processing (`n_jobs>1`) created a huge overhead when performing it on the batch-level
  - Using multi-processing (`n_jobs>1`) now boosts the forecast `TimeSeries` creation proportionally!
  - Instead of passing the entire `TimeSeries` as part of the prediction batches, we now only pass the schema of the `TimeSeries`.
- Added parameter `values_only: bool = True` to `TorchForecastingModel.predict_from_dataset()`:
  - Whether to return the predicted values only. If `False`, will return `TimeSeries` objects. Otherwise, will
     return a tuple of `(np.ndarray, list[dict[str, Any]], list[Union[pd.Timestamp, int]])`. The first element
     represents the predictions with shape `(num_predictions, n, columns, num_samples)`. The second element
     represents the schemas of forecasted target `TimeSeries`. The third element represents the prediction start
     times.
- Added `TimeSeries.schema(copy: bool = True)` to extract the schema from a series. This allows to create new series with identical schema.


Some comparisons:

| process | boost (time old / time new)|
|---------|----------------------|
| predict() or historical_forecast() (last_points_only=False) n_jobs=1 | 1.2 |
| predict() or historical_forecast() (last_points_only=False) n_jobs=-1 | 1.9 |
| historical_forecast() (last_points_only=True) n_jobs=1 | 5.4 |
| historical_forecast() (last_points_only=True) n_jobs=-1 | 5.4 |