### PR TITLE
Fix device mismatch error in TFTModel when moving a trained model to a different device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
-- Fixed a device mismatch error in `TFTModel` when moving a trained model to a different device (e.g., GPU to CPU for ONNX export). `attention_mask` and `relative_index` are now registered as non-persistent buffers so they are properly moved with the model. [#3052](https://github.com/unit8co/darts/issues/3052) by [Wolfhart Feldmeier](https://github.com/trahflow)
+- Fixed a device mismatch error in `TFTModel` when moving a trained model to a different device (e.g., GPU to CPU for ONNX export). `attention_mask` and `relative_index` are now registered as non-persistent buffers so they are properly moved with the model. [#3053](https://github.com/unit8co/darts/pull/3053) by [Wolfhart Feldmeier](https://github.com/trahflow)
 
 ### For developers of the library:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - Added native multi-quantile support for `CatBoostModel` by using CatBoost’s `MultiQuantile` loss for faster training and inference. Set `likelihood="multiquantile"` to enable this feature. [#3032](https://github.com/unit8co/darts/pull/3032) by [Zhihao Dai](https://github.com/daidahao)
 
+**Fixed**
+
+- Fixed a device mismatch error in `TFTModel` when moving a trained model to a different device (e.g., GPU to CPU for ONNX export). `attention_mask` and `relative_index` are now registered as non-persistent buffers so they are properly moved with the model. [#3052](https://github.com/unit8co/darts/issues/3052) by [Wolfhart Feldmeier](https://github.com/trahflow)
+
 ### For developers of the library:
 
 ## [0.43.0](https://github.com/unit8co/darts/tree/0.43.0) (2026-03-23)

--- a/darts/models/forecasting/tft_model.py
+++ b/darts/models/forecasting/tft_model.py
@@ -137,8 +137,8 @@ class _TFTModule(PLForecastingModule):
 
         # initialize last batch size to check if new mask needs to be generated
         self.batch_size_last = -1
-        self.attention_mask = None
-        self.relative_index = None
+        self.register_buffer("attention_mask", None, persistent=False)
+        self.register_buffer("relative_index", None, persistent=False)
 
         # general information on variable name endings:
         # _vsn: VariableSelectionNetwork

--- a/darts/tests/models/forecasting/test_TFT.py
+++ b/darts/tests/models/forecasting/test_TFT.py
@@ -12,6 +12,7 @@ if not TORCH_AVAILABLE:
         f"Torch not available. {__name__} tests will be skipped.",
         allow_module_level=True,
     )
+import torch
 import torch.nn as nn
 from torch.nn import MSELoss
 
@@ -435,3 +436,48 @@ class TestTFTModel:
         preds = model.predict(n=3, series=series)
         assert len(preds) == 3
         assert np.all(np.isfinite(preds.values()))
+
+    def test_relative_index_and_attention_mask_follow_device_transfer(self):
+        """Regression test for https://github.com/unit8co/darts/issues/3052.
+
+        attention_mask and relative_index must be registered buffers so that
+        they are moved when the model is transferred to a different device/dtype.
+        """
+        model = TFTModel(
+            input_chunk_length=4,
+            output_chunk_length=2,
+            add_relative_index=True,
+            n_epochs=1,
+            **tfm_kwargs,
+        )
+        series = tg.linear_timeseries(length=20).astype("float32")
+        model.fit(series, verbose=False)
+
+        inner = model.model
+        # After training, cached tensors should exist
+        assert inner.attention_mask is not None
+        assert inner.relative_index is not None
+        assert inner.relative_index.dtype == torch.float32
+
+        # Verify they are registered buffers (not plain attributes)
+        assert "attention_mask" in dict(inner.named_buffers())
+        assert "relative_index" in dict(inner.named_buffers())
+
+        # Device transfer is tested via dtype changes since CI has no GPU.
+        # .to(dtype) exercises the same _apply codepath as .to(device).
+        # Note: attention_mask is bool and unaffected by dtype changes,
+        # but it would be moved by an actual device transfer.
+
+        # Transfer to float64 — buffers must follow
+        inner.to(torch.float64)
+        assert inner.relative_index.dtype == torch.float64
+
+        # Transfer back to float32 — buffers must follow again
+        inner.to(torch.float32)
+        assert inner.relative_index.dtype == torch.float32
+
+        # Prediction with the same batch_size_last must work after transfer.
+        # Before the fix, this would fail with a device/dtype mismatch because
+        # the cached tensors were plain attributes not moved by .to().
+        preds = model.predict(n=2, series=[series] * inner.batch_size_last)
+        assert len(preds) == inner.batch_size_last


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #3052.

### Summary

Registers TFT's `attention_mask` and `relative_index` as pytorch buffers.
Thereby they're included when `_TFTModule.to()` etc. are called. 
