### PR TITLE
feat: add insample parameter to Diff and Pipeline inverse_transform

### DIFF
--- a/darts/dataprocessing/pipeline.py
+++ b/darts/dataprocessing/pipeline.py
@@ -5,6 +5,7 @@ Pipeline
 
 from collections.abc import Iterator, Sequence
 from copy import deepcopy
+from typing import TypeAlias, cast
 
 from darts import TimeSeries
 from darts.dataprocessing.transformers import (
@@ -12,10 +13,16 @@ from darts.dataprocessing.transformers import (
     FittableDataTransformer,
     InvertibleDataTransformer,
 )
+from darts.dataprocessing.transformers.invertible_data_transformer import (
+    ts_inverse_accepts_insample,
+)
 from darts.logging import get_logger, raise_if_not
 from darts.typing import TimeSeriesLike
 
 logger = get_logger(__name__)
+
+# Input/output shape for one step of :meth:`Pipeline.inverse_transform` (matches ``InvertibleDataTransformer``).
+_PipelineInverseStepData: TypeAlias = TimeSeriesLike | list[list[TimeSeries]]
 
 
 class Pipeline:
@@ -75,7 +82,7 @@ class Pipeline:
 
         if transformers is None or len(transformers) == 0:
             logger.warning("Empty pipeline created")
-            self._transformers: Sequence[BaseDataTransformer[TimeSeries]] = []
+            self._transformers: Sequence[BaseDataTransformer] = []
         elif copy:
             self._transformers = deepcopy(transformers)
         else:
@@ -180,6 +187,7 @@ class Pipeline:
         self,
         data: TimeSeriesLike,
         partial: bool = False,
+        insample: TimeSeries | None = None,
         series_idx: int | Sequence[int] | None = None,
     ) -> TimeSeriesLike:
         """
@@ -195,6 +203,14 @@ class Pipeline:
         partial
             If set to `True`, the inverse transformation is applied even if the pipeline is not fully invertible,
             calling `inverse_transform()` only on transformers of type `InvertibleDataTransformer`.
+        insample
+            Optionally, the transformed in-sample series produced by :func:`fit_transform()` on the full
+            pipeline (i.e. in the same transformed space as ``data``). When provided, it is threaded
+            backward through the pipeline so that each stage always receives its own in-sample context.
+            After each stage ``t``, ``insample`` is itself inverse-transformed by ``t`` (without an
+            ``insample`` argument) so that it moves into the next stage's input space, matching what
+            the next transformer expects.  Transformers that do not need the context (e.g.
+            :class:`~darts.dataprocessing.transformers.Scaler`) simply ignore it.
         series_idx
             Optionally, the index(es) of each series corresponding to their positions within the series used to fit
             the transformer (to retrieve the appropriate transformer parameters).
@@ -211,16 +227,53 @@ class Pipeline:
                 logger,
             )
 
+            insample_tail = insample
+            running: _PipelineInverseStepData = data
             for transformer in reversed(self._transformers):
-                data = transformer.inverse_transform(data, series_idx=series_idx)
-            return data
+                inv_t = cast(InvertibleDataTransformer, transformer)
+                if insample_tail is not None and ts_inverse_accepts_insample(
+                    inv_t.__class__
+                ):
+                    running = inv_t.inverse_transform(
+                        running,
+                        series_idx=series_idx,
+                        insample=insample_tail,
+                    )
+                else:
+                    running = inv_t.inverse_transform(running, series_idx=series_idx)
+                if insample_tail is not None:
+                    insample_tail = cast(
+                        TimeSeries | None,
+                        inv_t.inverse_transform(insample_tail, series_idx=series_idx),
+                    )
+            return cast(TimeSeriesLike, running)
         else:
+            insample_tail = insample
             for transformer in reversed(self._transformers):
                 if isinstance(transformer, InvertibleDataTransformer):
-                    data = transformer.inverse_transform(
-                        data,
-                        series_idx=series_idx,
-                    )
+                    if insample_tail is not None and ts_inverse_accepts_insample(
+                        transformer.__class__
+                    ):
+                        data = cast(
+                            TimeSeriesLike,
+                            transformer.inverse_transform(
+                                data,
+                                series_idx=series_idx,
+                                insample=insample_tail,
+                            ),
+                        )
+                    else:
+                        data = cast(
+                            TimeSeriesLike,
+                            transformer.inverse_transform(data, series_idx=series_idx),
+                        )
+                    if insample_tail is not None:
+                        insample_tail = cast(
+                            TimeSeries | None,
+                            transformer.inverse_transform(
+                                insample_tail, series_idx=series_idx
+                            ),
+                        )
             return data
 
     @property
@@ -288,15 +341,15 @@ class Pipeline:
         if isinstance(key, int):
             transformers = [self._transformers[key]]
         else:
-            transformers = self._transformers[key]
+            transformers = list(self._transformers[key])
         return Pipeline(transformers, copy=True)
 
     def __iter__(self) -> Iterator[BaseDataTransformer]:
         """
