### PR TITLE
.map() improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - 🔴 Renamed the `RegressionEnsembleModel` ensemble model attribute from `regression_model` to `ensemble_model` to make it more clear that this model is used to combine the predictions of the base models. [#2894](https://github.com/unit8co/darts/pull/2894) by [Dennis Bader](https://github.com/dennisbader).
 - Added parameter `verbose` to `ForecastingModel.fit()` and `predict()` that allows to control the verbosity for model fitting and prediction. Ignored if the underlying model does not support it. [#2805](https://github.com/unit8co/darts/pull/2805) by [Timon Erhart](https://github.com/turbotimon) and [Dennis Bader](https://github.com/dennisbader).
 - It is now possible to control the fit and predict verbosity in `ForecastingModel.historical_forecasts()` by passing `verbose` in parameters `fit_kwargs` and `predict_kwargs`. [#2805](https://github.com/unit8co/darts/pull/2805) by [Timon Erhart](https://github.com/turbotimon) and [Dennis Bader](https://github.com/dennisbader).
+- 🔴 Improved the performance of the `TimeSeries.map()` method. For functions that take two arguments, users must now reshape the TimeSeries index explicitly within their function definition. See more information in the `TimeSeries.map()` method documentation.
 
 **Fixed**
 

--- a/darts/tests/dataprocessing/transformers/test_mappers.py
+++ b/darts/tests/dataprocessing/transformers/test_mappers.py
@@ -18,11 +18,11 @@ class TestMappers:
 
     @staticmethod
     def ts_func(ts, x):
-        return x - ts.month
+        return x - ts.month.values.reshape(-1, 1, 1)
 
     @staticmethod
     def inverse_ts_func(ts, x):
-        return x + ts.month
+        return x + ts.month.values.reshape(-1, 1, 1)
 
     plus_ten = Mapper(func.__func__)
     plus_ten_invertible = InvertibleMapper(func.__func__, inverse_func.__func__)

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1667,7 +1667,7 @@ class TestTimeSeries:
         zeroes = zeroes.with_columns_renamed("constant", "linear")
 
         def function(ts, x):
-            return x - ts.month
+            return x - ts.month.values.reshape(-1, 1, 1)
 
         new_series = series.map(function)
         assert new_series == zeroes


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2889 .

### Summary

This PR changes the implementation of the TimeSeries.map() method, making it faster and improving type hinting. User now, in case of passing a 2 param func, needs to reshape the time index properly. 

### Other Information

This approach should speed up the implementation by about 5-6x, provided the user provides the data in proper shape.

Comparison between previous and current version, where shapes of ts are     
shapes = {
        "long": (100000, 1),
        "wide": (100, 100),
    }

<img width="915" height="584" alt="image" src="https://github.com/user-attachments/assets/807d3541-97aa-4c08-a857-8bb9ec7a753e" />

<img width="165" height="46" alt="Screenshot 2025-09-23 at 13 17 07 (1)" src="https://github.com/user-attachments/assets/31ba5104-35ae-4872-a581-8c68b41b6279" />
