### PR TITLE
git blame ignore py310 refactor

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,5 @@
 8158d3eaef9d9f6e04f219b029e306d1f1be46d5
 # Change Python target-version to 3.9 and update Ruff to 0.7.2
 18e2e3fd7d82d239ab24807fcc1033094ea09940
+# Change Python target-version to 3.10
+d5cda436e48d4eb773b1b165726556fe6a8db490


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md). (not required)

### Summary

Git blame ignores the diffs from the python 3.10 target version refactor from #3017.