-        Returns
+           Returns
         -------
-        Iterator
-            Iterator on sequence of data transformers
+           Iterator
+               Iterator on sequence of data transformers
         """
         return self._transformers.__iter__()
 

--- a/darts/dataprocessing/transformers/diff.py
+++ b/darts/dataprocessing/transformers/diff.py
@@ -16,6 +16,7 @@ from darts.dataprocessing.transformers.invertible_data_transformer import (
     InvertibleDataTransformer,
 )
 from darts.logging import get_logger, raise_log
+from darts.timeseries import concatenate
 
 logger = get_logger(__name__)
 
@@ -177,6 +178,8 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
     ) -> TimeSeries:
         lags, dropna = params["fixed"]["_lags"], params["fixed"]["_dropna"]
         start_vals, fit_component_mask, start_time, freq = params["fitted"]
+        insample: TimeSeries | None = kwargs.pop("insample", None)
+
         if series.freq != freq:
             raise_log(
                 ValueError(
@@ -187,20 +190,90 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
             )
         # Start dates 'missing' from differenced series if dropna = True, so need to shift forward:
         expected_start = start_time + sum(lags) * series.freq if dropna else start_time
-        if series.start_time() != expected_start:
-            raise_log(
-                ValueError(
-                    f"Expected series to begin at time {expected_start}; "
-                    f"instead, it begins at time {series.start_time()}."
-                ),
-                logger,
-            )
+
         component_mask = kwargs.get("component_mask")
         if np.any(fit_component_mask != component_mask):
             raise_log(
                 ValueError(
                     "Provided `component_mask` does not match "
                     "`component_mask` specified when `fit` was called."
+                ),
+                logger,
+            )
+
+        if insample is not None:
+            # `insample` must be the direct output of fit_transform() on the training series,
+            # i.e. the transformed series in the same space as `series` (the forecast).
+            # We prepend the relevant suffix of `insample` to `series` so that the combined
+            # series starts at `expected_start`, satisfying the standard inverse-transform
+            # entry condition, then slice back to only the forecast window.
+            if insample.freq != freq:
+                raise_log(
+                    ValueError(
+                        f"insample is of frequency {insample.freq}, but "
+                        f"transform was fitted to data of frequency {freq}."
+                    ),
+                    logger,
+                )
+            if insample.start_time() > expected_start:
+                raise_log(
+                    ValueError(
+                        f"Expected insample to begin at or before time {expected_start}; "
+                        f"instead, it begins at {insample.start_time()}. "
+                        "insample must be the direct output of fit_transform() "
+                        "applied to the training series."
+                    ),
+                    logger,
+                )
+            elif insample.start_time() < expected_start:
+                # Trim to expected_start — this can happen during rolling-window retrain
+                # when insample covers history prior to the current fit window.
+                insample = insample.drop_before(expected_start, keep_point=True)
+            if insample.n_components != series.n_components:
+                raise_log(
+                    ValueError(
+                        f"Expected insample to have {series.n_components} components; "
+                        f"instead, it has {insample.n_components}."
+                    ),
+                    logger,
+                )
+            if insample.n_samples != series.n_samples:
+                raise_log(
+                    ValueError(
+                        f"Expected insample to have {series.n_samples} samples; "
+                        f"instead, it has {insample.n_samples}."
+                    ),
+                    logger,
+                )
+            forecast_start = series.start_time()
+            # Keep only the part of insample that strictly precedes the forecast.
+            # When insample already ends before the forecast (the common case), use it
+            # as-is to avoid an out-of-bounds error from drop_after().
+            if insample.end_time() < forecast_start:
+                suffix = insample
+            else:
+                suffix = insample.drop_after(forecast_start)
+            if suffix.n_timesteps == 0:
+                raise_log(
+                    ValueError(
+                        "insample must contain at least one timestep strictly "
+                        f"before the forecast start {forecast_start}; "
+                        f"insample ends at {insample.end_time()}."
+                    ),
+                    logger,
+                )
+            # combined starts at expected_start, satisfying the standard entry condition.
+            combined = concatenate([suffix, series], axis=0)
+            # kwargs no longer contains 'insample' (already popped), so this won't recurse.
+            result = Diff.ts_inverse_transform(combined, params, **kwargs)
+            # Return only the forecast portion of the undifferenced result.
+            return result.drop_before(forecast_start, keep_point=True)
+
+        if series.start_time() != expected_start:
+            raise_log(
+                ValueError(
+                    f"Expected series to begin at time {expected_start}; "
+                    f"instead, it begins at time {series.start_time()}."
                 ),
                 logger,
             )

--- a/darts/dataprocessing/transformers/invertible_data_transformer.py
+++ b/darts/dataprocessing/transformers/invertible_data_transformer.py
@@ -3,6 +3,7 @@ Invertible Data Transformer Base Class
 --------------------------------------
 """
 
