### PR TITLE
update gh action workflow to install darts locally without dependencies

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Run tests"
         run: |
@@ -131,7 +131,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Build docs"
         run: |
@@ -181,7 +181,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Run example ${{matrix.example-name}}"
         working-directory: ./examples

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Build docs"
         run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Run tests"
         run: |
@@ -125,7 +125,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Run example ${{matrix.example-name}}"
         working-directory: ./examples
@@ -177,7 +177,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Build docs"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: "Install Darts Locally"
         run: |
-          pip install .
+          pip install . --no-deps
 
       - name: "Build docs"
         run: |

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -1,3 +1,13 @@
+import pytest
+
+from darts.tests.conftest import TORCH_AVAILABLE
+
+if not TORCH_AVAILABLE:
+    pytest.skip(
+        f"Torch not available. {__name__} tests will be skipped.",
+        allow_module_level=True,
+    )
+
 import copy
 import itertools
 import math
@@ -8,25 +18,6 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
-
-import darts.utils.timeseries_generation as tg
-from darts import TimeSeries
-from darts.dataprocessing.encoders import SequentialEncoder
-from darts.dataprocessing.transformers import BoxCox, Scaler
-from darts.metrics import mape
-from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs, tfm_kwargs_dev
-from darts.utils.data.torch_datasets.inference_dataset import (
-    SequentialTorchInferenceDataset,
-)
-from darts.utils.data.torch_datasets.training_dataset import (
-    SequentialTorchTrainingDataset,
-)
-
-if not TORCH_AVAILABLE:
-    pytest.skip(
-        f"Torch not available. {__name__} tests will be skipped.",
-        allow_module_level=True,
-    )
 import torch
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.loggers.logger import DummyLogger
@@ -40,6 +31,11 @@ from torchmetrics import (
     R2Score,
 )
 
+import darts.utils.timeseries_generation as tg
+from darts import TimeSeries
+from darts.dataprocessing.encoders import SequentialEncoder
+from darts.dataprocessing.transformers import BoxCox, Scaler
+from darts.metrics import mape
 from darts.models import (
     BlockRNNModel,
     DLinearModel,
@@ -58,6 +54,13 @@ from darts.models import (
 )
 from darts.models.components.layer_norm_variants import RINorm
 from darts.models.forecasting.global_baseline_models import _GlobalNaiveModel
+from darts.tests.conftest import tfm_kwargs, tfm_kwargs_dev
+from darts.utils.data.torch_datasets.inference_dataset import (
+    SequentialTorchInferenceDataset,
+)
+from darts.utils.data.torch_datasets.training_dataset import (
+    SequentialTorchTrainingDataset,
+)
 from darts.utils.likelihood_models.torch import (
     CauchyLikelihood,
     GaussianLikelihood,


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). (not required)

### Summary

- Avoids installing darts locally in gh actions workflows for running unit tests. Before, installing locally caused torch dependencies to be installed as well, and the notorch flavor tests did not properly catch issues on missing torch installations.