### PR TITLE
Deterministic sampling for all probabilistic models

### DIFF
--- a/darts/models/forecasting/arima.py
+++ b/darts/models/forecasting/arima.py
@@ -19,7 +19,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-import numpy as np
+from sklearn.utils import check_random_state
 from statsmodels.tsa.arima.model import ARIMA as staARIMA
 
 from darts.logging import get_logger
@@ -27,6 +27,7 @@ from darts.models.forecasting.forecasting_model import (
     TransferableFutureCovariatesLocalForecastingModel,
 )
 from darts.timeseries import TimeSeries
+from darts.utils.utils import random_method
 
 logger = get_logger(__name__)
 
@@ -35,6 +36,7 @@ IntOrIntSequence: TypeAlias = Union[int, Sequence[int]]
 
 
 class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
+    @random_method
     def __init__(
         self,
         p: IntOrIntSequence = 12,
@@ -133,11 +135,7 @@ class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
         self.seasonal_order = seasonal_order
         self.trend = trend
         self.model = None
-        self._random_state = (
-            random_state
-            if random_state is None
-            else np.random.RandomState(random_state)
-        )
+        self._random_state = check_random_state(random_state)
 
     @property
     def supports_multivariate(self) -> bool:
@@ -162,6 +160,7 @@ class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
 
         return self
 
+    @random_method
     def _predict(
         self,
         n: int,
@@ -171,6 +170,7 @@ class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
         num_samples: int = 1,
         predict_likelihood_parameters: bool = False,
         verbose: bool = False,
+        random_state: Optional[int] = None,
     ) -> TimeSeries:
         if num_samples > 1 and self.trend:
             logger.warning(
@@ -180,7 +180,12 @@ class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
             )
 
         super()._predict(
-            n, series, historic_future_covariates, future_covariates, num_samples
+            n,
+            series,
+            historic_future_covariates,
+            future_covariates,
+            num_samples,
+            random_state=random_state,
         )
 
         # updating statsmodels results object state with the new ts and covariates
@@ -202,11 +207,15 @@ class ARIMA(TransferableFutureCovariatesLocalForecastingModel):
                 ),
             )
         else:
+            if random_state is not None:
+                rng = check_random_state(random_state)
+            else:
+                rng = self._random_state
             forecast = self.model.simulate(
                 nsimulations=n,
                 repetitions=num_samples,
                 initial_state=self.model.states.predicted[-1, :],
-                random_state=self._random_state,
+                random_state=rng,
                 anchor="end",
                 exog=(
                     future_covariates.values(copy=False) if future_covariates else None

--- a/darts/models/forecasting/conformal_models.py
+++ b/darts/models/forecasting/conformal_models.py
@@ -251,6 +251,7 @@ class ConformalModel(GlobalForecastingModel, ABC):
         verbose: bool = False,
         predict_likelihood_parameters: bool = False,
         show_warnings: bool = True,
+        random_state: Optional[int] = None,
         **kwargs,
     ) -> Union[TimeSeries, Sequence[TimeSeries]]:
         """Forecasts calibrated quantile intervals (or samples from calibrated intervals) for `n` time steps after the
@@ -307,6 +308,8 @@ class ConformalModel(GlobalForecastingModel, ABC):
             If set to `True`, generates the quantile predictions directly. Only supported with `num_samples = 1`.
         show_warnings
             Whether to show warnings related auto-regression and past covariates usage.
+        random_state
+            Controls the randomness of the predictions.
         **kwargs
             Optional keyword arguments that will passed to the underlying forecasting model's `predict()` and
             `historical_forecasts()` methods.
@@ -380,6 +383,7 @@ class ConformalModel(GlobalForecastingModel, ABC):
             verbose=verbose,
             show_warnings=show_warnings,
             predict_likelihood_parameters=predict_likelihood_parameters,
+            random_state=random_state,
         )
         # convert historical forecasts output to simple forecast / prediction
         if called_with_single_series:
@@ -1037,6 +1041,7 @@ class ConformalModel(GlobalForecastingModel, ABC):
         verbose: bool = False,
         show_warnings: bool = True,
         predict_likelihood_parameters: bool = False,
+        random_state: Optional[int] = None,
     ) -> Union[TimeSeries, list[TimeSeries], list[list[TimeSeries]]]:
         """Generate calibrated historical forecasts.
 

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -11,19 +11,20 @@ import statsmodels.tsa.holtwinters as hw
 from darts.logging import get_logger
 from darts.models.forecasting.forecasting_model import LocalForecastingModel
 from darts.timeseries import TimeSeries
-from darts.utils.utils import ModelMode, SeasonalityMode
+from darts.utils.utils import ModelMode, SeasonalityMode, random_method
 
 logger = get_logger(__name__)
 
 
 class ExponentialSmoothing(LocalForecastingModel):
+    @random_method
     def __init__(
         self,
         trend: Optional[ModelMode] = ModelMode.ADDITIVE,
         damped: Optional[bool] = False,
         seasonal: Optional[SeasonalityMode] = SeasonalityMode.ADDITIVE,
         seasonal_periods: Optional[int] = None,
-        random_state: int = 0,
+        random_state: Optional[int] = None,
         kwargs: Optional[dict[str, Any]] = None,
         **fit_kwargs,
     ):
@@ -99,7 +100,7 @@ class ExponentialSmoothing(LocalForecastingModel):
         self.constructor_kwargs = dict() if kwargs is None else kwargs
         self.fit_kwargs = fit_kwargs
         self.model = None
-        np.random.seed(random_state)
+        # np.random.seed(random_state)
 
     def fit(self, series: TimeSeries):
         super().fit(series)
@@ -136,12 +137,14 @@ class ExponentialSmoothing(LocalForecastingModel):
 
         return self
 
+    @random_method
     def predict(
         self,
         n: int,
         num_samples: int = 1,
         verbose: bool = False,
         show_warnings: bool = True,
+        random_state: Optional[int] = None,
     ):
         super().predict(n, num_samples)
 

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -3236,6 +3236,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
         predict_likelihood_parameters: bool = False,
         verbose: bool = False,
         show_warnings: bool = True,
+        random_state: Optional[int] = None,
         **kwargs,
     ) -> TimeSeries:
         """Forecasts values for `n` time steps after the end of the training series.
@@ -3260,7 +3261,8 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
             Optionally, set the prediction verbosity. Not effective for all models.
         show_warnings
             Optionally, control whether warnings are shown. Not effective for all models.
-
+        random_state
+            Controls the randomness of the predictions.
         Returns
         -------
         TimeSeries, a single time series containing the `n` next points after then end of the training series.
@@ -3306,6 +3308,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
             future_covariates=future_covariates,
             num_samples=num_samples,
             predict_likelihood_parameters=predict_likelihood_parameters,
+            random_state=random_state,
             **kwargs,
         )
 
@@ -3317,6 +3320,7 @@ class FutureCovariatesLocalForecastingModel(LocalForecastingModel, ABC):
         num_samples: int = 1,
         predict_likelihood_parameters: bool = False,
         verbose: bool = False,
+        random_state: Optional[int] = None,
         **kwargs,
     ) -> TimeSeries:
         """Forecasts values for a certain number of time steps after the end of the series.
@@ -3538,6 +3542,7 @@ class TransferableFutureCovariatesLocalForecastingModel(
         num_samples: int = 1,
         predict_likelihood_parameters: bool = False,
         verbose: bool = False,
+        random_state: Optional[int] = None,
     ) -> TimeSeries:
         """Forecasts values for a certain number of time steps after the end of the series.
         TransferableFutureCovariatesLocalForecastingModel must implement the predict logic in this method.

--- a/darts/models/forecasting/kalman_forecaster.py
+++ b/darts/models/forecasting/kalman_forecaster.py
@@ -21,16 +21,19 @@ from darts.models.forecasting.forecasting_model import (
     TransferableFutureCovariatesLocalForecastingModel,
 )
 from darts.timeseries import TimeSeries
+from darts.utils.utils import random_method
 
 logger = get_logger(__name__)
 
 
 class KalmanForecaster(TransferableFutureCovariatesLocalForecastingModel):
+    @random_method
     def __init__(
         self,
         dim_x: int = 1,
         kf: Optional[Kalman] = None,
         add_encoders: Optional[dict] = None,
+        random_state: Optional[int] = None,
     ):
         """Kalman filter Forecaster
 
@@ -133,6 +136,7 @@ class KalmanForecaster(TransferableFutureCovariatesLocalForecastingModel):
         series = series if series is not None else self.training_series
         return super().predict(n, series, future_covariates, num_samples, **kwargs)
 