+import inspect
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -19,6 +20,14 @@ from darts.typing import TimeSeriesLike
 from darts.utils import _build_tqdm_iterator, _parallel_apply
 
 logger = get_logger(__name__)
+
+
+def ts_inverse_accepts_insample(cls: type) -> bool:
+    """Whether ``cls.ts_inverse_transform`` can receive an ``insample`` keyword argument."""
+    sig = inspect.signature(cls.ts_inverse_transform)
+    if "insample" in sig.parameters:
+        return True
+    return any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
 
 
 class InvertibleDataTransformer(BaseDataTransformer):
@@ -231,6 +240,7 @@ class InvertibleDataTransformer(BaseDataTransformer):
         series: TimeSeriesLike | Sequence[Sequence[TimeSeries]],
         *args,
         component_mask: np.ndarray | None = None,
+        insample: TimeSeries | None = None,
         series_idx: int | Sequence[int] | None = None,
         **kwargs,
     ) -> TimeSeries | list[TimeSeries] | list[list[TimeSeries]]:
@@ -260,6 +270,15 @@ class InvertibleDataTransformer(BaseDataTransformer):
         component_mask
             Optionally, a 1-D boolean np.ndarray of length ``series.n_components`` that specifies
             which components of the underlying `series` the inverse transform should consider.
+        insample
+            Optionally, the transformed in-sample series (i.e. the direct output of
+            :func:`fit_transform()` applied to the training series) in the same transformed space as
+            ``series``. When provided, transformers that require historical context to invert a
+            forecast — such as :class:`Diff` — will use ``insample`` to seed the inverse
+            transformation instead of requiring the full transformed series from the fit start.
+            Transformers that do not need this context simply ignore the parameter.
+            For a sequence input to ``series``, the same ``insample`` is broadcast to every element;
+            call :func:`inverse_transform` individually for per-series in-sample data.
         series_idx
             Optionally, the index(es) of each series corresponding to their positions within the series used to fit
             the transformer (to retrieve the appropriate transformer parameters).
@@ -346,9 +365,14 @@ class InvertibleDataTransformer(BaseDataTransformer):
         )
 
         # apply & unapply component masking to the transform method
+        # Drop any stray ``insample`` from caller ``**kwargs``; many ``ts_inverse_transform``
+        # implementations (e.g. MIDAS) do not accept ``**kwargs`` and would raise on it.
+        kwargs.pop("insample", None)
         kwargs["mask_components"] = self._mask_components
         kwargs["mask_components_apply_only"] = False
         kwargs["component_mask"] = component_mask
