### PR TITLE
Fix historical forecasts on a list of a single series with `retrain=False`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `"warn"` (default) raises a warning and returns `np.nan` for non-zero forecast errors, and `1.0` otherwise (forecast is on-par with naive forecast).
   - `"raise"` preserves the legacy error.
 
-
-
 **Fixed**
 
 - Fixed a device mismatch error in `TFTModel` when moving a trained model to a different device (e.g., GPU to CPU for ONNX export). `attention_mask` and `relative_index` are now registered as non-persistent buffers so they are properly moved with the model. [#3053](https://github.com/unit8co/darts/pull/3053) by [Wolfhart Feldmeier](https://github.com/trahflow)
+- Fixed a bug in historical forecasts, which raised an exception when forecasting a list of a single series with `retrain=False`. [#3070](https://github.com/unit8co/darts/pull/3070) by [Dennis Bader](https://github.com/dennisbader)
 
 ### For developers of the library:
 

--- a/darts/utils/historical_forecasts/utils.py
+++ b/darts/utils/historical_forecasts/utils.py
@@ -335,7 +335,11 @@ def _historical_forecasts_general_checks(
             else:
                 # at least one pipeline was fitted on several series with `global_fit=False` but only
                 # one series was passed
-                if n.show_warnings and max(fitted_params_pipelines) > 1:
+                if (
+                    n.show_warnings
+                    and len(fitted_params_pipelines) > 0
+                    and max(fitted_params_pipelines) > 1
+                ):
                     logger.warning(
                         "Provided only a single series, but at least one of the `data_transformers` "
                         "that use `global_fit=False` was fitted on multiple `TimeSeries`."


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- Fixes a bug in historical forecasts, which raised an exception when forecasting a list of a single series with `retrain=False`.