### PR TITLE
feat: Add add_regressor_configs to Prophet model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ We do our best to avoid the introduction of breaking changes,
 but cannot always guarantee backwards compatibility. Changes that may **break code which uses a previous release of Darts** are marked with a "🔴". Changes that deprecate functionalities are marked with a "🟠".
 
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
-
+- Added `add_regressor_configs` parameter to the `Prophet` model, enabling per-regressor control over `prior_scale`, `mode`, and `standardize`. [#2878](https://github.com/unit8co/darts/issues/2878)
+  by [Ramsay Davis](https://github.com/RamsayDavisWL).
 [Full Changelog](https://github.com/unit8co/darts/compare/0.37.1...master)
 
 ### For users of the library:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ We do our best to avoid the introduction of breaking changes,
 but cannot always guarantee backwards compatibility. Changes that may **break code which uses a previous release of Darts** are marked with a "🔴". Changes that deprecate functionalities are marked with a "🟠".
 
 ## [Unreleased](https://github.com/unit8co/darts/tree/master)
-- Added `add_regressor_configs` parameter to the `Prophet` model, enabling per-regressor control over `prior_scale`, `mode`, and `standardize`. [#2878](https://github.com/unit8co/darts/issues/2878)
-  by [Ramsay Davis](https://github.com/RamsayDavisWL).
+
 [Full Changelog](https://github.com/unit8co/darts/compare/0.37.1...master)
 
 ### For users of the library:
@@ -13,6 +12,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Improved**
 
 - 🔴 Added future and static covariates support to `BlockRNNModel`. This improvement required changes to the underlying model architecture which means that saved model instances from older Darts versions cannot be loaded any longer. [#2845](https://github.com/unit8co/darts/pull/2845) by [Gabriel Margaria](https://github.com/Jaco-Pastorius).
+- Added `add_regressor_configs` parameter to the `Prophet` model, enabling component-specific control over `prior_scale`, `mode`, and `standardize` for the future covariates. [#2882](https://github.com/unit8co/darts/issues/2882) by [Ramsay Davis](https://github.com/RamsayDavisWL).
 
 **Fixed**
 

--- a/darts/models/forecasting/prophet_model.py
+++ b/darts/models/forecasting/prophet_model.py
@@ -27,11 +27,9 @@ class Prophet(FutureCovariatesLocalForecastingModel):
     @random_method
     def __init__(
         self,
-        add_regressor_configs: Optional[dict[str, dict[str, Any]]] = None,
         add_seasonalities: Optional[Union[dict, list[dict]]] = None,
+        add_regressor_configs: Optional[dict[str, dict[str, Any]]] = None,
         country_holidays: Optional[str] = None,
-        suppress_stdout_stderror: bool = True,
-        add_encoders: Optional[dict] = None,
         cap: Optional[
             Union[
                 float,
@@ -44,7 +42,9 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                 Callable[[Union[pd.DatetimeIndex, pd.RangeIndex]], Sequence[float]],
             ]
         ] = None,
+        add_encoders: Optional[dict] = None,
         random_state: Optional[int] = None,
+        suppress_stdout_stderror: bool = True,
         **prophet_kwargs,
     ):
         """Facebook Prophet
@@ -55,22 +55,6 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         Parameters
         ----------
-        add_regressor_configs
-            Optionally, a dictionary of configuration dictionaries for custom regressors.
-            Each key is a regressor name, and the value is a dictionary of parameters for Prophet's
-            `add_regressor()` method. Supported parameters are `prior_scale`, `standardize`, and `mode`.
-            For example:
-
-            .. highlight:: python
-            .. code-block:: python
-
-                add_regressor_configs={
-                    'temperature': {'prior_scale': 5.0, 'standardize': True, 'mode': 'additive'},
-                    'humidity': {'prior_scale': 2.0, 'standardize': 'auto', 'mode': 'multiplicative'},
-                    'pressure': {'prior_scale': 15.0}  # uses defaults for other params
-                }
-            ..
-
         add_seasonalities
             Optionally, a dict or list of dicts with custom seasonality/ies to add to the model.
             Each dict takes the following mandatory and optional data:
@@ -96,6 +80,21 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             `add_seasonality()` method.
             Alternatively, you can add seasonalities after model creation and before fitting with
             :meth:`add_seasonality() <Prophet.add_seasonality()>`.
+        add_regressor_configs
+            Optionally, a dictionary of configuration dictionaries for custom regressors / components of
+            `future_covariates`. Each key is a regressor name, and the value is a dictionary of parameters for
+            Prophet's `add_regressor()` method. Supported parameters are `prior_scale`, `standardize`, and `mode`.
+            For example:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                add_regressor_configs={
+                    'temperature': {'prior_scale': 5.0, 'standardize': True, 'mode': 'additive'},
+                    'humidity': {'prior_scale': 2.0, 'standardize': 'auto', 'mode': 'multiplicative'},
+                    'pressure': {'prior_scale': 15.0}  # uses defaults for other params
+                }
+            ..
         country_holidays
             An optional country code, for which holidays can be taken into account by Prophet.
 
@@ -105,8 +104,26 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             countries: Brazil (BR), Indonesia (ID), India (IN), Malaysia (MY), Vietnam (VN),
             Thailand (TH), Philippines (PH), Turkey (TU), Pakistan (PK), Bangladesh (BD),
             Egypt (EG), China (CN), and Russia (RU).
-        suppress_stdout_stderror
-            Optionally suppress the log output produced by Prophet during training.
+        cap
+            Parameter specifying the maximum carrying capacity when predicting with logistic growth.
+            Mandatory when `growth = 'logistic'`, otherwise ignored.
+            See <https://facebook.github.io/prophet/docs/saturating_forecasts.html> for more information
+            on logistic forecasts.
+            Can be either
+
+            - a number, for constant carrying capacities
+            - a function taking a DatetimeIndex or RangeIndex and returning a corresponding a Sequence of numbers,
+            where each number indicates the carrying capacity at this index.
+        floor
+            Parameter specifying the minimum carrying capacity when predicting logistic growth.
+            Optional when `growth = 'logistic'` (defaults to 0), otherwise ignored.
+            See <https://facebook.github.io/prophet/docs/saturating_forecasts.html> for more information
+            on logistic forecasts.
+            Can be either
+
+            - a number, for constant carrying capacities
+            - a function taking a DatetimeIndex or RangeIndex and returning a corresponding a Sequence of numbers,
+            where each number indicates the carrying capacity at this index.
         add_encoders
             A large number of future covariates can be automatically generated with `add_encoders`.
             This can be done by adding multiple pre-defined index encoders and/or custom user-made functions that
@@ -131,28 +148,10 @@ class Prophet(FutureCovariatesLocalForecastingModel):
                     'tz': 'CET'
                 }
             ..
-        cap
-            Parameter specifying the maximum carrying capacity when predicting with logistic growth.
-            Mandatory when `growth = 'logistic'`, otherwise ignored.
-            See <https://facebook.github.io/prophet/docs/saturating_forecasts.html> for more information
-            on logistic forecasts.
-            Can be either
-
-            - a number, for constant carrying capacities
-            - a function taking a DatetimeIndex or RangeIndex and returning a corresponding a Sequence of numbers,
-            where each number indicates the carrying capacity at this index.
-        floor
-            Parameter specifying the minimum carrying capacity when predicting logistic growth.
-            Optional when `growth = 'logistic'` (defaults to 0), otherwise ignored.
-            See <https://facebook.github.io/prophet/docs/saturating_forecasts.html> for more information
-            on logistic forecasts.
-            Can be either
-
-            - a number, for constant carrying capacities
-            - a function taking a DatetimeIndex or RangeIndex and returning a corresponding a Sequence of numbers,
-            where each number indicates the carrying capacity at this index.
         random_state
             Controls the randomness for reproducible forecasting.
+        suppress_stdout_stderror
+            Optionally suppress the log output produced by Prophet during training.
         prophet_kwargs
             Some optional keyword arguments for Prophet.
             For information about the parameters see:
@@ -187,9 +186,8 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         super().__init__(add_encoders=add_encoders)
 
-        self.add_regressor_configs = add_regressor_configs or {}
-
         self._auto_seasonalities = self._extract_auto_seasonality(prophet_kwargs)
+        self._add_regressor_configs = add_regressor_configs or {}
 
         self._add_seasonalities = dict()
         add_seasonality_calls = (
@@ -258,6 +256,20 @@ class Prophet(FutureCovariatesLocalForecastingModel):
 
         # add covariates as additional regressors
         if future_covariates is not None:
+            if self._add_regressor_configs:
+                # check that all configured regressors are actually present in the future_covariates
+                comps_config = set(self._add_regressor_configs)
+                comps_actual = set(future_covariates.components)
+                comps_invalid = comps_config - comps_actual
+                if comps_invalid:
+                    raise_log(
+                        ValueError(
+                            f"The following components have been configured in `add_regressor_configs` "
+                            f"but are not present in the `future_covariates`: `{comps_invalid}`."
+                        ),
+                        logger=logger,
+                    )
+
             fit_df = fit_df.merge(
                 future_covariates.to_dataframe(),
                 left_on="ds",
@@ -267,7 +279,7 @@ class Prophet(FutureCovariatesLocalForecastingModel):
             for covariate in future_covariates.columns:
                 if covariate not in conditional_seasonality_covariates:
                     # Get the config dict for the current regressor, or an empty dict if not found
-                    config = self.add_regressor_configs.get(covariate, {})
+                    config = self._add_regressor_configs.get(covariate, {})
                     # Unpack the config dictionary into keyword arguments
                     self.model.add_regressor(covariate, **config)
 

--- a/darts/tests/models/forecasting/test_prophet.py
+++ b/darts/tests/models/forecasting/test_prophet.py
@@ -299,8 +299,50 @@ class TestProphet:
                 future_covariates=invalid_future_covariates.drop_columns("is_sunday"),
             )
 
-    def test_add_regressor_configs(self):
+    @pytest.mark.parametrize(
+        "config",
+        [
+            # Test Scenario 1: Both covariates have specific configurations
+            {
+                "cov1": {"prior_scale": 10.0, "mode": "additive"},
+                "cov2": {"standardize": True, "mode": "multiplicative"},
+            },
+            # Test Scenario 2: Only 'cov1' is configured; 'cov2' should use Prophet's defaults.
+            {"cov1": {"prior_scale": 5.0}},
+        ],
+    )
+    def test_add_regressor_configs_valid(self, config):
         """Tests the add_regressor_configs parameter."""
+        series, future_covariates = self.helper_generate_input_series()
+
+        model = Prophet(add_regressor_configs=config)
+        model.fit(series[:-6], future_covariates=future_covariates)
+
+        # check that prophet model has the correct regressor configs
+        assert model._add_regressor_configs == config
+        prophet_config = model.model.extra_regressors
+        for cov, kwargs_expected in config.items():
+            assert cov in prophet_config
+            kwargs_model = prophet_config[cov]
+            for kw, val in kwargs_expected.items():
+                assert kwargs_model.get(kw) == val
+
+        pred_full = model.predict(6)
+        assert len(pred_full) == 6
+
+    def test_add_regressor_configs_invalid(self):
+        """Add regressor contains invalid component names."""
+        series, future_covariates = self.helper_generate_input_series()
+
+        invalid_config = {"invalid_comp": {"prior_scale": 5.0}}
+        model = Prophet(add_regressor_configs=invalid_config)
+        with pytest.raises(ValueError) as exc:
+            model.fit(series[:-6], future_covariates=future_covariates)
+        assert str(exc.value).endswith(
+            f"are not present in the `future_covariates`: `{set(invalid_config)}`."
+        )
+
+    def helper_generate_input_series(self):
         # Create a simple timeseries
         times = pd.date_range(start="2020-01-01", periods=30, freq="MS")
         series = TimeSeries.from_times_and_values(times, range(30))
@@ -313,29 +355,4 @@ class TestProphet:
             times, range(40, 70), columns=["cov2"]
         )
         future_covariates = covariate1.stack(covariate2)
-
-        train_series = series[:24]
-        train_covariates = future_covariates[:24]
-
-        # Test Scenario 1: Both covariates have specific configurations
-        full_configs = {
-            "cov1": {"prior_scale": 10.0, "mode": "additive"},
-            "cov2": {"standardize": True, "mode": "multiplicative"},
-        }
-        model_full = Prophet(add_regressor_configs=full_configs)
-        model_full.fit(train_series, future_covariates=train_covariates)
-        pred_full = model_full.predict(6, future_covariates=future_covariates)
-        assert len(pred_full) == 6
-
-        # Test Scenario 2: Only 'cov1' is configured; 'cov2' should use Prophet's defaults.
-        partial_configs = {"cov1": {"prior_scale": 5.0}}
-        model_partial = Prophet(add_regressor_configs=partial_configs)
-        model_partial.fit(train_series, future_covariates=train_covariates)
-        pred_partial = model_partial.predict(6, future_covariates=future_covariates)
-        assert len(pred_partial) == 6
-
-        # Test Scenario 3: no configuration
-        model_default = Prophet()
-        model_default.fit(train_series, future_covariates=train_covariates)
-        pred_default = model_default.predict(6, future_covariates=future_covariates)
-        assert len(pred_default) == 6
+        return series, future_covariates


### PR DESCRIPTION
### Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #2878.

### Summary

This PR introduces a new parameter, `add_regressor_configs`, to the `DartsProphet` model to allow for per-regressor configurations.

Currently, all future regressors added to the Prophet model use the same default parameters. This change addresses that limitation by allowing users to specify individual settings for `prior_scale`, `mode`, and `standardize` for each regressor. This provides much greater flexibility and control over the model, which is especially useful when users have domain knowledge about the influence of different external variables.

The implementation follows the suggestion in issue #2878, using a dictionary of configurations that are unpacked during the `_fit` process. The change is fully backward-compatible and does not affect existing functionality. New unit tests have been added to verify the feature and protect against regressions.

### Other Information

N/A
