### PR TITLE
Feat/exp smoothing add argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - `from_group_dataframe()` now supports creating `TimeSeries` from **additional DataFrame backends** (Polars, PyArrow, ...). We leverage `narwhals` as the compatibility layer between DataFrame libraries. See their [documentation](https://narwhals-dev.github.io/narwhals/) for all supported backends. [#2766](https://github.com/unit8co/darts/pull/2766) by [He Weilin](https://github.com/cnhwl).
 - Added `add_regressor_configs` parameter to the `Prophet` model, enabling component-specific control over `prior_scale`, `mode`, and `standardize` for the future covariates. [#2882](https://github.com/unit8co/darts/issues/2882) by [Ramsay Davis](https://github.com/RamsayDavisWL).
 - 🔴 Increased the decimal places for quantile component names from 2 to 3 for more precise quantiles. (e.g. `component_name_q0.500` for quantile 0.5). This affects quantile forecasts as well as quantiles computed with `TimeSeries.quantile()`. [#2887](https://github.com/unit8co/darts/pull/2786) by [He Weilin](https://github.com/cnhwl).
-- Added support for `random_errors` and `error` keyword arguments in the `ExponentialSmoothing` model. [#2891](https://github.com/unit8co/darts/issues/2891) by [Jakub Chłapek](https://github.com/jakubchlapek)
+- Added model creation parameters `random_errors` and `error` to `ExponentialSmoothing` that give control over how probabilistic forecasts are generated. [#2290491](https://github.com/unit8co/darts/pull/2904) by [Jakub Chłapek](https://github.com/jakubchlapek)
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - `from_group_dataframe()` now supports creating `TimeSeries` from **additional DataFrame backends** (Polars, PyArrow, ...). We leverage `narwhals` as the compatibility layer between DataFrame libraries. See their [documentation](https://narwhals-dev.github.io/narwhals/) for all supported backends. [#2766](https://github.com/unit8co/darts/pull/2766) by [He Weilin](https://github.com/cnhwl).
 - Added `add_regressor_configs` parameter to the `Prophet` model, enabling component-specific control over `prior_scale`, `mode`, and `standardize` for the future covariates. [#2882](https://github.com/unit8co/darts/issues/2882) by [Ramsay Davis](https://github.com/RamsayDavisWL).
 - 🔴 Increased the decimal places for quantile component names from 2 to 3 for more precise quantiles. (e.g. `component_name_q0.500` for quantile 0.5). This affects quantile forecasts as well as quantiles computed with `TimeSeries.quantile()`. [#2887](https://github.com/unit8co/darts/pull/2786) by [He Weilin](https://github.com/cnhwl).
+- Added support for `random_errors` and `error` keyword arguments in the `ExponentialSmoothing` model. [#2891](https://github.com/unit8co/darts/issues/2891) by [Jakub Chłapek](https://github.com/jakubchlapek)
 
 **Fixed**
 

--- a/darts/models/forecasting/exponential_smoothing.py
+++ b/darts/models/forecasting/exponential_smoothing.py
@@ -68,16 +68,14 @@ class ExponentialSmoothing(LocalForecastingModel):
         error
             Specifies the type of error model for state space formulation to use when using predict()
             with ``num_samples > 1``. Default is `"add"`.
-            Argument that will be used to call
-            :func:`statsmodels.tsa.holtwinters.HoltWintersResults.simulate()`.
-            See `the documentation
-            <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.HoltWintersResults.simulate.html>`_.
+            Will be passed to statsmodels' :func:`simulate()` method. See the documentation `here
+            <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.HoltWintersResults.simulate.html>`_
+            for more information.
         random_errors
             Specifies how the random errors should be obtained, when using predict() with ``num_samples > 1``.
-            Argument that will be used to call
-            :func:`statsmodels.tsa.holtwinters.HoltWintersResults.simulate()`.
-            See `the documentation
-            <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.HoltWintersResults.simulate.html>`_.
+            Will be passed to statsmodels' :func:`simulate()` method. See the documentation `here
+            <https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.HoltWintersResults.simulate.html>`_
+            for more information.
         random_state
             Controls the randomness for reproducible forecasting.
         kwargs

--- a/darts/tests/models/forecasting/test_exponential_smoothing.py
+++ b/darts/tests/models/forecasting/test_exponential_smoothing.py
@@ -91,3 +91,31 @@ class TestExponentialSmoothing:
         # forecasts should be slightly different
         assert pred.time_index.equals(pred_ls.time_index)
         assert all(np.not_equal(pred.values(), pred_ls.values()))
+
+    def test_random_errors(self):
+        """Test whether random_errors parameter is correctly passed to simulate()"""
+        series = tg.sine_timeseries(length=100, freq="H")
+        model = ExponentialSmoothing()
+        model.fit(series)
+        pred = model.predict(n=10, num_samples=10, random_state=42)
+
+        model_boot = ExponentialSmoothing(random_errors="bootstrap")
+        model_boot.fit(series)
+        pred_boot = model_boot.predict(n=10, num_samples=10, random_state=42)
+
+        # methods with different random_errors set should yield different forecasts
+        assert not np.allclose(pred.values(), pred_boot.values(), atol=1e-5)
+
+    def test_error(self):
+        """Test whether error parameter is correctly passed to simulate()"""
+        series = tg.sine_timeseries(length=100, freq="H")
+        model = ExponentialSmoothing()
+        model.fit(series)
+        pred = model.predict(n=10, num_samples=10, random_state=42)
+
+        model_boot = ExponentialSmoothing(error="mul")
+        model_boot.fit(series)
+        pred_boot = model_boot.predict(n=10, num_samples=10, random_state=42)
+
+        # methods with different error set should yield different forecasts
+        assert not np.allclose(pred.values(), pred_boot.values(), atol=1e-5)

--- a/darts/tests/models/forecasting/test_exponential_smoothing.py
+++ b/darts/tests/models/forecasting/test_exponential_smoothing.py
@@ -95,11 +95,11 @@ class TestExponentialSmoothing:
     def test_random_errors(self):
         """Test whether random_errors parameter is correctly passed to simulate()"""
         series = tg.sine_timeseries(length=100, freq="H")
-        model = ExponentialSmoothing()
+        model = ExponentialSmoothing(random_state=42)
         model.fit(series)
         pred = model.predict(n=10, num_samples=10, random_state=42)
 
-        model_boot = ExponentialSmoothing(random_errors="bootstrap")
+        model_boot = ExponentialSmoothing(random_errors="bootstrap", random_state=42)
         model_boot.fit(series)
         pred_boot = model_boot.predict(n=10, num_samples=10, random_state=42)
 
@@ -109,11 +109,11 @@ class TestExponentialSmoothing:
     def test_error(self):
         """Test whether error parameter is correctly passed to simulate()"""
         series = tg.sine_timeseries(length=100, freq="H")
-        model = ExponentialSmoothing()
+        model = ExponentialSmoothing(random_state=42)
         model.fit(series)
         pred = model.predict(n=10, num_samples=10, random_state=42)
 
-        model_boot = ExponentialSmoothing(error="mul")
+        model_boot = ExponentialSmoothing(error="mul", random_state=42)
         model_boot.fit(series)
         pred_boot = model_boot.predict(n=10, num_samples=10, random_state=42)
 

--- a/darts/tests/models/forecasting/test_local_forecasting_models.py
+++ b/darts/tests/models/forecasting/test_local_forecasting_models.py
@@ -665,7 +665,7 @@ class TestLocalForecastingModels:
             (
                 ExponentialSmoothing(),
                 "ExponentialSmoothing(trend=ModelMode.ADDITIVE, damped=False, seasonal=SeasonalityMode.ADDITIVE, "
-                + "seasonal_periods=None, random_state=None, kwargs=None)",
+                + "seasonal_periods=None, error=add, random_errors=None, random_state=None, kwargs=None)",
             ),  # no params changed
             (
                 ARIMA(1, 1, 1),


### PR DESCRIPTION
Checklist before merging this PR:

- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](https://github.com/unit8co/darts/CHANGELOG.md).

Fixes #2891.

***Summary***
This PR adds support for `random_errors` and `error` keyword arguments in the `ExponentialSmoothing` model. Previously, these were not available. 

***Other Information***
The arguments are passed to the [`statsmodels.tsa.holtwinters.HoltWintersResults.simulate()`](https://www.statsmodels.org/dev/generated/statsmodels.tsa.holtwinters.HoltWintersResults.simulate.html) method inside of `predict()`. They are specified in the constructor as opposed to the `predict()` method itself, as explained here: https://github.com/unit8co/darts/issues/2891#issuecomment-3264932887  