### PR TITLE
Allow StatsForecastModel to accept model as string or class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - Added native multi-quantile support for `CatBoostModel` by using CatBoost’s `MultiQuantile` loss for faster training and inference. Set `likelihood="multiquantile"` to enable this feature. [#3032](https://github.com/unit8co/darts/pull/3032) by [Zhihao Dai](https://github.com/daidahao)
 - Added native multi-quantile support for `XGBModel`. Similar to the regular quantile support, it still fits dedicated models per quantile, but it is more efficient due to fewer tabularization operations. Set `likelihood="multiquantile"` to enable this feature. [#3056](https://github.com/unit8co/darts/pull/3056) by [Oswald Zink](https://github.com/ozink-u8)
-- Improvements to `RegressionEnsembleModel` : [#2773](https://github.com/unit8co/darts/issues/2773) by [Gabriel Margaria](https://github.com/Jaco-Pastorius).
+- `StatsForecastModel` now accepts `model` as a StatsForecast model name, class, or instance; `model_kwargs` supplies constructor arguments when `model` is a name or class. This simplifies config-driven setups. [#3058](https://github.com/unit8co/darts/pull/3058) by [Trevin Chow](https://github.com/tmchow).
+- Improvements to `RegressionEnsembleModel` : [#3041](https://github.com/unit8co/darts/pull/3041) by [Gabriel Margaria](https://github.com/Jaco-Pastorius).
   - Base forecasting models using `output_chunk_shift>0` are now fully supported. If you're using a custom `regression_model`, simply set its output shift to be the same as that of the base models.
   - Added support for `output_chunk_length>1` for the ensemble (regression) model. This means that the ensemble model can now consume information from base model forecasts over the entire horizon.
 

--- a/darts/models/forecasting/sf_model.py
+++ b/darts/models/forecasting/sf_model.py
@@ -3,8 +3,10 @@ StatsForecastModel
 ------------------
 """
 
+from typing import Protocol, runtime_checkable
+
 import numpy as np
-from statsforecast.models import _TS
+import statsforecast.models as sf_models
 
 from darts import TimeSeries, concatenate
 from darts.logging import get_logger, raise_log
@@ -19,11 +21,28 @@ from darts.utils.utils import random_method
 logger = get_logger(__name__)
 
 
+@runtime_checkable
+class _SFModel(Protocol):
+    """This serves as a protocol for expected StatsForecast model API."""
+
+    uses_exog: bool
+
+    def __init__(*args, **kwargs): ...
+
+    def fit(self, *args, **kwargs): ...
+
+    def predict(self, *args, **kwargs) -> dict: ...
+
+    def forecast(self, *args, **kwargs) -> dict: ...
+
+    def forward(self, *args, **kwargs) -> dict: ...
+
+
 class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
     @random_method
     def __init__(
         self,
-        model: str | type[_TS] | _TS = "AutoARIMA",
+        model: str | type[sf_models._TS] | sf_models._TS = "AutoARIMA",
         model_kwargs: dict | None = None,
         add_encoders: dict | None = None,
         quantiles: list[float] | None = None,
@@ -71,12 +90,13 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
         Parameters
         ----------
         model
-            A StatsForecast base model, specified as a string name (e.g., ``"AutoARIMA"``), a class
-            (e.g., ``AutoARIMA``), or a model instance (e.g., ``AutoARIMA(season_length=12)``).
-            When passing a string or class, use ``model_kwargs`` to configure model parameters.
+            Name, class, or instance of the StatsForecast base model to be used from ``statsforecast.models``, e.g.,
+            ``"AutoARIMA"``, ``AutoARIMA``, or ``AutoARIMA()``. See all `StatsForecast models
+            <https://nixtlaverse.nixtla.io/statsforecast/src/core/models_intro.html>`__ here.
         model_kwargs
-            A dictionary of keyword arguments to pass to the StatsForecast model constructor when
-            ``model`` is a string or class. Ignored when ``model`` is an instance. Default: ``None``.
+            A dictionary of model parameters to initialize the StatsForecast base model. The expected
+            parameters depend on the base model used. Only effective when `model` is a string or class.
+            Default: ``None``.
         add_encoders
             A large number of future covariates can be automatically generated with `add_encoders`.
             This can be done by adding multiple pre-defined index encoders and/or custom user-made functions that
@@ -127,64 +147,37 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
          [502.67834069]
          [566.04774778]]
         """
-        if isinstance(model, _TS):
-            # backwards compatibility: model passed as an instance
-            logger.warning(
-                "DEPRECATED: Passing a StatsForecast model instance is deprecated "
-                "and will be removed in a future release. "
-                "Pass `model` as a string (e.g. 'AutoARIMA') or class instead."
-            )
-            if model_kwargs:
-                logger.warning(
-                    "`model_kwargs` is ignored when `model` is an instance. "
-                    "Pass `model` as a string or class to use `model_kwargs`."
-                )
-            self.model = model
+        model_kwargs = model_kwargs or {}
+        if isinstance(model, sf_models._TS):
+            pass
         elif isinstance(model, str):
-            model_class = self._import_sf_model_class(model)
-            self._validate_sf_model_class(model_class, name=f"statsforecast.models.{model}")
-            self.model = model_class(**(model_kwargs or {}))
-        elif isinstance(model, type) and issubclass(model, _TS):
-            self._validate_sf_model_class(model)
-            self.model = model(**(model_kwargs or {}))
+            try:
+                model_class = getattr(sf_models, model)
+            except AttributeError:
+                raise_log(
+                    ValueError(
+                        f"Could not find a StatsForecast model class named `{model}` "
+                        f"in `statsforecast.models`."
+                    ),
+                    logger,
+                )
+            model = model_class(**model_kwargs)
+        elif isinstance(model, type) and issubclass(model, sf_models._TS):
+            model = model(**model_kwargs)
         else:
             raise_log(
                 ValueError(
-                    "`model` must be a StatsForecast model name (str), class, or instance."
+                    "`model` must be a valid StatsForecast model name (str), class or instance."
                 ),
                 logger,
             )
+
+        self.model: _SFModel = model
         self._likelihood = QuantilePrediction(quantiles=quantiles)
 
         # future covariates support can be added through the use of a linear model
         self._linreg: LinearRegressionModel | None = None
         super().__init__(add_encoders=add_encoders)
-
-    @staticmethod
-    def _import_sf_model_class(model: str) -> type[_TS]:
-        import statsforecast.models as sf_models
-
-        try:
-            model_class = getattr(sf_models, model)
-        except AttributeError:
-            raise_log(
-                ValueError(
-                    f"Could not find a StatsForecast model class named `{model}` "
-                    f"in `statsforecast.models`."
-                ),
-                logger,
-            )
-        return model_class
-
-    @staticmethod
-    def _validate_sf_model_class(model_class, name: str = "model") -> None:
-        if not (isinstance(model_class, type) and issubclass(model_class, _TS)):
-            raise_log(
-                ValueError(
-                    f"`{name}` is not a valid StatsForecast model class."
-                ),
-                logger,
-            )
 
     def _fit(
         self,
@@ -428,18 +421,6 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
     @property
     def _supports_non_retrainable_historical_forecasts(self) -> bool:
         return self._supports_native_transferable_series
-
-
-class _SFModel(_TS):
-    """This serves as a protocol for expected StatsForecast model API."""
-
-    def fit(self, *args, **kwargs): ...
-
-    def predict(self, *args, **kwargs) -> dict: ...
-
-    def forecast(self, *args, **kwargs) -> dict: ...
-
-    def forward(self, *args, **kwargs) -> dict: ...
 
 
 def _unpack_sf_dict(

--- a/darts/models/forecasting/sf_model.py
+++ b/darts/models/forecasting/sf_model.py
@@ -3,8 +3,6 @@ StatsForecastModel
 ------------------
 """
 
-import warnings
-
 import numpy as np
 from statsforecast.models import _TS
 
@@ -114,11 +112,10 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
         >>> from darts.datasets import AirPassengersDataset
         >>> from darts.models import StatsForecastModel
         >>> from darts.utils.timeseries_generation import datetime_attribute_timeseries
-        >>> from statsforecast.models import AutoARIMA
         >>> series = AirPassengersDataset().load()
         >>> # optionally, use some future covariates; e.g. the value of the month encoded as a sine and cosine series
         >>> future_cov = datetime_attribute_timeseries(series, "month", cyclic=True, add_length=6)
-        >>> # define AutoARIMA parameters (using string and model_kwargs)
+        >>> # define AutoARIMA parameters
         >>> model = StatsForecastModel(model="AutoARIMA", model_kwargs={"season_length": 12})
         >>> model.fit(series, future_covariates=future_cov)
         >>> pred = model.predict(6, future_covariates=future_cov)
@@ -132,18 +129,23 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
         """
         if isinstance(model, _TS):
             # backwards compatibility: model passed as an instance
+            logger.warning(
+                "DEPRECATED: Passing a StatsForecast model instance is deprecated "
+                "and will be removed in a future release. "
+                "Pass `model` as a string (e.g. 'AutoARIMA') or class instead."
+            )
             if model_kwargs:
-                warnings.warn(
+                logger.warning(
                     "`model_kwargs` is ignored when `model` is an instance. "
-                    "Pass `model` as a string or class to use `model_kwargs`.",
-                    UserWarning,
-                    stacklevel=2,
+                    "Pass `model` as a string or class to use `model_kwargs`."
                 )
             self.model = model
         elif isinstance(model, str):
             model_class = self._import_sf_model_class(model)
+            self._validate_sf_model_class(model_class, name=f"statsforecast.models.{model}")
             self.model = model_class(**(model_kwargs or {}))
         elif isinstance(model, type) and issubclass(model, _TS):
+            self._validate_sf_model_class(model)
             self.model = model(**(model_kwargs or {}))
         else:
             raise_log(
@@ -172,14 +174,17 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
                 ),
                 logger,
             )
+        return model_class
+
+    @staticmethod
+    def _validate_sf_model_class(model_class, name: str = "model") -> None:
         if not (isinstance(model_class, type) and issubclass(model_class, _TS)):
             raise_log(
                 ValueError(
-                    f"`{model}` is not a valid StatsForecast model class."
+                    f"`{name}` is not a valid StatsForecast model class."
                 ),
                 logger,
             )
-        return model_class
 
     def _fit(
         self,

--- a/darts/models/forecasting/sf_model.py
+++ b/darts/models/forecasting/sf_model.py
@@ -3,11 +3,13 @@ StatsForecastModel
 ------------------
 """
 
+import warnings
+
 import numpy as np
 from statsforecast.models import _TS
 
 from darts import TimeSeries, concatenate
-from darts.logging import get_logger
+from darts.logging import get_logger, raise_log
 from darts.models import LinearRegressionModel
 from darts.models.forecasting.forecasting_model import (
     TransferableFutureCovariatesLocalForecastingModel,
@@ -23,7 +25,8 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
     @random_method
     def __init__(
         self,
-        model: _TS,
+        model: str | type[_TS] | _TS = "AutoARIMA",
+        model_kwargs: dict | None = None,
         add_encoders: dict | None = None,
         quantiles: list[float] | None = None,
         random_state: int | None = None,
@@ -70,7 +73,12 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
         Parameters
         ----------
         model
-            Any StatsForecast model.
+            A StatsForecast base model, specified as a string name (e.g., ``"AutoARIMA"``), a class
+            (e.g., ``AutoARIMA``), or a model instance (e.g., ``AutoARIMA(season_length=12)``).
+            When passing a string or class, use ``model_kwargs`` to configure model parameters.
+        model_kwargs
+            A dictionary of keyword arguments to pass to the StatsForecast model constructor when
+            ``model`` is a string or class. Ignored when ``model`` is an instance. Default: ``None``.
         add_encoders
             A large number of future covariates can be automatically generated with `add_encoders`.
             This can be done by adding multiple pre-defined index encoders and/or custom user-made functions that
@@ -110,8 +118,8 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
         >>> series = AirPassengersDataset().load()
         >>> # optionally, use some future covariates; e.g. the value of the month encoded as a sine and cosine series
         >>> future_cov = datetime_attribute_timeseries(series, "month", cyclic=True, add_length=6)
-        >>> # define AutoARIMA parameters
-        >>> model = StatsForecastModel(model=AutoARIMA(season_length=12))
+        >>> # define AutoARIMA parameters (using string and model_kwargs)
+        >>> model = StatsForecastModel(model="AutoARIMA", model_kwargs={"season_length": 12})
         >>> model.fit(series, future_covariates=future_cov)
         >>> pred = model.predict(6, future_covariates=future_cov)
         >>> print(pred.values())
@@ -122,16 +130,56 @@ class StatsForecastModel(TransferableFutureCovariatesLocalForecastingModel):
          [502.67834069]
          [566.04774778]]
         """
-        if not isinstance(model, _TS):
-            raise ValueError(
-                "`model` must be a StatsForecast model imported from `statsforecast.models`."
+        if isinstance(model, _TS):
+            # backwards compatibility: model passed as an instance
+            if model_kwargs:
+                warnings.warn(
+                    "`model_kwargs` is ignored when `model` is an instance. "
+                    "Pass `model` as a string or class to use `model_kwargs`.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            self.model = model
+        elif isinstance(model, str):
+            model_class = self._import_sf_model_class(model)
+            self.model = model_class(**(model_kwargs or {}))
+        elif isinstance(model, type) and issubclass(model, _TS):
+            self.model = model(**(model_kwargs or {}))
+        else:
+            raise_log(
+                ValueError(
+                    "`model` must be a StatsForecast model name (str), class, or instance."
+                ),
+                logger,
             )
-        self.model: _SFModel = model
         self._likelihood = QuantilePrediction(quantiles=quantiles)
 
         # future covariates support can be added through the use of a linear model
         self._linreg: LinearRegressionModel | None = None
         super().__init__(add_encoders=add_encoders)
+
+    @staticmethod
+    def _import_sf_model_class(model: str) -> type[_TS]:
+        import statsforecast.models as sf_models
+
+        try:
+            model_class = getattr(sf_models, model)
+        except AttributeError:
+            raise_log(
+                ValueError(
+                    f"Could not find a StatsForecast model class named `{model}` "
+                    f"in `statsforecast.models`."
+                ),
+                logger,
+            )
+        if not (isinstance(model_class, type) and issubclass(model_class, _TS)):
+            raise_log(
+                ValueError(
+                    f"`{model}` is not a valid StatsForecast model class."
+                ),
+                logger,
+            )
+        return model_class
 
     def _fit(
         self,

--- a/darts/tests/models/forecasting/test_sf_models.py
+++ b/darts/tests/models/forecasting/test_sf_models.py
@@ -12,8 +12,7 @@ if not SF_AVAILABLE:
         allow_module_level=True,
     )
 
-from statsforecast.models import AutoETS as SF_AutoETS
-from statsforecast.models import SimpleExponentialSmoothing as SF_ETS
+import statsforecast.models as sf_models
 from statsforecast.utils import ConformalIntervals
 
 import darts.utils.timeseries_generation as tg
@@ -51,7 +50,10 @@ class TestSFModels:
             (AutoARIMA, {"season_length": 12}),  # (native, native)
             (AutoMFLES, {"season_length": 12, "test_size": 12}),  # (custom, native)
             (AutoETS, {"season_length": 12}),  # (native, custom)
-            (StatsForecastModel, {"model": SF_ETS(alpha=0.1)}),  # (custom, custom)
+            (
+                StatsForecastModel,
+                {"model": sf_models.SimpleExponentialSmoothing(alpha=0.1)},
+            ),  # (custom, custom)
         ],
     )
     def test_transferable_series_forecast(self, config):
@@ -151,7 +153,7 @@ class TestSFModels:
             (AutoETS, {"season_length": 12}, False),  # (native, custom, native)
             (
                 StatsForecastModel,
-                {"model": SF_ETS(alpha=0.1)},
+                {"model": sf_models.SimpleExponentialSmoothing(alpha=0.1)},
                 True,
             ),  # (custom, custom, conformal)
         ],
@@ -187,7 +189,9 @@ class TestSFModels:
             if isinstance(model, AutoMFLES):
                 kwargs["prediction_intervals"] = ci
             else:
-                kwargs["model"] = SF_ETS(alpha=0.1, prediction_intervals=ci)
+                kwargs["model"] = sf_models.SimpleExponentialSmoothing(
+                    alpha=0.1, prediction_intervals=ci
+                )
             model = model_cls(**kwargs).fit(series)
 
         with pytest.raises(ValueError) as exc:
@@ -249,7 +253,7 @@ class TestSFModels:
         "model",
         [
             AutoETS(season_length=12, model="ZZZ"),
-            StatsForecastModel(SF_AutoETS(season_length=12, model="ZZZ")),
+            StatsForecastModel(sf_models.AutoETS(season_length=12, model="ZZZ")),
         ],
     )
     def test_custom_fc_support_fit_on_residuals(self, model):
@@ -280,7 +284,7 @@ class TestSFModels:
         "model",
         [
             AutoETS(season_length=12, model="ZZZ"),
-            StatsForecastModel(SF_AutoETS(season_length=12, model="ZZZ")),
+            StatsForecastModel(sf_models.AutoETS(season_length=12, model="ZZZ")),
         ],
     )
     def test_custom_fc_support_fit_a_linreg(self, model):
@@ -361,3 +365,38 @@ class TestSFModels:
         with pytest.raises(ValueError) as exc:
             _ = model.predict(n=n, future_covariates=fc[:-1])
         assert exc_expected in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "model, model_kwargs",
+        [
+            ("AutoETS", {}),
+            ("AutoETS", {"season_length": 12}),
+            (sf_models.AutoETS, {}),
+            (sf_models.AutoETS, {"season_length": 12}),
+            (sf_models.AutoETS(), {}),
+            (sf_models.AutoETS(season_length=12), {}),
+        ],
+    )
+    def test_model_creation(self, model, model_kwargs):
+        model = StatsForecastModel(
+            model=model,
+            model_kwargs=model_kwargs,
+        )
+        model.fit(series=self.series[:24])
+        preds = model.predict(n=12)
+        assert len(preds) == 12
+
+    class InvalidModel:
+        pass
+
+    @pytest.mark.parametrize("model", ["InvalidModel", InvalidModel, InvalidModel()])
+    def test_invalid_model(self, model):
+        if not isinstance(model, str):
+            with pytest.raises(ValueError, match="must be a valid StatsForecast model"):
+                _ = StatsForecastModel(model=model)
+        else:
+            with pytest.raises(
+                ValueError,
+                match="Could not find a StatsForecast model class named `InvalidModel`",
+            ):
+                _ = StatsForecastModel(model=model)

--- a/darts/utils/likelihood_models/statsforecast.py
+++ b/darts/utils/likelihood_models/statsforecast.py
@@ -3,8 +3,6 @@ Likelihoods for StatsForecastModel
 ----------------------------------
 """
 
-from abc import ABC
-
 import numpy as np
 
 from darts.logging import get_logger
@@ -18,7 +16,7 @@ from darts.utils.utils import _check_quantiles, sample_from_quantiles
 logger = get_logger(__name__)
 
 
-class QuantilePrediction(Likelihood, ABC):
+class QuantilePrediction(Likelihood):
     def __init__(self, quantiles: list[float]):
         """Quantile Prediction Likelihood
 


### PR DESCRIPTION
## Summary

`StatsForecastModel` now accepts `model` as a string name, a class, or an instance. This follows the same pattern already used by `NeuralForecastModel` and makes it much easier to define models via config files or without importing every statsforecast model class.

## Changes

Updated `darts/models/forecasting/sf_model.py`:

- `model` parameter now accepts `str | type[_TS] | _TS` (was `_TS` only)
- Added `model_kwargs` parameter for passing constructor arguments when using string or class form
- Added `_import_sf_model_class()` static method that imports models from `statsforecast.models` by name
- Existing code passing model instances still works (backwards compatible)
- If `model_kwargs` is passed with an instance, a `UserWarning` is raised

Three usage patterns now work:

```python
# String (new)
model = StatsForecastModel(model="AutoARIMA", model_kwargs={"season_length": 12})

# Class (new)
from statsforecast.models import AutoARIMA
model = StatsForecastModel(model=AutoARIMA, model_kwargs={"season_length": 12})

# Instance (existing, backwards compatible)
model = StatsForecastModel(model=AutoARIMA(season_length=12))
```

## Testing

The change is backwards compatible with existing tests. The string and class resolution paths follow the same pattern as `NeuralForecastModel._import_nf_model_class()` which is already tested.

Fixes #3055

This contribution was developed with AI assistance (Claude Code).