### PR TITLE
Feature: Custom encoders returning multiple components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - 🚀🚀 Added new forecasting model `PatchTSTFMModel` : IBM's pre-trained ~260M-parameter foundational model for zero-shot forecasting. It supports univariate, multivariate, and multiple time series forecasting without training and can output deterministic or probabilistic forecasts. [#3120](https://github.com/unit8co/darts/pull/3120) by [Dennis Bader](https://github.com/dennisbader).
 - Added `use_longer_projection_head` to `TimesFM2p5Model` to enable longer non-autoregressive prediction horizons (up to 1024 steps for `output_chunk_length + output_chunk_shift`). [#3121](https://github.com/unit8co/darts/pull/3121) by [Zhihao Dai](https://github.com/daidahao).
-- Added support in `add_encoders` for custom encoders returning multiple components. [#3069](https://github.com/unit8co/darts/pull/3069) by [Moritz Waldleben](https://github.com/mwaldleben).
+- Custom encoders now support functions that return multiple components. Simply pass such a function via the `"custom"` encoder key in the `add_encoders` model input parameter. [#3069](https://github.com/unit8co/darts/pull/3069) by [Moritz Waldleben](https://github.com/mwaldleben).
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - 🚀🚀 Added new forecasting model `PatchTSTFMModel` : IBM's pre-trained ~260M-parameter foundational model for zero-shot forecasting. It supports univariate, multivariate, and multiple time series forecasting without training and can output deterministic or probabilistic forecasts. [#3120](https://github.com/unit8co/darts/pull/3120) by [Dennis Bader](https://github.com/dennisbader).
 - Added `use_longer_projection_head` to `TimesFM2p5Model` to enable longer non-autoregressive prediction horizons (up to 1024 steps for `output_chunk_length + output_chunk_shift`). [#3121](https://github.com/unit8co/darts/pull/3121) by [Zhihao Dai](https://github.com/daidahao).
+- Added support in `add_encoders` for custom encoders returning multiple components. [#3069](https://github.com/unit8co/darts/pull/3069) by [Moritz Waldleben](https://github.com/mwaldleben).
 
 **Fixed**
 

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -156,6 +156,7 @@ TorchForecastingModel (this is only meant to illustrate many features at once).
 ..
 """
 
+import contextlib
 import copy
 from collections.abc import Callable, Sequence
 
@@ -741,28 +742,24 @@ class CallableIndexEncoder(SingleEncoder):
         """Test the callable with sample `pd.DatetimeIndex` and `pd.RangeIndex` to determine
         the number of output components.
         """
-        n_components = 1
-        detected = False
+        n_components = None
 
         for idx in (
             pd.date_range("2000-01-01", periods=2, freq="D"),
             pd.RangeIndex(2),
         ):
-            try:
+            with contextlib.suppress(Exception):
                 encoded = np.asarray(attribute(idx))
                 n_components = 1 if encoded.ndim == 1 else encoded.shape[1]
-                detected = True
                 break
-            except Exception:
-                continue
 
-        if not detected:
+        if n_components is None:
             raise_log(
                 ValueError(
                     "Encountered invalid encoder argument for encoder `callable`. "
                     "Attribute must be a callable that accepts a `pd.DatetimeIndex` "
                     "or `pd.RangeIndex` and returns an array-like of shape "
-                    "`(len(index),)` or `(len(index), n)`."
+                    "`(len(index),)` or `(len(index), n_output_components)`."
                 ),
                 logger,
             )
@@ -774,7 +771,7 @@ class CallableIndexEncoder(SingleEncoder):
         """Apply the user-defined callable to encode the index."""
         super()._encode(index, target_end, dtype)
 
-        values = np.array(self.attribute(index)).astype(np.dtype(dtype))
+        values = np.array(self.attribute(index), dtype=dtype)
         components = [
             self.base_component_name + ("custom" if i == 0 else f"custom_{i}")
             for i in range(self._n_components)
@@ -822,10 +819,15 @@ class PastCallableIndexEncoder(CallableIndexEncoder):
         ----------
         attribute
             A callable that takes an index `index` of type `(pd.DatetimeIndex, pd.RangeIndex)` as input
-            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n)`.
+            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n_output_components)`.
             An example for a correct `attribute` for `index` of type pd.DatetimeIndex:
-            ``attribute = lambda index: (index.year - 1950) / 50``. And for pd.RangeIndex:
-            ``attribute = lambda index: (index - 1950) / 50``
+
+            - ``attribute = lambda index: (index.year - 1950) / 50`` or
+            - ``attribute = lambda index: np.stack([index.year, index.month], axis=1)``,
+
+            And for pd.RangeIndex:
+
+            - ``attribute = lambda index: (index - 1950) / 50``
         input_chunk_length
             Optionally, the number of input target time steps per chunk. Only required for
             :class:`TorchForecastingModel`, and :class:`SKLearnModel`.
@@ -869,10 +871,15 @@ class FutureCallableIndexEncoder(CallableIndexEncoder):
         ----------
         attribute
             A callable that takes an index `index` of type `(pd.DatetimeIndex, pd.RangeIndex)` as input
-            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n)`.
+            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n_output_components)`.
             An example for a correct `attribute` for `index` of type pd.DatetimeIndex:
-            ``attribute = lambda index: (index.year - 1950) / 50``. And for pd.RangeIndex:
-            ``attribute = lambda index: (index - 1950) / 50``
+
+            - ``attribute = lambda index: (index.year - 1950) / 50`` or
+            - ``attribute = lambda index: np.stack([index.year, index.month], axis=1)``,
+
+            And for pd.RangeIndex:
+
+            - ``attribute = lambda index: (index - 1950) / 50``
         input_chunk_length
             Optionally, the number of input target time steps per chunk. Only required for
             :class:`TorchForecastingModel`, and :class:`SKLearnModel`.

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -774,7 +774,7 @@ class CallableIndexEncoder(SingleEncoder):
         values = np.array(self.attribute(index), dtype=dtype)
         components = [
             self.base_component_name + ("custom" if i == 0 else f"custom_{i}")
-            for i in range(self._n_components)
+            for i in range(self.encoding_n_components)
         ]
         return TimeSeries(
             times=index,
@@ -786,7 +786,7 @@ class CallableIndexEncoder(SingleEncoder):
     @property
     def accept_transformer(self) -> list[bool]:
         """`CallableIndexEncoder` accepts transformations."""
-        return [True] * self._n_components
+        return [True] * self.encoding_n_components
 
     @property
     def requires_fit(self) -> bool:

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -173,7 +173,7 @@ from darts.dataprocessing.encoders.encoder_base import (
     _EncoderMethod,
 )
 from darts.dataprocessing.transformers import FittableDataTransformer
-from darts.logging import get_logger, raise_if, raise_if_not
+from darts.logging import get_logger, raise_log
 from darts.timeseries import DIMS
 from darts.typing import TimeIndex, TimeSeriesLike, TimeZone
 from darts.utils.timeseries_generation import datetime_attribute_timeseries
@@ -548,12 +548,14 @@ class IntegerIndexEncoder(SingleEncoder):
             Currently only 'relative' is supported. The generated encoded values will range from (-inf, inf) and the
             target series end time will be used as a reference to evaluate the relative index positions.
         """
-        raise_if_not(
-            isinstance(attribute, str) and attribute in INTEGER_INDEX_ATTRIBUTES,
-            f"Encountered invalid encoder argument `{attribute}` for encoder `position`. "
-            f'Attribute must be `"relative"`.',
-            logger,
-        )
+        if not (isinstance(attribute, str) and attribute in INTEGER_INDEX_ATTRIBUTES):
+            raise_log(
+                ValueError(
+                    f"Encountered invalid encoder argument `{attribute}` for encoder `position`. "
+                    f'Attribute must be `"relative"`.'
+                ),
+                logger,
+            )
         super().__init__(index_generator)
 
         self.attribute = attribute
@@ -713,19 +715,21 @@ class CallableIndexEncoder(SingleEncoder):
             `generate_inference_idx()`. Used to generate the index for encoders.
         attribute
             A callable that takes an index `index` of type `(pd.DatetimeIndex, pd.RangeIndex)` as input
-            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n)`.
+            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n_output_components)`.
             Examples for a correct `attribute` for `index` of type `pd.DatetimeIndex`:
             ``attribute = lambda index: (index.year - 1950) / 50``
-            ``attribute = lambda index: np.stack([index.year, index.year - 1], axis=1)``
+            ``attribute = lambda index: np.stack([index.year, index.month], axis=1)``
             And for `pd.RangeIndex`:
             ``attribute = lambda index: (index - 1950) / 50``
         """
-        raise_if_not(
-            callable(attribute),
-            f"Encountered invalid encoder argument `{attribute}` for encoder `callable`. "
-            f"Attribute must be a callable that returns a `np.ndarray`.",
-            logger,
-        )
+        if not callable(attribute):
+            raise_log(
+                ValueError(
+                    f"Encountered invalid encoder argument `{attribute}` for encoder `callable`. "
+                    f"Attribute must be a callable that returns a `np.ndarray`."
+                ),
+                logger,
+            )
 
         super().__init__(index_generator)
 
@@ -752,15 +756,16 @@ class CallableIndexEncoder(SingleEncoder):
             except Exception:
                 continue
 
-        raise_if_not(
-            detected,
-            "Encountered invalid encoder argument for encoder `callable`. "
-            "Attribute must be a callable that accepts a `pd.DatetimeIndex` "
-            "or `pd.RangeIndex` and returns an array-like of shape "
-            "`(len(index),)` or `(len(index), n)`.",
-            logger,
-        )
-
+        if not detected:
+            raise_log(
+                ValueError(
+                    "Encountered invalid encoder argument for encoder `callable`. "
+                    "Attribute must be a callable that accepts a `pd.DatetimeIndex` "
+                    "or `pd.RangeIndex` and returns an array-like of shape "
+                    "`(len(index),)` or `(len(index), n)`."
+                ),
+                logger,
+            )
         return n_components
 
     def _encode(
@@ -1113,12 +1118,15 @@ class SequentialEncoder(Encoder):
             If input {x}_covariates is None and no {x}_encoders are given, will return `None`
             for the {x}_covariates.
         """
-        raise_if(
-            not self.fit_called and self.requires_fit,
-            f"`{self.__class__.__name__}` contains encoders or transformers which must be trained before inference. "
-            "Call method `encode_train()` before `encode_inference()`.",
-            logger=logger,
-        )
+        if not self.fit_called and self.requires_fit:
+            raise_log(
+                ValueError(
+                    f"`{self.__class__.__name__}` contains encoders or transformers which must "
+                    f"be trained before inference. Call method `encode_train()` before "
+                    f"`encode_inference()`."
+                ),
+                logger,
+            )
         return self._launch_encoder(
             target=target,
             past_covariates=past_covariates,
@@ -1473,12 +1481,14 @@ class SequentialEncoder(Encoder):
             for enc in params
             if enc not in ENCODER_KEYS + TZ_KEYS + TRANSFORMER_KEYS
         ]
-        raise_if(
-            len(invalid_encoders) > 0,
-            f"Encountered invalid encoder types `{invalid_encoders}` in `add_encoders` parameter at model "
-            f"creation. Supported encoder types are: `{ENCODER_KEYS + TRANSFORMER_KEYS}`.",
-            logger,
-        )
+        if len(invalid_encoders) > 0:
+            raise_log(
+                ValueError(
+                    f"Encountered invalid encoder types `{invalid_encoders}` in `add_encoders` parameter at model "
+                    f"creation. Supported encoder types are: `{ENCODER_KEYS + TRANSFORMER_KEYS}`."
+                ),
+                logger,
+            )
 
         encoders = {enc: params[enc] for enc in ENCODER_KEYS if params.get(enc, None)}
 
@@ -1489,12 +1499,14 @@ class SequentialEncoder(Encoder):
                 t_type for t_type in t_types.keys() if t_type not in VALID_TIME_PARAMS
             ]
 
-        raise_if(
-            len(invalid_time_params) > 0,
-            f"Encountered invalid temporal types `{invalid_time_params}` in `add_encoders` parameter at model "
-            f"creation. Supported temporal types are: `{VALID_TIME_PARAMS}`.",
-            logger,
-        )
+        if len(invalid_time_params) > 0:
+            raise_log(
+                ValueError(
+                    f"Encountered invalid temporal types `{invalid_time_params}` in `add_encoders` parameter at model "
+                    f"creation. Supported temporal types are: `{VALID_TIME_PARAMS}`."
+                ),
+                logger,
+            )
 
         # check that encoders are not lambda functions (not pickable)
         lambda_func_encoders = set()
@@ -1502,13 +1514,15 @@ class SequentialEncoder(Encoder):
         past_encoders, future_encoders = list(), list()
         for enc, enc_params in encoders.items():
             for enc_time, enc_attr in enc_params.items():
-                raise_if_not(
-                    isinstance(enc_attr, VALID_ENCODER_DTYPES),
-                    f"Encountered value `{enc_attr}` of invalid type `{type(enc_attr)}` for encoder "
-                    f"`{enc}` in `add_encoders` at model creation. Supported data types are: "
-                    f"`{VALID_ENCODER_DTYPES}`.",
-                    logger,
-                )
+                if not isinstance(enc_attr, VALID_ENCODER_DTYPES):
+                    raise_log(
+                        ValueError(
+                            f"Encountered value `{enc_attr}` of invalid type `{type(enc_attr)}` for encoder "
+                            f"`{enc}` in `add_encoders` at model creation. Supported data types are: "
+                            f"`{VALID_ENCODER_DTYPES}`."
+                        ),
+                        logger,
+                    )
                 attrs = [enc_attr] if isinstance(enc_attr, str) else enc_attr
                 for attr in attrs:
                     encoder_id = "_".join([enc, enc_time])
@@ -1520,14 +1534,16 @@ class SequentialEncoder(Encoder):
                     if isinstance(attr, Callable) and attr.__name__ == "<lambda>":
                         lambda_func_encoders.add(enc)
 
-        raise_if(
-            len(lambda_func_encoders) > 0,
-            f"Encountered lambda function in the following `add_encoders` entries : {lambda_func_encoders} "
-            f"at model creation. "
-            f"In order to prevent issues when saving the model, these encoders must be converted to "
-            f"named functions.",
-            logger,
-        )
+        if len(lambda_func_encoders) > 0:
+            raise_log(
+                ValueError(
+                    f"Encountered lambda function in the following `add_encoders` entries : {lambda_func_encoders} "
+                    f"at model creation. "
+                    f"In order to prevent issues when saving the model, these encoders must be converted to "
+                    f"named functions."
+                ),
+                logger,
+            )
 
         for temp_enc, takes_temp, temp in [
             (past_encoders, self.takes_past_covariates, "past"),
@@ -1562,13 +1578,15 @@ class SequentialEncoder(Encoder):
         if transformer is None:
             return None, [], []
 
-        raise_if_not(
-            isinstance(transformer, VALID_TRANSFORMER_DTYPES),
-            f"Encountered `{TRANSFORMER_KEYS[0]}` of invalid type `{type(transformer)}` "
-            f"in `add_encoders` at model creation. Transformer must be an instance of "
-            f"`{VALID_TRANSFORMER_DTYPES}`.",
-            logger,
-        )
+        if not isinstance(transformer, VALID_TRANSFORMER_DTYPES):
+            raise_log(
+                ValueError(
+                    f"Encountered `{TRANSFORMER_KEYS[0]}` of invalid type `{type(transformer)}` "
+                    f"in `add_encoders` at model creation. Transformer must be an instance of "
+                    f"`{VALID_TRANSFORMER_DTYPES}`."
+                ),
+                logger,
+            )
 
         transform_past_mask = [
             transform

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -713,7 +713,7 @@ class CallableIndexEncoder(SingleEncoder):
             `generate_inference_idx()`. Used to generate the index for encoders.
         attribute
             A callable that takes an index `index` of type `(pd.DatetimeIndex, pd.RangeIndex)` as input
-            and returns a np.ndarray of shape `(len(index),)`.
+            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n)`.
             An example for a correct `attribute` for `index` of type pd.DatetimeIndex:
             ``attribute = lambda index: (index.year - 1950) / 50``. And for pd.RangeIndex:
             ``attribute = lambda index: (index - 1950) / 50``
@@ -728,16 +728,31 @@ class CallableIndexEncoder(SingleEncoder):
         super().__init__(index_generator)
 
         self.attribute = attribute
-        self._n_components: int = 1
+        self._n_components = self._detect_n_components(attribute)
+
+    @staticmethod
+    def _detect_n_components(attribute: Callable) -> int:
+        """Test the callable with sample `pd.DatetimeIndex` and `pd.RangeIndex` to determine
+        the number of output components.
+        """
+        for idx in [
+            pd.date_range("2000-01-01", periods=2, freq="D"),
+            pd.RangeIndex(2),
+        ]:
+            try:
+                encoded = np.array(attribute(idx))
+                return 1 if encoded.ndim == 1 else encoded.shape[1]
+            except Exception:
+                continue
+        return 1
 
     def _encode(
         self, index: TimeIndex, target_end: pd.Timestamp, dtype: np.dtype
     ) -> TimeSeries:
-        """Apply the user-defined callable to encode the index"""
+        """Apply the user-defined callable to encode the index."""
         super()._encode(index, target_end, dtype)
 
         values = np.array(self.attribute(index)).astype(np.dtype(dtype))
-        self._n_components = 1 if values.ndim == 1 else values.shape[1]
         components = [
             self.base_component_name + ("custom" if i == 0 else f"custom_{i}")
             for i in range(self._n_components)
@@ -785,7 +800,7 @@ class PastCallableIndexEncoder(CallableIndexEncoder):
         ----------
         attribute
             A callable that takes an index `index` of type `(pd.DatetimeIndex, pd.RangeIndex)` as input
-            and returns a np.ndarray of shape `(len(index),)`.
+            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n)`.
             An example for a correct `attribute` for `index` of type pd.DatetimeIndex:
             ``attribute = lambda index: (index.year - 1950) / 50``. And for pd.RangeIndex:
             ``attribute = lambda index: (index - 1950) / 50``
@@ -832,7 +847,7 @@ class FutureCallableIndexEncoder(CallableIndexEncoder):
         ----------
         attribute
             A callable that takes an index `index` of type `(pd.DatetimeIndex, pd.RangeIndex)` as input
-            and returns a np.ndarray of shape `(len(index),)`.
+            and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n)`.
             An example for a correct `attribute` for `index` of type pd.DatetimeIndex:
             ``attribute = lambda index: (index.year - 1950) / 50``. And for pd.RangeIndex:
             ``attribute = lambda index: (index - 1950) / 50``

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -728,6 +728,7 @@ class CallableIndexEncoder(SingleEncoder):
         super().__init__(index_generator)
 
         self.attribute = attribute
+        self._n_components: int = 1
 
     def _encode(
         self, index: TimeIndex, target_end: pd.Timestamp, dtype: np.dtype
@@ -735,17 +736,23 @@ class CallableIndexEncoder(SingleEncoder):
         """Apply the user-defined callable to encode the index"""
         super()._encode(index, target_end, dtype)
 
+        values = np.array(self.attribute(index)).astype(np.dtype(dtype))
+        self._n_components = 1 if values.ndim == 1 else values.shape[1]
+        components = [
+            self.base_component_name + ("custom" if i == 0 else f"custom_{i}")
+            for i in range(self._n_components)
+        ]
         return TimeSeries(
             times=index,
-            values=self.attribute(index).astype(np.dtype(dtype)),
-            components=[self.base_component_name + "custom"],
+            values=values,
+            components=components,
             copy=False,
         )
 
     @property
     def accept_transformer(self) -> list[bool]:
         """`CallableIndexEncoder` accepts transformations."""
-        return [True]
+        return [True] * self._n_components
 
     @property
     def requires_fit(self) -> bool:
@@ -757,7 +764,7 @@ class CallableIndexEncoder(SingleEncoder):
 
     @property
     def encoding_n_components(self) -> int:
-        return 1
+        return self._n_components
 
 
 class PastCallableIndexEncoder(CallableIndexEncoder):

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -735,16 +735,31 @@ class CallableIndexEncoder(SingleEncoder):
         """Test the callable with sample `pd.DatetimeIndex` and `pd.RangeIndex` to determine
         the number of output components.
         """
-        for idx in [
+        n_components = 1
+        detected = False
+
+        for idx in (
             pd.date_range("2000-01-01", periods=2, freq="D"),
             pd.RangeIndex(2),
-        ]:
+        ):
             try:
-                encoded = np.array(attribute(idx))
-                return 1 if encoded.ndim == 1 else encoded.shape[1]
+                encoded = np.asarray(attribute(idx))
+                n_components = 1 if encoded.ndim == 1 else encoded.shape[1]
+                detected = True
+                break
             except Exception:
                 continue
-        return 1
+
+        raise_if_not(
+            detected,
+            "Encountered invalid encoder argument for encoder `callable`. "
+            "Attribute must be a callable that accepts a `pd.DatetimeIndex` "
+            "or `pd.RangeIndex` and returns an array-like of shape "
+            "`(len(index),)` or `(len(index), n)`.",
+            logger,
+        )
+
+        return n_components
 
     def _encode(
         self, index: TimeIndex, target_end: pd.Timestamp, dtype: np.dtype

--- a/darts/dataprocessing/encoders/encoders.py
+++ b/darts/dataprocessing/encoders/encoders.py
@@ -714,8 +714,10 @@ class CallableIndexEncoder(SingleEncoder):
         attribute
             A callable that takes an index `index` of type `(pd.DatetimeIndex, pd.RangeIndex)` as input
             and returns a `np.ndarray` of shape `(len(index),)` or `(len(index), n)`.
-            An example for a correct `attribute` for `index` of type pd.DatetimeIndex:
-            ``attribute = lambda index: (index.year - 1950) / 50``. And for pd.RangeIndex:
+            Examples for a correct `attribute` for `index` of type `pd.DatetimeIndex`:
+            ``attribute = lambda index: (index.year - 1950) / 50``
+            ``attribute = lambda index: np.stack([index.year, index.year - 1], axis=1)``
+            And for `pd.RangeIndex`:
             ``attribute = lambda index: (index - 1950) / 50``
         """
         raise_if_not(

--- a/darts/tests/dataprocessing/encoders/test_encoders.py
+++ b/darts/tests/dataprocessing/encoders/test_encoders.py
@@ -970,9 +970,11 @@ class TestEncoder:
         def invalid_callable(index):
             return index.year[0]
 
-        # ===> test callable index encoder with multi component ouput <===
+        # ===> test callable index encoder with multi component output <===
         # test invalid callable at encoder creation
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Attribute must be a callable that accepts"
+        ):
             _ = PastCallableIndexEncoder(
                 attribute=invalid_callable,
                 input_chunk_length=input_chunk_length,

--- a/darts/tests/dataprocessing/encoders/test_encoders.py
+++ b/darts/tests/dataprocessing/encoders/test_encoders.py
@@ -895,6 +895,16 @@ class TestEncoder:
             and (fc2.univariate_values() == np.arange(3, 10)).all()
         )
 
+        encoder_params = {"position": {"past": ["invalid"]}}
+        with pytest.raises(ValueError, match='Attribute must be `"relative"`.'):
+            _ = SequentialEncoder(
+                add_encoders=encoder_params,
+                input_chunk_length=input_chunk_length,
+                output_chunk_length=output_chunk_length,
+                takes_past_covariates=True,
+                takes_future_covariates=True,
+            )
+
     def test_callable_encoder(self):
         """Test `CallableIndexEncoder`"""
         ts = tg.linear_timeseries(length=24, freq="YE")
@@ -956,6 +966,16 @@ class TestEncoder:
 
         # check that the input series is not modified
         assert ts == ts_copy
+
+        encoder_params = {"custom": {"past": ["invalid"]}}
+        with pytest.raises(ValueError, match="Attribute must be a callable"):
+            _ = SequentialEncoder(
+                add_encoders=encoder_params,
+                input_chunk_length=input_chunk_length,
+                output_chunk_length=output_chunk_length,
+                takes_past_covariates=True,
+                takes_future_covariates=True,
+            )
 
     def test_callable_encoder_multi_component_output(self):
         """Test `CallableIndexEncoder` with a callable returning multiple components."""
@@ -1262,6 +1282,20 @@ class TestEncoder:
                     assert abs(cov[cov_name].values(copy=False).max() - 2.5) < 10e-9
                 else:
                     assert abs(cov[cov_name].values(copy=False).max() - 1.0) < 10e-9
+
+    def test_transformer_invalid(self):
+        encoder_params = {
+            "datetime_attribute": {"past": ["month"]},
+            "transformer": "invalid",
+        }
+        with pytest.raises(ValueError, match="Transformer must be an instance of"):
+            _ = SequentialEncoder(
+                add_encoders=encoder_params,
+                input_chunk_length=11,
+                output_chunk_length=6,
+                takes_past_covariates=True,
+                takes_future_covariates=True,
+            )
 
     def helper_test_cyclic_encoder(
         self,

--- a/darts/tests/dataprocessing/encoders/test_encoders.py
+++ b/darts/tests/dataprocessing/encoders/test_encoders.py
@@ -957,6 +957,60 @@ class TestEncoder:
         # check that the input series is not modified
         assert ts == ts_copy
 
+    def test_callable_encoder_multi_component_output(self):
+        """Test `CallableIndexEncoder` with a callable returning multiple components."""
+        ts = tg.linear_timeseries(length=24, freq="YE")
+
+        input_chunk_length = 12
+        output_chunk_length = 6
+
+        def index_year_and_shifted(index):
+            return np.stack([index.year, index.year - 1], axis=1)
+
+        # ===> test callable index encoder with multi component ouput <===
+        encoder_params = {
+            "custom": {
+                "past": [index_year_and_shifted],
+                "future": [index_year_and_shifted],
+            }
+        }
+        encs = SequentialEncoder(
+            add_encoders=encoder_params,
+            input_chunk_length=input_chunk_length,
+            output_chunk_length=output_chunk_length,
+            takes_past_covariates=True,
+            takes_future_covariates=True,
+        )
+
+        # train set
+        pc, fc = encs.encode_train(ts)
+        # past covariates
+        np.testing.assert_array_equal(
+            ts[:-output_chunk_length].time_index.year.values,
+            pc.values()[:, 0],
+        )
+        np.testing.assert_array_equal(
+            ts[:-output_chunk_length].time_index.year.values - 1,
+            pc.values()[:, 1],
+        )
+        # future covariates
+        np.testing.assert_array_equal(ts.time_index.year.values, fc.values()[:, 0])
+        np.testing.assert_array_equal(
+            ts.time_index.year.values - 1,
+            fc.values()[:, 1],
+        )
+        # verify number and names of components
+        assert pc.n_components == 2
+        assert list(pc.components) == [
+            "darts_enc_pc_cus_custom",
+            "darts_enc_pc_cus_custom_1",
+        ]
+        assert fc.n_components == 2
+        assert list(fc.components) == [
+            "darts_enc_fc_cus_custom",
+            "darts_enc_fc_cus_custom_1",
+        ]
+
     def test_transformer_single_series(self):
         def test_routine_cyclic(past_covs):
             for curve in ["sin", "cos"]:

--- a/darts/tests/dataprocessing/encoders/test_encoders.py
+++ b/darts/tests/dataprocessing/encoders/test_encoders.py
@@ -967,7 +967,19 @@ class TestEncoder:
         def index_year_and_shifted(index):
             return np.stack([index.year, index.year - 1], axis=1)
 
+        def invalid_callable(index):
+            return index.year[0]
+
         # ===> test callable index encoder with multi component ouput <===
+        # test invalid callable at encoder creation
+        with pytest.raises(ValueError):
+            _ = PastCallableIndexEncoder(
+                attribute=invalid_callable,
+                input_chunk_length=input_chunk_length,
+                output_chunk_length=output_chunk_length,
+            )
+
+        # test valid multi component callable
         encoder_params = {
             "custom": {
                 "past": [index_year_and_shifted],


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #2806.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->
 This PR adds support in `CallableIndexEncoder` for custom encoders to return multiple components. A single callable used via `add_encoders["custom"]` can now return either a 1D array of shape `(len(index),)` or a 2D array of shape `(len(index), n)`.

For a 2D output,  one encoded covariate component per column are created. The number of components is detected at initialization time. If the callable does not accept a supported index type or does not return the correct output shape, a `ValueError` is raised at initialization.

<!--Thank you for contributing to darts! -->
