### PR TITLE
Devops/cap lightning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Dependencies**
 
 - Removed the upper version cap on `scipy<1.16.0` since `statsmodels` added support in version `0.14.5`. [#2853](https://github.com/unit8co/darts/pull/2853) by [Dennis Bader](https://github.com/dennisbader).
+- We set an upper version cap on `pytorch-lightning<2.5.3` until an issue with `lr_find()` is resolved. [#2871](https://github.com/unit8co/darts/pull/2871) by [Dennis Bader](https://github.com/dennisbader).
 
 ### For developers of the library:
 

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,3 +1,3 @@
-pytorch-lightning>=1.5.0
+pytorch-lightning>=1.5.0,<2.5.3
 tensorboardX>=2.1
 torch>=1.8.0


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- Fixes failing unit tests due to new lightning version.
- We set an upper version cap on `pytorch-lightning<2.5.3` until an issue with `lr_find()` is resolved.