+    @random_method
     def _predict(
         self,
         n: int,
@@ -142,6 +146,7 @@ class KalmanForecaster(TransferableFutureCovariatesLocalForecastingModel):
         num_samples: int = 1,
         predict_likelihood_parameters: bool = False,
         verbose: bool = False,
+        random_state: Optional[int] = None,
     ) -> TimeSeries:
         super()._predict(
             n, series, historic_future_covariates, future_covariates, num_samples

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -17,12 +17,14 @@ from darts.models.forecasting.forecasting_model import (
     FutureCovariatesLocalForecastingModel,
 )
 from darts.timeseries import TimeSeries
+from darts.utils.utils import random_method
 
 logger = get_logger(__name__)
 logger.level = logging.WARNING  # set to warning to suppress prophet logs
 
 
 class Prophet(FutureCovariatesLocalForecastingModel):
+    @random_method
     def __init__(
         self,
         add_seasonalities: Optional[Union[dict, list[dict]]] = None,
@@ -41,6 +43,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                 Callable[[Union[pd.DatetimeIndex, pd.RangeIndex]], Sequence[float]],
             ]
         ] = None,
+        random_state: Optional[int] = None,
         **prophet_kwargs,
     ):
         """Facebook Prophet
@@ -257,6 +260,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         return self
 
+    @random_method
     def _predict(
         self,
         n: int,
@@ -264,6 +268,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
         num_samples: int = 1,
         predict_likelihood_parameters: bool = False,
         verbose: bool = False,
+        random_state: Optional[int] = None,
         **kwargs,
     ) -> TimeSeries:
         _ = self._check_seasonality_conditions(future_covariates=future_covariates)

--- a/darts/models/forecasting/sf_model.py
+++ b/darts/models/forecasting/sf_model.py
@@ -169,6 +169,7 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
         num_samples: int = 1,
         predict_likelihood_parameters: bool = False,
         verbose: bool = False,
+        random_state: Optional[int] = None,
     ) -> TimeSeries:
         super()._predict(
             n, series, historic_future_covariates, future_covariates, num_samples

--- a/darts/models/forecasting/sklearn_model.py
+++ b/darts/models/forecasting/sklearn_model.py
@@ -998,6 +998,7 @@ class SKLearnModel(GlobalForecastingModel):
         verbose: bool = False,
         predict_likelihood_parameters: bool = False,
         show_warnings: bool = True,
+        random_state: Optional[int] = None,
         **kwargs,
     ) -> Union[TimeSeries, Sequence[TimeSeries]]:
         """Forecasts values for `n` time steps after the end of the series.
@@ -1027,6 +1028,8 @@ class SKLearnModel(GlobalForecastingModel):
             Default: ``False``
         show_warnings
             Optionally, control whether warnings are shown. Not effective for all models.
+        random_state
+            Controls the randomness of the predictions.
         **kwargs : dict, optional
             Additional keyword arguments passed to the `predict` method of the model. Only works with
             univariate target series.
@@ -1216,7 +1219,11 @@ class SKLearnModel(GlobalForecastingModel):
 
             # X has shape (n_series * n_samples, n_regression_features)
             prediction = self._predict(
-                X, num_samples, predict_likelihood_parameters, **kwargs
+                X,
+                num_samples,
+                predict_likelihood_parameters,
+                random_state=random_state,
+                **kwargs,
             )
             # prediction shape (n_series * n_samples, output_chunk_length, n_components)
             # append prediction to final predictions
@@ -1255,6 +1262,7 @@ class SKLearnModel(GlobalForecastingModel):
         x: np.ndarray,
         num_samples: int,
         predict_likelihood_parameters: bool,
+        random_state: Optional[int] = None,
         **kwargs,
     ) -> np.ndarray:
         """Generate predictions.
@@ -1270,6 +1278,7 @@ class SKLearnModel(GlobalForecastingModel):
                 x=x,
                 num_samples=num_samples,
                 predict_likelihood_parameters=predict_likelihood_parameters,
+                random_state=random_state,
                 **kwargs,
             )
 

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -1495,6 +1495,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         mc_dropout: bool = False,
         predict_likelihood_parameters: bool = False,
         show_warnings: bool = True,
+        random_state: Optional[int] = None,
     ) -> Union[TimeSeries, Sequence[TimeSeries]]:
         """Predict the ``n`` time step following the end of the training series, or of the specified ``series``.
 
@@ -1567,7 +1568,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             Default: ``False``.
         show_warnings
             Optionally, control whether warnings are shown. Not effective for all models.
-
+        random_state
+            Controls the randomness of the predictions.
         Returns
         -------
         Union[TimeSeries, Sequence[TimeSeries]]
