### PR TITLE
Ignore static covs for OLS with custom future covariates support in SF models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug when training a `TorchForecastingModel`, where using certain `torchmetrics` that require a 2D model output (e.g. R2Score) raised an error. [He Weilin](https://github.com/cnhwl).
 - Fixed a bug with `SKLearnModel.__str__()` which raised an error when the model was wrapped by Darts' MultioutputRegressor. [#2811](https://github.com/unit8co/darts/pull/2811) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed the default `_ShapMethod` for three tree based regression models (HistGradientBoostingRegressor, ExtraTreesRegressor and RandomForestRegressor). [#2821](https://https://github.com/unit8co/darts/pull/2821) by [Rijk van der Meulen](https://github.com/rijkvandermeulen).
+- Fixed a bug in `StatsForecastModel` where custom future covariates support (OLS) resulted in a feature error with target series that contain static covariates. [#2824](https://github.com/unit8co/darts/pull/2824) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 

--- a/darts/models/forecasting/sf_model.py
+++ b/darts/models/forecasting/sf_model.py
@@ -144,7 +144,10 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
             target = series.values(copy=False).flatten()
         else:
             # perform OLS and get in-sample residuals
-            self._linreg = LinearRegressionModel(lags_future_covariates=[0])
+            self._linreg = LinearRegressionModel(
+                lags_future_covariates=[0],
+                use_static_covariates=False,
+            )
             self._linreg.fit(series, future_covariates=future_covariates)
             target = self._get_target_residuals(series, future_covariates)
 


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2823.

### Summary

- Fixes bug in StatsForecastModel where custom future covariates support (OLS) resulted in a feature error with target series that contain static covariates.