### PR TITLE
Devops/bump min lightning 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Dependencies**
 
+- We raised the minimum pytorch-lightning version to `pytorch-lightning>=2.0.0`. [#2888](https://github.com/unit8co/darts/pull/2888) by [Dennis Bader](https://github.com/dennisbader).
+
 ### For developers of the library:
 
 ## [0.37.1](https://github.com/unit8co/darts/tree/0.37.1) (2025-08-18)

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -38,6 +38,8 @@ import pandas as pd
 import pytorch_lightning as pl
 import torch
 from pytorch_lightning import loggers as pl_loggers
+from pytorch_lightning.callbacks import ProgressBar
+from pytorch_lightning.tuner import Tuner
 from torch.utils.data import DataLoader
 
 from darts import TimeSeries
@@ -77,18 +79,6 @@ from darts.utils.timeseries_generation import _build_forecast_series_from_schema
 from darts.utils.torch import random_method
 from darts.utils.ts_utils import get_single_series, seq2series, series2seq
 from darts.utils.utils import _build_tqdm_iterator, _parallel_apply
-
-# Check whether we are running pytorch-lightning >= 2.0.0 or not:
-tokens = pl.__version__.split(".")
-pl_200_or_above = int(tokens[0]) >= 2
-
-if pl_200_or_above:
-    from pytorch_lightning.callbacks import ProgressBar
-    from pytorch_lightning.tuner import Tuner
-else:
-    from pytorch_lightning.callbacks import ProgressBarBase as ProgressBar
-    from pytorch_lightning.tuner.tuning import Tuner
-
 
 DEFAULT_DARTS_FOLDER = "darts_logs"
 CHECKPOINTS_FOLDER = "checkpoints"
@@ -450,10 +440,10 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         dtype = self.train_sample[0].dtype
         if np.issubdtype(dtype, np.float32):
             logger.info("Time series values are 32-bits; casting model to float32.")
-            precision = "32" if not pl_200_or_above else "32-true"
+            precision = "32-true"
         elif np.issubdtype(dtype, np.float64):
             logger.info("Time series values are 64-bits; casting model to float64.")
-            precision = "64" if not pl_200_or_above else "64-true"
+            precision = "64-true"
         else:
             raise_log(
                 ValueError(
@@ -471,9 +461,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
         )
         if precision_user is not None:
             # currently, we only support float 64 and 32
-            valid_precisions = (
-                ["64", "32"] if not pl_200_or_above else ["64-true", "32-true"]
-            )
+            valid_precisions = ["64-true", "32-true"]
             if str(precision_user) not in valid_precisions:
                 raise_log(
                     ValueError(

--- a/darts/tests/models/forecasting/test_ptl_trainer.py
+++ b/darts/tests/models/forecasting/test_ptl_trainer.py
@@ -21,11 +21,7 @@ class TestPTLTrainer:
         "enable_checkpointing": False,
     }
     series = linear_timeseries(length=100).astype(np.float32)
-    pl_200_or_above = int(pl.__version__.split(".")[0]) >= 2
-    precisions = {
-        32: "32" if not pl_200_or_above else "32-true",
-        64: "64" if not pl_200_or_above else "64-true",
-    }
+    precisions = {32: "32-true", 64: "64-true"}
 
     def test_prediction_loaded_custom_trainer(self, tmpdir_module):
         """validate manual save with automatic save files by comparing output between the two"""

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,3 +1,3 @@
-pytorch-lightning>=1.5.0,<2.5.3
+pytorch-lightning>=2.0.0,<2.5.3
 tensorboardX>=2.1
 torch>=1.8.0


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- Bumps minimum pytorch-lightning version to from 1.5.0 to 2.0.0. Version 2.0.0 has been released 2.5 years ago and it was time to clean up some dependency handling and for future continuity.
