### PR TITLE
Add mixed precision and 16-bit support to `TorchForecastingModel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- Added mixed precision and 16-bit precision support to `TorchForecastingModel`. The latter is for `pytorch-lightning>=2.0.0` only. Simply specify `{"precision": "16-mixd" }` (`"16"` if using `pytorch-lightning<2.0.0`) for `pl_trainer_kwargs` to enable mixed precision training. Alternatively, declare a custom `pytorch_lightning.Trainer` with a `"precision"` parameter and pass the trainer to `fit()`. Note that mixed precision is not implemented on CPU and `"bf16-mixed"` would be used instead. Other precision options such as `"64-true"` and `"bf16-mixed"` supported by `pytorch_lightning` are also allowed. [#]() by [Zhihao Dai](https://github.com/daidahao).
 - 🔴 Added future and static covariates support to `BlockRNNModel`. This improvement required changes to the underlying model architecture which means that saved model instances from older Darts versions cannot be loaded any longer. [#2845](https://github.com/unit8co/darts/pull/2845) by [Gabriel Margaria](https://github.com/Jaco-Pastorius).
 
 **Fixed**


### PR DESCRIPTION

Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Addresses #2484 #2755

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

Previously, the `"precision"` option set in `pl_trainer_kwargs` is ignored in favour of precision of the time series data type. That led to the lack of support for mixed precision training and 16-bit true precision despite `pytorch-lightning.Trainer` native support.

I added support for mixed precision and any other precision options supported by Lightning in `TorchForecastingModel`.

Here, by default when the `"precision"` option is not set in `pl_trainer_kwargs` or a custom trainer, the model precision is determined by the data type. When it is set, we can assume that the user understand the ramifications of that option and the option is always passed along to the trainer, even when there is a mismatch between the model precision and the data type.

Sometimes the mismatch is necessary when the data type is 32-bit but the model can be trained in mixed precision. The other times the mismatch would cause an error, say, training 32-bit model on 64-bit data.

**Precision is an advanced option for `TorchForecastingModel` training and users should only use it at their own benefits and risks!**


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
N/A