### PR TITLE
add os.Path support for load/save torch models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - 🔴 Improved the performance of the `TimeSeries.map()` method for functions that take two arguments. The mapping is now applied on the entire time index and values array which requires users to reshape the time index explicitly within the function. See more information in the `TimeSeries.map()` method documentation. [#2911](https://github.com/unit8co/darts/pull/2911) by [Jakub Chłapek](https://github.com/jakubchlapek)
 
+- Improved the `save`/`load` methods for `TorchForecastingModel` to support `os.PathLike` objects as file path. [#2947](https://github.com/unit8co/darts/pull/2947) by [Timon Erhart](https://github.com/timonerhart)
+
 **Fixed**
 
 **Dependencies**

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -2004,7 +2004,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
 
     @staticmethod
     def load(
-        path: Optional[Union[str, os.PathLike]] = None,
+        path: Union[str, os.PathLike],
         pl_trainer_kwargs: Optional[dict] = None,
         **kwargs,
     ) -> "TorchForecastingModel":


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->

### Summary

Currently, the save/load methdos for TorchForecastingModel do not support [os.PathLike](https://docs.python.org/3/library/os.html#os.PathLike) object for the path argument. Other model-families (conformal, ensemble, forecasting) already do so. This PR changes that, improving the usability as well as make the interface more similar.

No additional test are needed. As the path argument is transformed to a pathlib.Path object at the beginning it is [guaranteed to work with str as well as any os.PathLike objects](https://docs.python.org/3/library/pathlib.html#pure-paths)

The other Model-family also support file-like objects (IObuffer). But since [pl.Trainer.save_checkpoint](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.trainer.trainer.Trainer.html#lightning.pytorch.trainer.trainer.Trainer.save_checkpoint) does not supports it, i didn't add this support as well. Torch.save would support it, however.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
