### PR TITLE
[Bugfix] Segmentation fault for darts[all] on macOS arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,10 @@ Repository = "https://github.com/unit8co/darts"
 [project.optional-dependencies]
 # Main feature sets - pip installable with: pip install "darts[torch]"
 torch = [
-    "torch>=2.0.0",
+    # torch-2.11 bundled libomp is not compatible with lightgbm 4.6.0 on macOS arm64
+    # causing segmentation faults.
+    "torch>=2.0.0,<=2.10; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "torch>=2.0.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "pytorch-lightning>=2.0.0,<2.5.3",
     "tensorboardx>=2.1",
     "huggingface-hub>=0.35.3",


### PR DESCRIPTION
Checklist before merging this PR:
- [ ] Mentioned all issues that this PR fixes or addresses.
- [ ] Summarized the updates of this PR under **Summary**.
- [ ] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #.

### Summary
torch (latest, 2.11) bundled libomp is not compatible with lightgbm (latest, 4.6.0) on macOS arm64, causing segmentation faults:
```py
from darts.models import LightGBMModel
from darts.utils.timeseries_generation import linear_timeseries

series = linear_timeseries(length=100)
model = LightGBMModel(12).fit(series)
```

**Related Issue**:
- https://github.com/lightgbm-org/LightGBM/issues/6595


Until it is fixed on either side, I suggest capping the torch version to 2.10.


<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