+        if insample is not None and ts_inverse_accepts_insample(self.__class__):
+            kwargs["insample"] = insample
 
         transformed_data = _parallel_apply(
             input_iterator,

--- a/darts/tests/dataprocessing/transformers/test_diff.py
+++ b/darts/tests/dataprocessing/transformers/test_diff.py
@@ -8,7 +8,10 @@ import pytest
 
 from darts import TimeSeries
 from darts import concatenate as darts_concat
+from darts.dataprocessing.pipeline import Pipeline
 from darts.dataprocessing.transformers import Diff
+from darts.dataprocessing.transformers.scaler import Scaler
+from darts.datasets import AirPassengersDataset
 from darts.utils.timeseries_generation import linear_timeseries, sine_timeseries
 
 
@@ -354,3 +357,279 @@ class TestDiff:
         startvals2 = deepcopy(diff._fitted_params)[0][0]
 
         assert not np.allclose(startvals1, startvals2)
+
+
+class TestDiffInsample:
+    """Tests for `Diff.inverse_transform(..., insample=...)` using AirPassengersDataset."""
+
+    @pytest.fixture(autouse=True)
+    def _load_air_passengers(self):
+        """Load AirPassengers once per test; split into train/test halves."""
+        full = AirPassengersDataset().load()
+        # Split at the halfway point along the time axis.
+        split = len(full) // 2
+        self.train = full[:split]
+        self.test = full[split:]
+        self.full = full
+        self.train_end = self.train.end_time()
+
+    # ------------------------------------------------------------------
+    # helper
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _split_diff(full_diff: TimeSeries, train_end) -> tuple[TimeSeries, TimeSeries]:
+        """Split a differenced series at `train_end` using the original time boundary.
+
+        Returns ``(train_diff, test_diff)`` where:
+        - ``train_diff`` covers everything up to and including ``train_end``.
+        - ``test_diff`` covers everything strictly after ``train_end``.
+        """
+        train_diff = full_diff.drop_after(train_end, keep_point=True)
+        test_diff = full_diff.drop_before(train_end)
+        return train_diff, test_diff
+
+    # ------------------------------------------------------------------
+    # 1. Parity: insample path == direct full-series path (sliced to test)
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "lags,dropna",
+        [
+            (1, True),
+            (1, False),
+            ([1, 2], True),
+            ([1, 2], False),
+            ([1, 12], True),
+        ],
+    )
+    def test_insample_parity_with_full_series(self, lags, dropna):
+        """
+        Inverting the test-half diff with insample=train_half must give the same
+        result as inverting the full differenced series and slicing the test window.
+        """
+        diff = Diff(lags=lags, dropna=dropna)
+        full_diff = diff.fit_transform(self.full)
+
+        train_diff, test_diff = self._split_diff(full_diff, self.train_end)
+
+        # Baseline: full inverse then slice to test window.
+        result_full = diff.inverse_transform(full_diff)
+        expected = result_full.drop_before(self.test.start_time(), keep_point=True)
+
+        # New insample path.
+        actual = diff.inverse_transform(test_diff, insample=train_diff)
+
+        np.testing.assert_allclose(
+            expected.all_values(),
+            actual.all_values(),
+            atol=1e-8,
+            equal_nan=True,
+        )
+        assert expected.time_index.equals(actual.time_index)
+
+    # ------------------------------------------------------------------
+    # 2. Forecast-only inverse: result matches the original level series
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "lags,dropna",
+        [
+            (1, True),
+            (1, False),
+            ([1, 2], True),
+            ([1, 2], False),
+            ([1, 12], True),
+            ([1, 12], False),
+        ],
+    )
+    def test_insample_forecast_recovers_original(self, lags, dropna):
+        """
+        Diff.inverse_transform(test_diff, insample=train_diff) must recover
+        the original level test series exactly, without any manual concatenation.
+        """
+        diff = Diff(lags=lags, dropna=dropna)
+        # Fit only on the training half; transform the entire series in diff-space.
+        diff.fit(self.train)
+        full_diff = diff.transform(self.full)
+
+        train_diff, test_diff = self._split_diff(full_diff, self.train_end)
+
+        recovered = diff.inverse_transform(test_diff, insample=train_diff)
+
+        np.testing.assert_allclose(
+            self.test.all_values(),
+            recovered.all_values(),
+            atol=1e-6,
+            equal_nan=True,
+        )
+        assert self.test.time_index.equals(recovered.time_index)
+
+    # ------------------------------------------------------------------
+    # 3. Equivalence: insample path == old manual-concat workaround
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize("lags,dropna", [(1, True), ([1, 12], True)])
+    def test_insample_equivalent_to_manual_concat(self, lags, dropna):
+        """
+        The insample path must produce exactly the same result as the manual
+        workaround: concatenate(train_diff, test_diff) then inverse_transform,
+        sliced back to the test window.
+        """
+        diff = Diff(lags=lags, dropna=dropna)
+        diff.fit(self.train)
+        full_diff = diff.transform(self.full)
+
+        train_diff, test_diff = self._split_diff(full_diff, self.train_end)
+
+        # Old manual workaround.
+        manual_concat = darts_concat([train_diff, test_diff], axis=0)
+        result_manual = diff.inverse_transform(manual_concat)
+        result_manual = result_manual.drop_before(
+            self.test.start_time(), keep_point=True
+        )
+
+        # New insample path.
+        result_insample = diff.inverse_transform(test_diff, insample=train_diff)
+
+        np.testing.assert_allclose(
+            result_manual.all_values(),
+            result_insample.all_values(),
+            atol=1e-8,
+        )
+        assert result_manual.time_index.equals(result_insample.time_index)
+
+    # ------------------------------------------------------------------
+    # 4. Component mask respected
+    # ------------------------------------------------------------------
+    def test_insample_with_component_mask(self):
+        """
+        When a component_mask is supplied only the masked components are
+        inverse-differenced; unmasked components must pass through unchanged.
+        """
+        multi = darts_concat([AirPassengersDataset().load()] * 3, axis=1)
+        mask = np.array([True, False, True])
+
+        diff = Diff(lags=1, dropna=False)
+        transformed = diff.fit_transform(multi, component_mask=mask)
+
+        train_end = multi[: len(multi) // 2].end_time()
+        train_diff, test_diff = self._split_diff(transformed, train_end)
+
+        recovered = diff.inverse_transform(
+            test_diff, component_mask=mask, insample=train_diff
+        )
+
+        np.testing.assert_allclose(
+            multi[len(multi) // 2 :].all_values(),
+            recovered.all_values(),
+            atol=1e-6,
+        )
+
+    # ------------------------------------------------------------------
+    # 5. Validation errors
+    # ------------------------------------------------------------------
+    def test_insample_wrong_freq_raises(self):
+        """insample with a different frequency must raise ValueError."""
+        diff = Diff(lags=1, dropna=True)
+        full_diff = diff.fit_transform(self.full)
+        _, test_diff = self._split_diff(full_diff, self.train_end)
+
+        # Build an insample-shaped series with quarterly frequency (wrong).
+        bad_insample = TimeSeries.from_times_and_values(
+            times=pd.date_range(start=full_diff.start_time(), periods=10, freq="QE"),
+            values=np.zeros((10, 1)),
+        )
+        with pytest.raises(ValueError, match="insample is of frequency"):
+            diff.inverse_transform(test_diff, insample=bad_insample)
+
+    def test_insample_wrong_start_raises(self):
+        """insample that does not start at expected_start must raise ValueError."""
+        diff = Diff(lags=1, dropna=True)
+        train_diff = diff.fit_transform(self.train)
+        full_diff = diff.transform(self.full)
+        _, test_diff = self._split_diff(full_diff, self.train_end)
+
+        # Trim one step from the front so start_time shifts by one period.
+        bad_insample = train_diff.drop_before(train_diff.start_time())
+
+        with pytest.raises(
+            ValueError, match="Expected insample to begin at or before time"
+        ):
+            diff.inverse_transform(test_diff, insample=bad_insample)
+
+    def test_insample_too_short_raises(self):
+        """insample must contain at least one timestep strictly before the forecast.
+
+        We trigger this by making the forecast start exactly at expected_start, so
+        that drop_after(forecast_start) removes all of insample.
+        """
+        diff = Diff(lags=1, dropna=True)
+        full_diff = diff.fit_transform(self.full)
+        expected_start = full_diff.start_time()
+
+        # Forecast that starts at expected_start — no room for suffix in insample.
+        forecast_at_expected_start = TimeSeries.from_times_and_values(
+            times=pd.date_range(start=expected_start, periods=5, freq=full_diff.freq),
+            values=np.zeros((5, 1)),
+        )
+        with pytest.raises(ValueError, match="insample must contain at least one"):
+            diff.inverse_transform(forecast_at_expected_start, insample=full_diff)
+
+    # ------------------------------------------------------------------
+    # 6. Pipeline: [Diff → Scaler] — insample threads through both stages
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize("lags,dropna", [(1, True), ([1, 12], True)])
+    def test_pipeline_insample(self, lags, dropna):
+        """
+        Pipeline([Diff, Scaler]).inverse_transform(test_tf, insample=train_tf)
+        must recover the original level test series end-to-end.
+        """
+        pipeline = Pipeline([Diff(lags=lags, dropna=dropna), Scaler()])
+        full_transformed = pipeline.fit_transform(self.full)
+
+        # Use the original train/test time boundary to split the transformed output.
+        train_tf, test_tf = self._split_diff(full_transformed, self.train_end)
+
+        recovered = pipeline.inverse_transform(test_tf, insample=train_tf)
+
+        np.testing.assert_allclose(
+            self.test.all_values(),
+            recovered.all_values(),
+            atol=1e-4,
+        )
+        assert self.test.time_index.equals(recovered.time_index)
+
+    # ------------------------------------------------------------------
+    # 7. Stochastic (multi-sample) series
+    # ------------------------------------------------------------------
+    def test_insample_stochastic(self):
+        """insample path must work correctly for stochastic (multi-sample) series."""
+        rng = np.random.default_rng(42)
+        n_samples = 20
+        base = AirPassengersDataset().load()
+
+        # Build a stochastic series: base level + independent noise per sample.
+        base_vals = base.all_values()  # (T, 1, 1)
+        # Broadcast to (T, 1, n_samples) then add per-sample noise.
+        stochastic_vals = np.broadcast_to(base_vals, (len(base), 1, n_samples)).copy()
+        stochastic_vals += rng.normal(0, 3.0, stochastic_vals.shape)
+        stochastic = TimeSeries.from_times_and_values(
+            times=base.time_index,
+            values=stochastic_vals,
+        )
+
+        train_end = stochastic[: len(stochastic) // 2].end_time()
+
+        diff = Diff(lags=1, dropna=True)
+        diff.fit(stochastic[: len(stochastic) // 2])
+        full_diff = diff.transform(stochastic)
+
+        train_diff, test_diff = self._split_diff(full_diff, train_end)
+
+        recovered = diff.inverse_transform(test_diff, insample=train_diff)
+
+        np.testing.assert_allclose(
+            stochastic[len(stochastic) // 2 :].all_values(),
+            recovered.all_values(),
+            atol=1e-5,
+        )
+        assert stochastic[len(stochastic) // 2 :].time_index.equals(
+            recovered.time_index
+        )

--- a/darts/utils/historical_forecasts/utils.py
+++ b/darts/utils/historical_forecasts/utils.py
@@ -6,7 +6,7 @@ Optimized Historical Forecasts Utils
 import inspect
 from collections.abc import Callable, Sequence
 from types import SimpleNamespace
-from typing import Any, Literal, TypeAlias, TypeVar
+from typing import Any, Literal, TypeAlias, TypeVar, cast
 
 import numpy as np
 import pandas as pd
@@ -1444,8 +1444,16 @@ def _apply_inverse_data_transformers(
         called_with_single_series = get_series_seq_type(series) == SeriesType.SINGLE
         if called_with_single_series:
             forecasts = [forecasts]
+        # Pass the transformed target series as `insample` so that transformers such as
+        # `Diff` can recover the original scale from the forecast-only series without
+        # requiring the caller to manually prepend history.  For multi-series (global)
+        # calls we leave `insample=None` because the per-series pairing is not yet
+        # supported in the base `inverse_transform` signature.
+        insample: TimeSeries | None = (
+            cast(TimeSeries, series) if called_with_single_series else None
+        )
         forecasts = data_transformers["series"].inverse_transform(
-            forecasts, series_idx=series_idx
+            forecasts, series_idx=series_idx, insample=insample
         )
         return forecasts[0] if called_with_single_series else forecasts
     else:


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #3045.

### Summary
This PR adds an optional `insample` parameter to `inverse_transform()` in `InvertibleDataTransformer` and `Pipeline`. 
It specifically enables the `Diff` transformer to use historical context for accurate inversion. 
I've also refactored the `Pipeline` inverse loop to handle types correctly and update the context iteratively.

### Other Information
Verified with ~8,100 tests. Added new tests for `Diff` in `test_diff.py`. 
Unrelated local failures on Windows (Uber hash, Tkinter) are noted but do not affect this PR's logic.

**Note to reviewers:**
I hope this implementation aligns with the library standards. I'm very open to feedback and would be happy to make any necessary changes or improvements based on your review!