### PR TITLE
fix PLForecastingModel.configure_torch_metrics() with updated args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- `TorchForecastingModel` parameter `torch_metrics` now supports all input metric types from ``torchmetrics.MetricCollection``. Eg. now you can also pass a dictionary or sequence of metrics. [#2958](https://github.com/unit8co/darts/pull/2958) by [CorticallyAI](https://github.com/CorticallyAI).
+
 **Fixed**
 
 - Fixed an issue in `TFTExplainer` where attempting to explain a list of series longer than the model's batch size resulted in an `IndexError`. A more informative error message is now raised instead. [#2957](https://github.com/unit8co/darts/pull/2957) by [Dennis Bader](https://github.com/dennisbader).
-- Fixed a limitation in `PLTorchForecastingModule.torch_metrics=` where we did not support all types as the resulting `torchmetrics.MetricCollection()` does. Eg. metrics can now be set with user-configurable keys in a `Dict[str, Metric]`. [#2958](https://github.com/unit8co/darts/pull/2958) by [CorticallyAI](https://github.com/CorticallyAI).  
 
 **Dependencies**
 

--- a/darts/models/forecasting/pl_forecasting_module.py
+++ b/darts/models/forecasting/pl_forecasting_module.py
@@ -85,7 +85,12 @@ class PLForecastingModule(pl.LightningModule, ABC):
         train_sample_shape: Optional[tuple] = None,
         loss_fn: nn.modules.loss._Loss = nn.MSELoss(),
         torch_metrics: Optional[
-            Union[torchmetrics.Metric, torchmetrics.MetricCollection]
+            Union[
+                torchmetrics.Metric,
+                torchmetrics.MetricCollection,
+                Sequence[Union[torchmetrics.Metric, torchmetrics.MetricCollection]],
+                dict[str, Union[torchmetrics.Metric, torchmetrics.MetricCollection]],
+            ]
         ] = None,
         likelihood: Optional[TorchLikelihood] = None,
         optimizer_cls: torch.optim.Optimizer = torch.optim.Adam,
@@ -130,9 +135,8 @@ class PLForecastingModule(pl.LightningModule, ABC):
             This parameter will be ignored for probabilistic models if the ``likelihood`` parameter is specified.
             Default: ``torch.nn.MSELoss()``.
         torch_metrics
-            A torchmetric.Metric or a collection used for evaluation. A full list of available metrics can be found
-            at https://torchmetrics.readthedocs.io/en/latest/ , see `torchmetrics.MetricCollection()`.
-            Default: ``None``.
+            A ``torchmetric.Metric`` or a ``MetricCollection`` used for evaluation. A full list of available metrics
+            can be found `here <https://torchmetrics.readthedocs.io/en/latest/>`__. Default: ``None``.
         likelihood
             One of Darts' :meth:`Likelihood <darts.utils.likelihood_models.torch.TorchLikelihood>` models to be used for
             probabilistic forecasts. Default: ``None``.
@@ -803,13 +807,11 @@ class PLForecastingModule(pl.LightningModule, ABC):
         torch_metrics: Union[
             torchmetrics.Metric,
             torchmetrics.MetricCollection,
-            Sequence[torchmetrics.Metric | torchmetrics.MetricCollection],
-            dict[str, torchmetrics.Metric | torchmetrics.MetricCollection],
+            Sequence[Union[torchmetrics.Metric, torchmetrics.MetricCollection]],
+            dict[str, Union[torchmetrics.Metric, torchmetrics.MetricCollection]],
         ],
     ) -> torchmetrics.MetricCollection:
         """process the torch_metrics parameter."""
-        if torch_metrics is None:
-            torch_metrics = torchmetrics.MetricCollection([])
-        else:
-            torch_metrics = torchmetrics.MetricCollection(torch_metrics)
-        return torch_metrics
+        return torchmetrics.MetricCollection(
+            torch_metrics if torch_metrics is not None else []
+        )

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -1508,14 +1508,20 @@ class TestTorchForecastingModel:
         with pytest.raises(ValueError):
             _ = RnnModelLambda(0, input_chunk_length=12, **invalid_kwargs)
 
-    def test_metrics(self):
-        metric = MeanAbsolutePercentageError()
-        metric_collection = MetricCollection([
-            MeanAbsolutePercentageError(),
-            MeanAbsoluteError(),
-            R2Score(),
-        ])
-
+    @pytest.mark.parametrize(
+        "metric",
+        [
+            MeanAbsolutePercentageError(),  # single metric
+            MetricCollection([
+                MeanAbsolutePercentageError(),
+                MeanAbsoluteError(),
+                R2Score(),
+            ]),  # metric collection
+            {"metric_name": MeanAbsolutePercentageError()},  # dict of metrics
+            [MeanAbsolutePercentageError()],  # sequence of metrics
+        ],
+    )
+    def test_metrics(self, metric):
         model_kwargs = {
             "logger": DummyLogger(),
             "log_every_n_steps": 1,
@@ -1533,18 +1539,6 @@ class TestTorchForecastingModel:
         )
         model.fit(self.series)
 
-        # test metric collection
-        model = RNNModel(
-            12,
-            "RNN",
-            10,
-            10,
-            n_epochs=1,
-            torch_metrics=metric_collection,
-            pl_trainer_kwargs=model_kwargs,
-        )
-        model.fit(self.series)
-
         # test multivariate series
         model = RNNModel(
             12,
@@ -1552,7 +1546,7 @@ class TestTorchForecastingModel:
             10,
             10,
             n_epochs=1,
-            torch_metrics=metric_collection,
+            torch_metrics=metric,
             pl_trainer_kwargs=model_kwargs,
         )
         model.fit(self.multivariate_series)


### PR DESCRIPTION

Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

simplify our wrapper method configure_torch_metrics(), delegate the init and error handling to the torchmetrics.MetricCollection().

The problem was that our if-elif handling got obsolete wrt the MetricCollection capabilities.

Fixed: now we support eg. Dict[str, Metric].

