### PR TITLE
Fix SKLearn Multioutput string representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - Fixed some issues in `NLinearModel` with `normalize=True` that resulted in decreased predictive accuracy. Using `shared_weights=True` and auto-regressive forecasting now work properly. [#2757](https://github.com/unit8co/darts/pull/2757) by [Timon Erhart](https://github.com/turbotimon).
 - Fixed a bug when training a `TorchForecastingModel`, where using certain `torchmetrics` that require a 2D model output (e.g. R2Score) raised an error. [He Weilin](https://github.com/cnhwl).
+- Fixed a bug with `SKLearnModel.__str__()` which raised an error when the model was wrapped by Darts' MultioutputRegressor. [#2811](https://github.com/unit8co/darts/pull/2811) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 

--- a/darts/models/forecasting/sklearn_model.py
+++ b/darts/models/forecasting/sklearn_model.py
@@ -911,7 +911,7 @@ class SKLearnModel(GlobalForecastingModel):
                 "eval_weight_name": val_weight_name,
                 "n_jobs": n_jobs_multioutput_wrapper,
             }
-            self.model = MultiOutputRegressor(self.model, **mor_kwargs)
+            self.model = MultiOutputRegressor(estimator=self.model, **mor_kwargs)
 
         if (
             not isinstance(self.model, MultiOutputRegressor)

--- a/darts/tests/models/forecasting/test_sklearn_models.py
+++ b/darts/tests/models/forecasting/test_sklearn_models.py
@@ -1435,6 +1435,27 @@ class TestSKLearnModels:
         else:
             assert not isinstance(model.model, MultiOutputRegressor)
 
+    def test_model_representation(self):
+        """Check that model representation works with and without MultiOutputRegressor"""
+        model_1 = LinearRegressionModel(lags=4, output_chunk_length=1)
+        model_1.fit(series=self.sine_univariate1)
+        assert not isinstance(model_1.model, MultiOutputRegressor)
+
+        model_2 = XGBModel(
+            lags=4,
+            output_chunk_length=2,
+            multi_models=True,
+            likelihood="quantile",
+            quantiles=[0.1, 0.5, 0.9],
+            **xgb_test_params,
+        )
+        model_2.fit(series=self.sine_univariate1)
+        assert isinstance(model_2.model, MultiOutputRegressor)
+
+        for model in [model_1, model_2]:
+            assert model.__repr__().startswith(model.__class__.__name__)
+            assert model.__str__().startswith(model.model.__class__.__name__)
+
     def test_get_estimator_multi_models(self):
         """Craft training data so that estimator_[i].predict(X) == i + 1"""
 


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2810.

### Summary

Fixes a bug with `SKLearnModel.__str__()` which raised an error when the model was wrapped by Darts' MultioutputRegressor.
