### PR TITLE
handle static covariates timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
-- `TimeSeries.to_json()` and `TimeSeries.from_json()` now support serialization and deserialization of static covariates, metadata, and hierarchy. The optional parameters in `from_json()` can still be used to override or provide these values if they are not present in the JSON string. [#2996](https://github.com/unit8co/darts/pull/2996) by [Tiberiu Sabau](https://github.com/tibisabau).
+- `TimeSeries.to_json()` and `from_json()` now support serialization and deserialization of static covariates, metadata, and hierarchy. The optional parameters in `from_json()` can still be used to override or provide these values if they are not present in the JSON string. [#2996](https://github.com/unit8co/darts/pull/2996) by [Tiberiu Sabau](https://github.com/tibisabau).
 - Added new time aggregated metric `autc()` (Area Under Tolerance Curve): The tolerance curve gives the fraction of predicted target values within tolerance bands of the actual target values across a range of tolerances (defined as % of target range). The AUTC is the normalized area under this tolerance curve and given as a score between [0, 1]. Higher scores are better. [#2994](https://github.com/unit8co/darts/pull/2994) by [Jakub Chłapek](https://github.com/jakubchlapek)
 - Added new plotting function `darts.utils.statistics.plot_tolerance_curve()` to plot the tolerance curve described above. [#2994](https://github.com/unit8co/darts/pull/2994) by [Jakub Chłapek](https://github.com/jakubchlapek)
 - Added `TimeSeries.plotly()` method for interactive time series visualization using Plotly backend. [#2977](https://github.com/unit8co/darts/pull/2977) by [Dustin Brunner](https://github.com/brunnedu).

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1514,15 +1514,22 @@ class TimeSeries:
         (3, 1, 1)
         """
         parsed = json.loads(json_str)
-        json_sc = parsed.pop("static_covariates", None)
-        if json_sc is not None and static_covariates is None:
-            static_covariates = pd.DataFrame(
-                data=json_sc["data"], index=json_sc["index"], columns=json_sc["columns"]
-            )
-        hierarchy = parsed.pop("hierarchy", hierarchy)
-        metadata = parsed.pop("metadata", metadata)
-        df = pd.read_json(StringIO(json.dumps(parsed)), orient="split")
 
+        static_covariates_ = parsed.pop("static_covariates", None)
+        if static_covariates_ is not None and static_covariates is None:
+            static_covariates = pd.read_json(
+                StringIO(json.dumps(static_covariates_)), orient="split"
+            )
+
+        hierarchy_ = parsed.pop("hierarchy", None)
+        if hierarchy is None:
+            hierarchy = hierarchy_
+
+        metadata_ = parsed.pop("metadata", None)
+        if metadata is None:
+            metadata = metadata_
+
+        df = pd.read_json(StringIO(json.dumps(parsed)), orient="split")
         return cls.from_dataframe(
             df=df,
             static_covariates=static_covariates,


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #2966.

### Summary

Added support for automatic serialization and deserialization of static covariates, metadata, and hierarchy in `TimeSeries.to_json()` and `TimeSeries.from_json()` methods. Previously, these attributes were lost during JSON serialization and had to be manually re-added when deserializing. Now they are automatically preserved in the JSON string and restored when loading, while maintaining backward compatibility with the optional parameter override functionality.

### Other Information
**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**