### PR TITLE
update to_dataframe() warning

### DIFF
--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1800,10 +1800,11 @@ class TimeSeries:
         if not self.is_deterministic:
             if not suppress_warnings:
                 logger.warning(
-                    "You are transforming a stochastic TimeSeries (i.e., contains several samples). "
+                    "You are transforming a stochastic TimeSeries (it contains several samples). "
                     "The resulting DataFrame is a 2D object with all samples on the columns. "
-                    "If this is not the expected behavior consider calling a function "
-                    "adapted to stochastic TimeSeries like quantile_df()."
+                    "If this is not the expected behavior, extract statistics from the TimeSeries "
+                    "before calling `to_dataframe()` (e.g. with `TimeSeries.quantile()`, `mean()`, "
+                    "...)."
                 )
 
             comp_name = list(self.components)


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). (not required)

<!-- Please mention an issue this pull request addresses. -->
Fixes #2922.

### Summary

- Adapt warning in `to_dataframe()` for stochastic series to not reference the deprecated `quantile_df` method anymore