@@ -1644,6 +1646,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             dataloader_kwargs=dataloader_kwargs,
             mc_dropout=mc_dropout,
             predict_likelihood_parameters=predict_likelihood_parameters,
+            random_state=random_state,
         )
 
         return predictions[0] if called_with_single_series else predictions
@@ -1662,6 +1665,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         dataloader_kwargs: Optional[dict[str, Any]] = None,
         mc_dropout: bool = False,
         predict_likelihood_parameters: bool = False,
+        random_state: Optional[int] = None,
     ) -> Sequence[TimeSeries]:
         """
         This method allows for predicting with a specific :class:`darts.utils.data.TorchInferenceDataset` instance.
@@ -1712,6 +1716,8 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             If set to `True`, the model predicts the parameters of its `likelihood` instead of the target. Only
             supported for probabilistic models with a likelihood, `num_samples = 1` and `n<=output_chunk_length`.
             Default: ``False``
+        random_state
+            Controls the randomness of the predictions.
 
         Returns
         -------

--- a/darts/tests/models/forecasting/test_sklearn_models.py
+++ b/darts/tests/models/forecasting/test_sklearn_models.py
@@ -4008,6 +4008,29 @@ class TestProbabilisticSKLearnModels:
         pred3 = model.predict(n=10, num_samples=2).values()
         assert (pred2 != pred3).any()
 
+        # test whether two consecutive predictions with a random_state specified are the same
+        pred4 = model.predict(n=10, num_samples=2, random_state=38).values()
+        pred5 = model.predict(n=10, num_samples=2, random_state=38).values()
+        assert (pred4 == pred5).all()
+
+        # additional tests :
+        model = model_cls(**model_kwargs)
+        model.fit(self.constant_noisy_multivar_ts)
+        pred6 = model.predict(n=10, num_samples=2).values()
+        pred7 = model.predict(n=10, num_samples=2).values()
+
+        model = model_cls(**model_kwargs)
+        model.fit(self.constant_noisy_multivar_ts)
+        pred8 = model.predict(n=10, num_samples=2).values()
+        pred9 = model.predict(n=10, num_samples=2, random_state=38).values()
+        pred10 = model.predict(n=10, num_samples=2, random_state=38).values()
+        pred11 = model.predict(n=10, num_samples=2).values()
+
+        assert (pred6 != pred7).any()
+        assert (pred8 == pred6).all()
+        assert (pred9 == pred10).all()
+        assert (pred11 == pred7).all()
+
     @pytest.mark.parametrize("config", product(models_cls_kwargs_errs, [True, False]))
     def test_probabilistic_forecast_accuracy_univariate(self, config):
         (model_cls, model_kwargs, err), mode = config

--- a/darts/utils/torch.py
+++ b/darts/utils/torch.py
@@ -67,8 +67,14 @@ def random_method(decorated: Callable[..., T]) -> Callable[..., T]:
     @wraps(decorated)
     def decorator(self, *args, **kwargs) -> T:
         if "random_state" in kwargs.keys():
-            # get random state for first time from model constructor
-            self._random_instance = check_random_state(kwargs["random_state"])
+            if hasattr(self, "_random_instance") and kwargs["random_state"] is not None:
+                random_instance = check_random_state(kwargs["random_state"])
+
+                with fork_rng():
+                    manual_seed(random_instance.randint(0, high=MAX_TORCH_SEED_VALUE))
+                    return decorated(self, *args, **kwargs)
+            elif not hasattr(self, "_random_instance"):
+                self._random_instance = check_random_state(kwargs["random_state"])
         elif not hasattr(self, "_random_instance"):
             # get random state for first time from other method
             self._random_instance = check_random_state(


### PR DESCRIPTION
Checklist before merging this PR:
- [ ] Mentioned all issues that this PR fixes or addresses.
- [ ] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #1835, #1779.

### Summary
**Main feature** : when specifying `random_state` in `predict` function, the output is always the same. This was implemented in the `random_method` decorators in the  darts.utils.utils.py and darts.utils.torch.py files. 

All the probabilistic models now have a unified randomization both at model initialization and prediction. Models concerned :
- Models inheriting from StatsForecastModel
- Models inheriting from TorchForecastingModel
- Models inheriting from SKLearnModel
- Models inheriting from ConformalModel
- Additional models : VARIMA, ARIMA, Prophet, KalmanForecaster, ExponentialSmoothing 
<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
