### PR TITLE
Add type hinting for lazy imports for IDEs

### DIFF
--- a/darts/ad/__init__.py
+++ b/darts/ad/__init__.py
@@ -26,7 +26,33 @@ on time series.
   applying boolean logic.
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.ad.aggregators import AndAggregator as AndAggregator
+    from darts.ad.aggregators import (
+        EnsembleSklearnAggregator as EnsembleSklearnAggregator,
+    )
+    from darts.ad.aggregators import OrAggregator as OrAggregator
+    from darts.ad.anomaly_model import FilteringAnomalyModel as FilteringAnomalyModel
+    from darts.ad.anomaly_model import (
+        ForecastingAnomalyModel as ForecastingAnomalyModel,
+    )
+    from darts.ad.detectors import QuantileDetector as QuantileDetector
+    from darts.ad.detectors import ThresholdDetector as ThresholdDetector
+    from darts.ad.scorers import CauchyNLLScorer as CauchyNLLScorer
+    from darts.ad.scorers import DifferenceScorer as DifferenceScorer
+    from darts.ad.scorers import ExponentialNLLScorer as ExponentialNLLScorer
+    from darts.ad.scorers import GammaNLLScorer as GammaNLLScorer
+    from darts.ad.scorers import GaussianNLLScorer as GaussianNLLScorer
+    from darts.ad.scorers import KMeansScorer as KMeansScorer
+    from darts.ad.scorers import LaplaceNLLScorer as LaplaceNLLScorer
+    from darts.ad.scorers import NormScorer as NormScorer
+    from darts.ad.scorers import PoissonNLLScorer as PoissonNLLScorer
+    from darts.ad.scorers import PyODScorer as PyODScorer
+    from darts.ad.scorers import WassersteinScorer as WassersteinScorer
 
 _LAZY_IMPORTS: dict[str, str] = {
     # anomaly aggregators

--- a/darts/dataprocessing/transformers/__init__.py
+++ b/darts/dataprocessing/transformers/__init__.py
@@ -6,7 +6,46 @@ Data transformers for preprocessing time series data, including scalers, missing
 differencing, BoxCox transformations, and hierarchical reconciliation methods.
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.dataprocessing.transformers.base_data_transformer import (
+        BaseDataTransformer as BaseDataTransformer,
+    )
+    from darts.dataprocessing.transformers.boxcox import BoxCox as BoxCox
+    from darts.dataprocessing.transformers.diff import Diff as Diff
+    from darts.dataprocessing.transformers.fittable_data_transformer import (
+        FittableDataTransformer as FittableDataTransformer,
+    )
+    from darts.dataprocessing.transformers.invertible_data_transformer import (
+        InvertibleDataTransformer as InvertibleDataTransformer,
+    )
+    from darts.dataprocessing.transformers.mappers import (
+        InvertibleMapper as InvertibleMapper,
+    )
+    from darts.dataprocessing.transformers.mappers import Mapper as Mapper
+    from darts.dataprocessing.transformers.midas import MIDAS as MIDAS
+    from darts.dataprocessing.transformers.missing_values_filler import (
+        MissingValuesFiller as MissingValuesFiller,
+    )
+    from darts.dataprocessing.transformers.reconciliation import (
+        BottomUpReconciliator as BottomUpReconciliator,
+    )
+    from darts.dataprocessing.transformers.reconciliation import (
+        MinTReconciliator as MinTReconciliator,
+    )
+    from darts.dataprocessing.transformers.reconciliation import (
+        TopDownReconciliator as TopDownReconciliator,
+    )
+    from darts.dataprocessing.transformers.scaler import Scaler as Scaler
+    from darts.dataprocessing.transformers.static_covariates_transformer import (
+        StaticCovariatesTransformer as StaticCovariatesTransformer,
+    )
+    from darts.dataprocessing.transformers.window_transformer import (
+        WindowTransformer as WindowTransformer,
+    )
 
 _LAZY_IMPORTS: dict[str, str] = {
     "BaseDataTransformer": "darts.dataprocessing.transformers.base_data_transformer",

--- a/darts/datasets/__init__.py
+++ b/darts/datasets/__init__.py
@@ -51,7 +51,44 @@ Multivariate Datasets
 - :class:`~darts.datasets.datasets.WeatherDataset` - Weather indicators (21 components, 10-min, 2020)
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.datasets.datasets import AirPassengersDataset as AirPassengersDataset
+    from darts.datasets.datasets import AusBeerDataset as AusBeerDataset
+    from darts.datasets.datasets import (
+        AustralianTourismDataset as AustralianTourismDataset,
+    )
+    from darts.datasets.datasets import (
+        ElectricityConsumptionZurichDataset as ElectricityConsumptionZurichDataset,
+    )
+    from darts.datasets.datasets import ElectricityDataset as ElectricityDataset
+    from darts.datasets.datasets import EnergyDataset as EnergyDataset
+    from darts.datasets.datasets import ETTh1Dataset as ETTh1Dataset
+    from darts.datasets.datasets import ETTh2Dataset as ETTh2Dataset
+    from darts.datasets.datasets import ETTm1Dataset as ETTm1Dataset
+    from darts.datasets.datasets import ETTm2Dataset as ETTm2Dataset
+    from darts.datasets.datasets import ExchangeRateDataset as ExchangeRateDataset
+    from darts.datasets.datasets import GasRateCO2Dataset as GasRateCO2Dataset
+    from darts.datasets.datasets import HeartRateDataset as HeartRateDataset
+    from darts.datasets.datasets import IceCreamHeaterDataset as IceCreamHeaterDataset
+    from darts.datasets.datasets import ILINetDataset as ILINetDataset
+    from darts.datasets.datasets import MonthlyMilkDataset as MonthlyMilkDataset
+    from darts.datasets.datasets import (
+        MonthlyMilkIncompleteDataset as MonthlyMilkIncompleteDataset,
+    )
+    from darts.datasets.datasets import SunspotsDataset as SunspotsDataset
+    from darts.datasets.datasets import TaxiNewYorkDataset as TaxiNewYorkDataset
+    from darts.datasets.datasets import TaylorDataset as TaylorDataset
+    from darts.datasets.datasets import TemperatureDataset as TemperatureDataset
+    from darts.datasets.datasets import TrafficDataset as TrafficDataset
+    from darts.datasets.datasets import UberTLCDataset as UberTLCDataset
+    from darts.datasets.datasets import USGasolineDataset as USGasolineDataset
+    from darts.datasets.datasets import WeatherDataset as WeatherDataset
+    from darts.datasets.datasets import WineDataset as WineDataset
+    from darts.datasets.datasets import WoolyDataset as WoolyDataset
 
 _LAZY_IMPORTS: dict[str, str] = {
     "AirPassengersDataset": "darts.datasets.datasets",

--- a/darts/explainability/__init__.py
+++ b/darts/explainability/__init__.py
@@ -6,7 +6,22 @@ Tools for explaining and interpreting forecasting model predictions, including S
 model-specific explainability methods.
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.explainability.explainability_result import (
+        ShapExplainabilityResult as ShapExplainabilityResult,
+    )
+    from darts.explainability.explainability_result import (
+        TFTExplainabilityResult as TFTExplainabilityResult,
+    )
+    from darts.explainability.explainability_result import (
+        _ExplainabilityResult as _ExplainabilityResult,
+    )
+    from darts.explainability.shap_explainer import ShapExplainer as ShapExplainer
+    from darts.explainability.tft_explainer import TFTExplainer as TFTExplainer
 
 _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "ShapExplainabilityResult": ("darts.explainability.explainability_result", None),

--- a/darts/metrics/__init__.py
+++ b/darts/metrics/__init__.py
@@ -95,8 +95,55 @@ For Dynamic Time Warping (DTW) (aggregated over time):
 """
 
 import importlib
+from typing import TYPE_CHECKING
 
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.metrics.metrics import accuracy as accuracy
+    from darts.metrics.metrics import ae as ae
+    from darts.metrics.metrics import ape as ape
+    from darts.metrics.metrics import arre as arre
+    from darts.metrics.metrics import ase as ase
+    from darts.metrics.metrics import autc as autc
+    from darts.metrics.metrics import (
+        coefficient_of_variation as coefficient_of_variation,
+    )
+    from darts.metrics.metrics import confusion_matrix as confusion_matrix
+    from darts.metrics.metrics import dtw_metric as dtw_metric
+    from darts.metrics.metrics import err as err
+    from darts.metrics.metrics import f1 as f1
+    from darts.metrics.metrics import ic as ic
+    from darts.metrics.metrics import incs_qr as incs_qr
+    from darts.metrics.metrics import iw as iw
+    from darts.metrics.metrics import iws as iws
+    from darts.metrics.metrics import mae as mae
+    from darts.metrics.metrics import mape as mape
+    from darts.metrics.metrics import marre as marre
+    from darts.metrics.metrics import mase as mase
+    from darts.metrics.metrics import merr as merr
+    from darts.metrics.metrics import mic as mic
+    from darts.metrics.metrics import mincs_qr as mincs_qr
+    from darts.metrics.metrics import miw as miw
+    from darts.metrics.metrics import miws as miws
+    from darts.metrics.metrics import mql as mql
+    from darts.metrics.metrics import mse as mse
+    from darts.metrics.metrics import msse as msse
+    from darts.metrics.metrics import ope as ope
+    from darts.metrics.metrics import precision as precision
+    from darts.metrics.metrics import ql as ql
+    from darts.metrics.metrics import qr as qr
+    from darts.metrics.metrics import r2_score as r2_score
+    from darts.metrics.metrics import recall as recall
+    from darts.metrics.metrics import rmse as rmse
+    from darts.metrics.metrics import rmsle as rmsle
+    from darts.metrics.metrics import rmsse as rmsse
+    from darts.metrics.metrics import sape as sape
+    from darts.metrics.metrics import se as se
+    from darts.metrics.metrics import sle as sle
+    from darts.metrics.metrics import smape as smape
+    from darts.metrics.metrics import sse as sse
+    from darts.metrics.metrics import wmape as wmape
 
 _LAZY_IMPORTS: dict[str, str] = {
     "accuracy": "darts.metrics.metrics",

--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -8,7 +8,115 @@ machine learning models (LightGBM, CatBoost, sklearn-based, ...), neural network
 N-BEATS, TiDE...), and foundation models (Chronos-2, TimesFM 2.5).
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.models.filtering.gaussian_process_filter import (
+        GaussianProcessFilter as GaussianProcessFilter,
+    )
+    from darts.models.filtering.kalman_filter import KalmanFilter as KalmanFilter
+    from darts.models.filtering.moving_average_filter import (
+        MovingAverageFilter as MovingAverageFilter,
+    )
+    from darts.models.forecasting.arima import ARIMA as ARIMA
+    from darts.models.forecasting.baselines import NaiveDrift as NaiveDrift
+    from darts.models.forecasting.baselines import NaiveMean as NaiveMean
+    from darts.models.forecasting.baselines import (
+        NaiveMovingAverage as NaiveMovingAverage,
+    )
+    from darts.models.forecasting.baselines import NaiveSeasonal as NaiveSeasonal
+    from darts.models.forecasting.block_rnn_model import BlockRNNModel as BlockRNNModel
+    from darts.models.forecasting.catboost_model import (
+        CatBoostClassifierModel as CatBoostClassifierModel,
+    )
+    from darts.models.forecasting.catboost_model import CatBoostModel as CatBoostModel
+    from darts.models.forecasting.chronos2_model import Chronos2Model as Chronos2Model
+    from darts.models.forecasting.conformal_models import (
+        ConformalNaiveModel as ConformalNaiveModel,
+    )
+    from darts.models.forecasting.conformal_models import (
+        ConformalQRModel as ConformalQRModel,
+    )
+    from darts.models.forecasting.dlinear import DLinearModel as DLinearModel
+    from darts.models.forecasting.ensemble_model import EnsembleModel as EnsembleModel
+    from darts.models.forecasting.exponential_smoothing import (
+        ExponentialSmoothing as ExponentialSmoothing,
+    )
+    from darts.models.forecasting.fft import FFT as FFT
+    from darts.models.forecasting.global_baseline_models import (
+        GlobalNaiveAggregate as GlobalNaiveAggregate,
+    )
+    from darts.models.forecasting.global_baseline_models import (
+        GlobalNaiveDrift as GlobalNaiveDrift,
+    )
+    from darts.models.forecasting.global_baseline_models import (
+        GlobalNaiveSeasonal as GlobalNaiveSeasonal,
+    )
+    from darts.models.forecasting.kalman_forecaster import (
+        KalmanForecaster as KalmanForecaster,
+    )
+    from darts.models.forecasting.lgbm import (
+        LightGBMClassifierModel as LightGBMClassifierModel,
+    )
+    from darts.models.forecasting.lgbm import LightGBMModel as LightGBMModel
+    from darts.models.forecasting.linear_regression_model import (
+        LinearRegressionModel as LinearRegressionModel,
+    )
+    from darts.models.forecasting.naive_ensemble_model import (
+        NaiveEnsembleModel as NaiveEnsembleModel,
+    )
+    from darts.models.forecasting.nbeats import NBEATSModel as NBEATSModel
+    from darts.models.forecasting.nf_model import (
+        NeuralForecastModel as NeuralForecastModel,
+    )
+    from darts.models.forecasting.nhits import NHiTSModel as NHiTSModel
+    from darts.models.forecasting.nlinear import NLinearModel as NLinearModel
+    from darts.models.forecasting.prophet_model import Prophet as Prophet
+    from darts.models.forecasting.random_forest import RandomForest as RandomForest
+    from darts.models.forecasting.random_forest import (
+        RandomForestModel as RandomForestModel,
+    )
+    from darts.models.forecasting.regression_ensemble_model import (
+        RegressionEnsembleModel as RegressionEnsembleModel,
+    )
+    from darts.models.forecasting.rnn_model import RNNModel as RNNModel
+    from darts.models.forecasting.sf_auto_arima import AutoARIMA as AutoARIMA
+    from darts.models.forecasting.sf_auto_ces import AutoCES as AutoCES
+    from darts.models.forecasting.sf_auto_ets import AutoETS as AutoETS
+    from darts.models.forecasting.sf_auto_mfles import AutoMFLES as AutoMFLES
+    from darts.models.forecasting.sf_auto_tbats import AutoTBATS as AutoTBATS
+    from darts.models.forecasting.sf_auto_theta import AutoTheta as AutoTheta
+    from darts.models.forecasting.sf_croston import Croston as Croston
+    from darts.models.forecasting.sf_model import (
+        StatsForecastModel as StatsForecastModel,
+    )
+    from darts.models.forecasting.sf_tbats import TBATS as TBATS
+    from darts.models.forecasting.sklearn_model import (
+        RegressionModel as RegressionModel,
+    )
+    from darts.models.forecasting.sklearn_model import (
+        SKLearnClassifierModel as SKLearnClassifierModel,
+    )
+    from darts.models.forecasting.sklearn_model import SKLearnModel as SKLearnModel
+    from darts.models.forecasting.tcn_model import TCNModel as TCNModel
+    from darts.models.forecasting.tft_model import TFTModel as TFTModel
+    from darts.models.forecasting.theta import FourTheta as FourTheta
+    from darts.models.forecasting.theta import Theta as Theta
+    from darts.models.forecasting.tide_model import TiDEModel as TiDEModel
+    from darts.models.forecasting.timesfm2p5_model import (
+        TimesFM2p5Model as TimesFM2p5Model,
+    )
+    from darts.models.forecasting.transformer_model import (
+        TransformerModel as TransformerModel,
+    )
+    from darts.models.forecasting.tsmixer_model import TSMixerModel as TSMixerModel
+    from darts.models.forecasting.varima import VARIMA as VARIMA
+    from darts.models.forecasting.xgboost import (
+        XGBClassifierModel as XGBClassifierModel,
+    )
+    from darts.models.forecasting.xgboost import XGBModel as XGBModel
 
 # mapping of public name -> (module_path, optional_dependency_name | None);
 # when optional_dependency_name is not None, a missing dependency yields a

--- a/darts/utils/data/__init__.py
+++ b/darts/utils/data/__init__.py
@@ -6,7 +6,29 @@ Datasets and utilities for preparing time series data for training and inference
 including torch-based datasets and tabularization methods for SKLearn-like models.
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.utils.data.torch_datasets.inference_dataset import (
+        SequentialTorchInferenceDataset as SequentialTorchInferenceDataset,
+    )
+    from darts.utils.data.torch_datasets.inference_dataset import (
+        TorchInferenceDataset as TorchInferenceDataset,
+    )
+    from darts.utils.data.torch_datasets.training_dataset import (
+        HorizonBasedTorchTrainingDataset as HorizonBasedTorchTrainingDataset,
+    )
+    from darts.utils.data.torch_datasets.training_dataset import (
+        SequentialTorchTrainingDataset as SequentialTorchTrainingDataset,
+    )
+    from darts.utils.data.torch_datasets.training_dataset import (
+        ShiftedTorchTrainingDataset as ShiftedTorchTrainingDataset,
+    )
+    from darts.utils.data.torch_datasets.training_dataset import (
+        TorchTrainingDataset as TorchTrainingDataset,
+    )
 
 _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "SequentialTorchInferenceDataset": (

--- a/darts/utils/historical_forecasts/__init__.py
+++ b/darts/utils/historical_forecasts/__init__.py
@@ -5,7 +5,26 @@ Utils for Historical Forecasting
 Utilities for generating and optimizing historical forecasts.
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.utils.historical_forecasts.optimized_historical_forecasts_regression import (
+        _optimized_historical_forecasts_regression as _optimized_historical_forecasts_regression,
+    )
+    from darts.utils.historical_forecasts.utils import (
+        _check_optimizable_historical_forecasts_global_models as _check_optimizable_historical_forecasts_global_models,
+    )
+    from darts.utils.historical_forecasts.utils import (
+        _get_historical_forecast_boundaries as _get_historical_forecast_boundaries,
+    )
+    from darts.utils.historical_forecasts.utils import (
+        _historical_forecasts_general_checks as _historical_forecasts_general_checks,
+    )
+    from darts.utils.historical_forecasts.utils import (
+        _process_historical_forecast_input as _process_historical_forecast_input,
+    )
 
 _LAZY_IMPORTS: dict[str, str] = {
     "_optimized_historical_forecasts_regression": (

--- a/darts/utils/likelihood_models/__init__.py
+++ b/darts/utils/likelihood_models/__init__.py
@@ -5,7 +5,54 @@ Likelihood Models
 Likelihood models for producing probabilistic forecasts.
 """
 
+from typing import TYPE_CHECKING
+
 from darts.utils._lazy import setup_lazy_imports
+
+if TYPE_CHECKING:
+    from darts.utils.likelihood_models.torch import (
+        BernoulliLikelihood as BernoulliLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import BetaLikelihood as BetaLikelihood
+    from darts.utils.likelihood_models.torch import CauchyLikelihood as CauchyLikelihood
+    from darts.utils.likelihood_models.torch import (
+        ContinuousBernoulliLikelihood as ContinuousBernoulliLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        DirichletLikelihood as DirichletLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        ExponentialLikelihood as ExponentialLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import GammaLikelihood as GammaLikelihood
+    from darts.utils.likelihood_models.torch import (
+        GaussianLikelihood as GaussianLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        GeometricLikelihood as GeometricLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import GumbelLikelihood as GumbelLikelihood
+    from darts.utils.likelihood_models.torch import (
+        HalfNormalLikelihood as HalfNormalLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        LaplaceLikelihood as LaplaceLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        LogNormalLikelihood as LogNormalLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        NegativeBinomialLikelihood as NegativeBinomialLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        PoissonLikelihood as PoissonLikelihood,
+    )
+    from darts.utils.likelihood_models.torch import (
+        QuantileRegression as QuantileRegression,
+    )
+    from darts.utils.likelihood_models.torch import (
+        WeibullLikelihood as WeibullLikelihood,
+    )
 
 _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "BernoulliLikelihood": ("darts.utils.likelihood_models.torch", "(Py)Torch"),


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

After the lazy imports added #3066, IDEs were not able anymore to properly resolve the imported objects. This PR fixes it by adding the objects for type hinting. Since the imports are not used anymore, we need to write every import as 
`from darts... import X as X` which according to [PEP 484](https://peps.python.org/pep-0484/) as the standard for stub files (or similar type hinting-related code).