### PR TITLE
Fix/hfc retrain with tfm and ocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed a bug in `darts.utils.timeseries_generation.sine_timeseries()`, where the returned series ignored the specified `dtype`. [#2856](https://github.com/unit8co/darts/pull/2856) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug in `TimeSeries.__getitem__()`, where indexing with a list of integers of `length <= 2` resulted in an error. [#2857](https://github.com/unit8co/darts/pull/2857) by [Dennis Bader](https://github.com/dennisbader).
 - Fixed a bug in `TorchForecastingModel` which raised an error when calling any predict method after training the model with `fit_from_dataset()` on a dataset that uses static covariates. [#2860](https://github.com/unit8co/darts/pull/2860) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a bug in `ForecastingModel.historical_forecasts`, where calling the method with `retrain=True`, `start=None`, and a model that uses `output_chunk_shift > 0` raised an error due to the start point not being properly inferred. [#2869](https://github.com/unit8co/darts/pull/2869) by [Dennis Bader](https://github.com/dennisbader).
 - Removed `darts/tests` and `examples` from the Darts package distribution. These are only required for internal testing. [#2854](https://github.com/unit8co/darts/pull/2854) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -1111,7 +1111,7 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
             )
 
             # adjust the start of the series depending on whether we train (at some point), or predict only
-            # must be performed after the operation on historical_foreacsts_time_index
+            # must be performed after the operation on historical_forecasts_time_index
             if min_timestamp_series > series_.time_index[0]:
                 series_ = series_.drop_before(min_timestamp_series - 1 * series_.freq)
 

--- a/darts/utils/historical_forecasts/utils.py
+++ b/darts/utils/historical_forecasts/utils.py
@@ -681,10 +681,7 @@ def _get_historical_forecastable_time_index(
 
     # longest possible time index for target
     if is_training:
-        start = (
-            series.start_time()
-            + (output_lag - output_chunk_shift - min_target_lag + 1) * series.freq
-        )
+        start = series.start_time() + (output_lag - min_target_lag + 1) * series.freq
     else:
         start = series.start_time() - min_target_lag * series.freq
     end = series.end_time() + 1 * series.freq

--- a/darts/utils/historical_forecasts/utils.py
+++ b/darts/utils/historical_forecasts/utils.py
@@ -693,8 +693,7 @@ def _get_historical_forecastable_time_index(
         if is_training:
             start_pc = (
                 past_covariates.start_time()
-                + (output_lag - output_chunk_shift - min_past_cov_lag + 1)
-                * past_covariates.freq
+                + (output_lag - min_past_cov_lag + 1) * past_covariates.freq
             )
         else:
             start_pc = (
@@ -717,8 +716,7 @@ def _get_historical_forecastable_time_index(
         if is_training:
             start_fc = (
                 future_covariates.start_time()
-                + (output_lag - output_chunk_shift - min_future_cov_lag + 1)
-                * future_covariates.freq
+                + (output_lag - min_future_cov_lag + 1) * future_covariates.freq
             )
         else:
             start_fc = (


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2848.

### Summary

- Fixes a bug in `ForecastingModel.historical_forecasts`, where calling the method with `retrain=True`, `start=None`, and a model that uses `output_chunk_shift > 0` raised an error due to the start point not being properly inferred.
