### PR TITLE
fix: change default shap method of extra trees and random forest models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed some issues in `NLinearModel` with `normalize=True` that resulted in decreased predictive accuracy. Using `shared_weights=True` and auto-regressive forecasting now work properly. [#2757](https://github.com/unit8co/darts/pull/2757) by [Timon Erhart](https://github.com/turbotimon).
 - Fixed a bug when training a `TorchForecastingModel`, where using certain `torchmetrics` that require a 2D model output (e.g. R2Score) raised an error. [He Weilin](https://github.com/cnhwl).
 - Fixed a bug with `SKLearnModel.__str__()` which raised an error when the model was wrapped by Darts' MultioutputRegressor. [#2811](https://github.com/unit8co/darts/pull/2811) by [Dennis Bader](https://github.com/dennisbader).
-- Fixed the default `_ShapMethod` for two tree based regression models (Random Forest and Extra Trees). [#2821](https://https://github.com/unit8co/darts/pull/2821) by [Rijk van der Meulen](https://github.com/rijkvandermeulen).
+- Fixed the default `_ShapMethod` for three tree based regression models (HistGradientBoostingRegressor, ExtraTreesRegressor and RandomForestRegressor). [#2821](https://https://github.com/unit8co/darts/pull/2821) by [Rijk van der Meulen](https://github.com/rijkvandermeulen).
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed some issues in `NLinearModel` with `normalize=True` that resulted in decreased predictive accuracy. Using `shared_weights=True` and auto-regressive forecasting now work properly. [#2757](https://github.com/unit8co/darts/pull/2757) by [Timon Erhart](https://github.com/turbotimon).
 - Fixed a bug when training a `TorchForecastingModel`, where using certain `torchmetrics` that require a 2D model output (e.g. R2Score) raised an error. [He Weilin](https://github.com/cnhwl).
 - Fixed a bug with `SKLearnModel.__str__()` which raised an error when the model was wrapped by Darts' MultioutputRegressor. [#2811](https://github.com/unit8co/darts/pull/2811) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed the default `_ShapMethod` for two tree based regression models (Random Forest and Extra Trees). [#2821](https://https://github.com/unit8co/darts/pull/2821) by [Rijk van der Meulen](https://github.com/rijkvandermeulen).
 
 **Dependencies**
 

--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -529,12 +529,11 @@ class _RegressionShapExplainers:
         # Tree models
         "DecisionTreeRegressor": _ShapMethod.TREE,
         "ExtraTreeRegressor": _ShapMethod.TREE,
+        "RandomForestRegressor": _ShapMethod.TREE,
         # Ensemble model
         "AdaBoostRegressor": _ShapMethod.PERMUTATION,
         "BaggingRegressor": _ShapMethod.PERMUTATION,
-        "ExtraTreesRegressor": _ShapMethod.PERMUTATION,
         "HistGradientBoostingRegressor": _ShapMethod.PERMUTATION,
-        "RandomForestRegressor": _ShapMethod.PERMUTATION,
         "RidgeCV": _ShapMethod.PERMUTATION,
         "Ridge": _ShapMethod.PERMUTATION,
         # Linear models

--- a/darts/explainability/shap_explainer.py
+++ b/darts/explainability/shap_explainer.py
@@ -526,14 +526,15 @@ class _RegressionShapExplainers:
         "CatBoostRegressor": _ShapMethod.TREE,
         "XGBRegressor": _ShapMethod.TREE,
         "GradientBoostingRegressor": _ShapMethod.TREE,
+        "HistGradientBoostingRegressor": _ShapMethod.TREE,
         # Tree models
         "DecisionTreeRegressor": _ShapMethod.TREE,
         "ExtraTreeRegressor": _ShapMethod.TREE,
+        "ExtraTreesRegressor": _ShapMethod.TREE,
         "RandomForestRegressor": _ShapMethod.TREE,
         # Ensemble model
         "AdaBoostRegressor": _ShapMethod.PERMUTATION,
         "BaggingRegressor": _ShapMethod.PERMUTATION,
-        "HistGradientBoostingRegressor": _ShapMethod.PERMUTATION,
         "RidgeCV": _ShapMethod.PERMUTATION,
         "Ridge": _ShapMethod.PERMUTATION,
         # Linear models


### PR DESCRIPTION
### Summary

I noticed that retrieving shapley values for certain tree-based models (e.g., `ExtraTreeRegressor`) took significantly longer when the `shap_method` argument was not specified explicitly. When this argument is unspecified a mapping based on the underlying ML model happens in the background. I noticed there that the `ExtraTreeRegressor` and `RandomForestRegressor` mapped to the permutation method rather than the (faster and hence more applicable default) tree method. Notice that the `ExtraTreeRegressor`  model in fact had 2 entries in the dict (one mapping to the tree method and one mapping to permutation). Due to the sequence this will always evaluate to permutation.

This PR changes the default for both models to `_ShapMethod.TREE`
