### PR TITLE
Feature/add `name` parameter to all metric functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `"warn"` (default) raises a warning and returns `np.nan` for non-zero forecast errors, and `1.0` otherwise (forecast is on-par with naive forecast).
   - `"raise"` preserves the legacy error.
 - 🔴 We moved `NaiveEnsembleModel` from `darts.models.forecasting.baselines` into a dedicated module `darts.models.forecasting.naive_ensemble_model` to separate the heavier dependencies from the baseline models and improve import times. Models that were saved in older Darts versions (pickled) cannot be loaded anymore. To fix it, simply re-create the model and store it again. [#3066](https://github.com/unit8co/darts/pull/3066) by [Dennis Bader](https://github.com/dennisbader)
+- Added name parameter to all metric functions. [#3084](https://https://github.com/unit8co/darts/pull/3084)
+  by [Bruno Da Costa](https://github.com/BrunoDaC).
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `"warn"` (default) raises a warning and returns `np.nan` for non-zero forecast errors, and `1.0` otherwise (forecast is on-par with naive forecast).
   - `"raise"` preserves the legacy error.
 - 🔴 We moved `NaiveEnsembleModel` from `darts.models.forecasting.baselines` into a dedicated module `darts.models.forecasting.naive_ensemble_model` to separate the heavier dependencies from the baseline models and improve import times. Models that were saved in older Darts versions (pickled) cannot be loaded anymore. To fix it, simply re-create the model and store it again. [#3066](https://github.com/unit8co/darts/pull/3066) by [Dennis Bader](https://github.com/dennisbader)
-- Added name parameter to all metric functions. [#3084](https://https://github.com/unit8co/darts/pull/3084)
+- Added name parameter to all metric functions. [#3084](https://github.com/unit8co/darts/pull/3084)
   by [Bruno Da Costa](https://github.com/BrunoDaC).
 
 **Fixed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `"warn"` (default) raises a warning and returns `np.nan` for non-zero forecast errors, and `1.0` otherwise (forecast is on-par with naive forecast).
   - `"raise"` preserves the legacy error.
 - 🔴 We moved `NaiveEnsembleModel` from `darts.models.forecasting.baselines` into a dedicated module `darts.models.forecasting.naive_ensemble_model` to separate the heavier dependencies from the baseline models and improve import times. Models that were saved in older Darts versions (pickled) cannot be loaded anymore. To fix it, simply re-create the model and store it again. [#3066](https://github.com/unit8co/darts/pull/3066) by [Dennis Bader](https://github.com/dennisbader)
-- Added name parameter to all metric functions. [#3084](https://github.com/unit8co/darts/pull/3084)
+- Added parameter `name` to all metric functions for customizing the displayed name. [#3084](https://github.com/unit8co/darts/pull/3084)
   by [Bruno Da Costa](https://github.com/BrunoDaC).
 
 **Fixed**

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -48,7 +48,7 @@ def err(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "err",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Error (ERR).
 
@@ -95,7 +95,7 @@ def err(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"err"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -144,7 +144,7 @@ def merr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "merr",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Error (MERR).
 
@@ -186,7 +186,7 @@ def merr(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"merr"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -233,7 +233,7 @@ def ae(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "ae",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Error (AE).
 
@@ -280,7 +280,7 @@ def ae(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"ae"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -329,7 +329,7 @@ def mae(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "mae",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Error (MAE).
 
@@ -371,7 +371,7 @@ def mae(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"mae"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -421,7 +421,7 @@ def ase(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "ase",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Scaled Error (ASE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -490,7 +490,7 @@ def ase(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"ase"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -551,7 +551,7 @@ def mase(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "mase",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Scaled Error (MASE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -615,7 +615,7 @@ def mase(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"mase"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -675,7 +675,7 @@ def se(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "se",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Squared Error (SE).
 
@@ -722,7 +722,7 @@ def se(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"se"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -771,7 +771,7 @@ def mse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "mse",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Squared Error (MSE).
 
@@ -813,7 +813,7 @@ def mse(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"mse"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -863,7 +863,7 @@ def sse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "sse",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Squared Scaled Error (SSE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -932,7 +932,7 @@ def sse(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"sse"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -993,7 +993,7 @@ def msse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "msse",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Squared Scaled Error (MSSE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -1057,7 +1057,7 @@ def msse(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"msse"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -1116,7 +1116,7 @@ def rmse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "rmse",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Root Mean Squared Error (RMSE).
 
@@ -1158,7 +1158,7 @@ def rmse(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"rmse"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -1206,7 +1206,7 @@ def rmsse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "rmsse",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Root Mean Squared Scaled Error (RMSSE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -1270,7 +1270,7 @@ def rmsse(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"rmsse"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -1326,7 +1326,7 @@ def sle(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "sle",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Squared Log Error (SLE).
 
@@ -1375,7 +1375,7 @@ def sle(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"sle"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -1425,7 +1425,7 @@ def rmsle(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "rmsle",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Root Mean Squared Log Error (RMSLE).
 
@@ -1469,7 +1469,7 @@ def rmsle(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"rmsle"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -1518,7 +1518,7 @@ def ape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "ape",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Percentage Error (APE).
 
@@ -1568,7 +1568,7 @@ def ape(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"ape"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -1629,7 +1629,7 @@ def mape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "mape",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Percentage Error (MAPE).
 
@@ -1674,7 +1674,7 @@ def mape(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"mape"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -1726,7 +1726,7 @@ def wmape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "wmape",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Weighted Mean Absolute Percentage Error (WMAPE). (see [1]_ for more information).
 
@@ -1768,7 +1768,7 @@ def wmape(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"wmape"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -1829,7 +1829,7 @@ def sape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "sape",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """symmetric Absolute Percentage Error (sAPE).
 
@@ -1880,7 +1880,7 @@ def sape(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"sape"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -1936,7 +1936,7 @@ def smape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "smape",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """symmetric Mean Absolute Percentage Error (sMAPE).
 
@@ -1983,7 +1983,7 @@ def smape(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"smape"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -2030,7 +2030,7 @@ def ope(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "ope",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Overall Percentage Error (OPE).
 
@@ -2073,7 +2073,7 @@ def ope(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"ope"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -2136,7 +2136,7 @@ def arre(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "arre",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Ranged Relative Error (ARRE).
 
@@ -2183,7 +2183,7 @@ def arre(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"arre"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -2247,7 +2247,7 @@ def marre(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "marre",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Ranged Relative Error (MARRE).
 
@@ -2290,7 +2290,7 @@ def marre(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"marre"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -2336,7 +2336,7 @@ def r2_score(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "r2_score",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Coefficient of Determination :math:`R^2` (see [1]_ for more details).
 
@@ -2382,7 +2382,7 @@ def r2_score(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"r2_score"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -2434,7 +2434,7 @@ def coefficient_of_variation(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "coefficient_of_variation",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Coefficient of Variation (percentage).
 
@@ -2479,7 +2479,7 @@ def coefficient_of_variation(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"coefficient_of_variation"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -2533,7 +2533,7 @@ def _tolerance_coverages(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "_tolerance_coverages",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Computes the tolerance coverages for different tolerance levels.
 
@@ -2593,7 +2593,7 @@ def autc(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "autc",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Area Under Tolerance Curve (AUTC).
 
@@ -2656,7 +2656,7 @@ def autc(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"autc"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Raises
     ------
@@ -2720,7 +2720,7 @@ def dtw_metric(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "dtw_metric",
+    name: str | None = None,
     **kwargs,
 ) -> METRIC_OUTPUT_TYPE:
     """
@@ -2757,7 +2757,7 @@ def dtw_metric(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"dtw_metric"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -2801,7 +2801,7 @@ def qr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "qr",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Quantile Risk (QR)
 
@@ -2849,7 +2849,7 @@ def qr(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"qr"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -2915,7 +2915,7 @@ def ql(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "ql",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Quantile Loss (QL).
 
@@ -2968,7 +2968,7 @@ def ql(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"ql"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3019,7 +3019,7 @@ def mql(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "mql",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Quantile Loss (MQL).
 
@@ -3068,7 +3068,7 @@ def mql(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"mql"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3117,7 +3117,7 @@ def iw(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "iw",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Width (IW).
 
@@ -3170,7 +3170,7 @@ def iw(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"iw"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3221,7 +3221,7 @@ def miw(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "miw",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Width (MIW).
 
@@ -3269,7 +3269,7 @@ def miw(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"miw"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3319,7 +3319,7 @@ def iws(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "iws",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Winkler Score (IWS) [1]_.
 
@@ -3378,7 +3378,7 @@ def iws(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"iws"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3450,7 +3450,7 @@ def miws(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "miws",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Winkler Score (IWS) [1]_.
 
@@ -3496,7 +3496,7 @@ def miws(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"miws"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3550,7 +3550,7 @@ def ic(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "ic",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Coverage (IC).
 
@@ -3608,7 +3608,7 @@ def ic(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"ic"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3659,7 +3659,7 @@ def mic(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "mic",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Coverage (MIC).
 
@@ -3705,7 +3705,7 @@ def mic(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"mic"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3756,7 +3756,7 @@ def incs_qr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "incs_qr",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Non-Conformity Score for Quantile Regression (INCS_QR).
 
@@ -3812,7 +3812,7 @@ def incs_qr(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"incs_qr"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3867,7 +3867,7 @@ def mincs_qr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "mincs_qr",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Non-Conformity Score for Quantile Regression (MINCS_QR).
 
@@ -3916,7 +3916,7 @@ def mincs_qr(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"mincs_qr"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -3964,7 +3964,7 @@ def accuracy(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "accuracy",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Accuracy Score [1]_.
 
@@ -4007,7 +4007,7 @@ def accuracy(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"accuracy"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -4056,7 +4056,7 @@ def precision(
     label_reduction: str | None | _LabelReduction = _LabelReduction.MACRO,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "precision",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Precision Score [1]_.
 
@@ -4111,7 +4111,7 @@ def precision(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"precision"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -4174,7 +4174,7 @@ def recall(
     label_reduction: str | None | _LabelReduction = _LabelReduction.MACRO,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "recall",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Recall Score [1]_.
 
@@ -4229,7 +4229,7 @@ def recall(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"recall"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -4292,7 +4292,7 @@ def f1(
     label_reduction: str | None | _LabelReduction = _LabelReduction.MACRO,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "f1",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """F1 Score [1]_.
 
@@ -4348,7 +4348,7 @@ def f1(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"f1"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------
@@ -4411,7 +4411,7 @@ def confusion_matrix(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
-    name: str = "confusion_matrix",
+    name: str | None = None,
 ) -> METRIC_OUTPUT_TYPE:
     """Confusion Matrix (CM) [1]_.
 
@@ -4456,7 +4456,7 @@ def confusion_matrix(
     verbose
         Optionally, whether to print operations progress.
     name
-        The name of the metric. Default: `"confusion_matrix"`.
+        Optionally, the metric name to display. If `None`, will use the metric function name.
 
     Returns
     -------

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -48,6 +48,7 @@ def err(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "err",
 ) -> METRIC_OUTPUT_TYPE:
     """Error (ERR).
 
@@ -93,6 +94,8 @@ def err(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"err"`.
 
     Returns
     -------
@@ -141,6 +144,7 @@ def merr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "merr",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Error (MERR).
 
@@ -181,6 +185,8 @@ def merr(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"merr"`.
 
     Returns
     -------
@@ -227,6 +233,7 @@ def ae(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "ae",
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Error (AE).
 
@@ -272,6 +279,8 @@ def ae(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"ae"`.
 
     Returns
     -------
@@ -320,6 +329,7 @@ def mae(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "mae",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Error (MAE).
 
@@ -360,6 +370,8 @@ def mae(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"mae"`.
 
     Returns
     -------
@@ -409,6 +421,7 @@ def ase(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "ase",
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Scaled Error (ASE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -476,6 +489,8 @@ def ase(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"ase"`.
 
     Raises
     ------
@@ -536,6 +551,7 @@ def mase(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "mase",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Scaled Error (MASE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -598,6 +614,8 @@ def mase(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"mase"`.
 
     Raises
     ------
@@ -657,6 +675,7 @@ def se(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "se",
 ) -> METRIC_OUTPUT_TYPE:
     """Squared Error (SE).
 
@@ -702,6 +721,8 @@ def se(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"se"`.
 
     Returns
     -------
@@ -750,6 +771,7 @@ def mse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "mse",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Squared Error (MSE).
 
@@ -790,6 +812,8 @@ def mse(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"mse"`.
 
     Returns
     -------
@@ -839,6 +863,7 @@ def sse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "sse",
 ) -> METRIC_OUTPUT_TYPE:
     """Squared Scaled Error (SSE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -906,6 +931,8 @@ def sse(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"sse"`.
 
     Raises
     ------
@@ -966,6 +993,7 @@ def msse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "msse",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Squared Scaled Error (MSSE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -1028,6 +1056,8 @@ def msse(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"msse"`.
 
     Raises
     ------
@@ -1086,6 +1116,7 @@ def rmse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "rmse",
 ) -> METRIC_OUTPUT_TYPE:
     """Root Mean Squared Error (RMSE).
 
@@ -1126,6 +1157,8 @@ def rmse(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"rmse"`.
 
     Returns
     -------
@@ -1173,6 +1206,7 @@ def rmsse(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "rmsse",
 ) -> METRIC_OUTPUT_TYPE:
     """Root Mean Squared Scaled Error (RMSSE) (see [1]_ for more information on scaled forecasting errors).
 
@@ -1235,6 +1269,8 @@ def rmsse(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"rmsse"`.
 
     Raises
     ------
@@ -1290,6 +1326,7 @@ def sle(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "sle",
 ) -> METRIC_OUTPUT_TYPE:
     """Squared Log Error (SLE).
 
@@ -1337,6 +1374,8 @@ def sle(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"sle"`.
 
     Returns
     -------
@@ -1386,6 +1425,7 @@ def rmsle(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "rmsle",
 ) -> METRIC_OUTPUT_TYPE:
     """Root Mean Squared Log Error (RMSLE).
 
@@ -1428,6 +1468,8 @@ def rmsle(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"rmsle"`.
 
     Returns
     -------
@@ -1476,6 +1518,7 @@ def ape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "ape",
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Percentage Error (APE).
 
@@ -1524,6 +1567,8 @@ def ape(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"ape"`.
 
     Raises
     ------
@@ -1584,6 +1629,7 @@ def mape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "mape",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Percentage Error (MAPE).
 
@@ -1627,6 +1673,8 @@ def mape(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"mape"`.
 
     Raises
     ------
@@ -1678,6 +1726,7 @@ def wmape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "wmape",
 ) -> METRIC_OUTPUT_TYPE:
     """Weighted Mean Absolute Percentage Error (WMAPE). (see [1]_ for more information).
 
@@ -1718,6 +1767,8 @@ def wmape(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"wmape"`.
 
     Raises
     ------
@@ -1778,6 +1829,7 @@ def sape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "sape",
 ) -> METRIC_OUTPUT_TYPE:
     """symmetric Absolute Percentage Error (sAPE).
 
@@ -1827,6 +1879,8 @@ def sape(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"sape"`.
 
     Returns
     -------
@@ -1882,6 +1936,7 @@ def smape(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "smape",
 ) -> METRIC_OUTPUT_TYPE:
     """symmetric Mean Absolute Percentage Error (sMAPE).
 
@@ -1927,6 +1982,8 @@ def smape(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"smape"`.
 
     Returns
     -------
@@ -1973,6 +2030,7 @@ def ope(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "ope",
 ) -> METRIC_OUTPUT_TYPE:
     """Overall Percentage Error (OPE).
 
@@ -2014,6 +2072,8 @@ def ope(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"ope"`.
 
     Raises
     ------
@@ -2076,6 +2136,7 @@ def arre(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "arre",
 ) -> METRIC_OUTPUT_TYPE:
     """Absolute Ranged Relative Error (ARRE).
 
@@ -2121,6 +2182,8 @@ def arre(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"arre"`.
 
     Raises
     ------
@@ -2184,6 +2247,7 @@ def marre(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "marre",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Absolute Ranged Relative Error (MARRE).
 
@@ -2225,6 +2289,8 @@ def marre(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"marre"`.
 
     Raises
     ------
@@ -2270,6 +2336,7 @@ def r2_score(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "r2_score",
 ) -> METRIC_OUTPUT_TYPE:
     """Coefficient of Determination :math:`R^2` (see [1]_ for more details).
 
@@ -2314,6 +2381,8 @@ def r2_score(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"r2_score"`.
 
     Returns
     -------
@@ -2365,6 +2434,7 @@ def coefficient_of_variation(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "coefficient_of_variation",
 ) -> METRIC_OUTPUT_TYPE:
     """Coefficient of Variation (percentage).
 
@@ -2408,6 +2478,8 @@ def coefficient_of_variation(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"coefficient_of_variation"`.
 
     Returns
     -------
@@ -2461,6 +2533,7 @@ def _tolerance_coverages(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "_tolerance_coverages",
 ) -> METRIC_OUTPUT_TYPE:
     """Computes the tolerance coverages for different tolerance levels.
 
@@ -2520,6 +2593,7 @@ def autc(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "autc",
 ) -> METRIC_OUTPUT_TYPE:
     """Area Under Tolerance Curve (AUTC).
 
@@ -2581,6 +2655,8 @@ def autc(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"autc"`.
 
     Raises
     ------
@@ -2644,6 +2720,7 @@ def dtw_metric(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "dtw_metric",
     **kwargs,
 ) -> METRIC_OUTPUT_TYPE:
     """
@@ -2679,6 +2756,8 @@ def dtw_metric(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"dtw_metric"`.
 
     Returns
     -------
@@ -2722,6 +2801,7 @@ def qr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "qr",
 ) -> METRIC_OUTPUT_TYPE:
     """Quantile Risk (QR)
 
@@ -2768,6 +2848,8 @@ def qr(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"qr"`.
 
     Returns
     -------
@@ -2833,6 +2915,7 @@ def ql(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "ql",
 ) -> METRIC_OUTPUT_TYPE:
     """Quantile Loss (QL).
 
@@ -2884,6 +2967,8 @@ def ql(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"ql"`.
 
     Returns
     -------
@@ -2934,6 +3019,7 @@ def mql(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "mql",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Quantile Loss (MQL).
 
@@ -2981,6 +3067,8 @@ def mql(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"mql"`.
 
     Returns
     -------
@@ -3029,6 +3117,7 @@ def iw(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "iw",
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Width (IW).
 
@@ -3080,6 +3169,8 @@ def iw(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"iw"`.
 
     Returns
     -------
@@ -3130,6 +3221,7 @@ def miw(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "miw",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Width (MIW).
 
@@ -3176,6 +3268,8 @@ def miw(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"miw"`.
 
     Returns
     -------
@@ -3225,6 +3319,7 @@ def iws(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "iws",
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Winkler Score (IWS) [1]_.
 
@@ -3282,6 +3377,8 @@ def iws(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"iws"`.
 
     Returns
     -------
@@ -3353,6 +3450,7 @@ def miws(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "miws",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Winkler Score (IWS) [1]_.
 
@@ -3397,6 +3495,8 @@ def miws(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"miws"`.
 
     Returns
     -------
@@ -3450,6 +3550,7 @@ def ic(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "ic",
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Coverage (IC).
 
@@ -3506,6 +3607,8 @@ def ic(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"ic"`.
 
     Returns
     -------
@@ -3556,6 +3659,7 @@ def mic(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "mic",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Coverage (MIC).
 
@@ -3600,6 +3704,8 @@ def mic(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"mic"`.
 
     Returns
     -------
@@ -3650,6 +3756,7 @@ def incs_qr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "incs_qr",
 ) -> METRIC_OUTPUT_TYPE:
     """Interval Non-Conformity Score for Quantile Regression (INCS_QR).
 
@@ -3704,6 +3811,8 @@ def incs_qr(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"incs_qr"`.
 
     Returns
     -------
@@ -3758,6 +3867,7 @@ def mincs_qr(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "mincs_qr",
 ) -> METRIC_OUTPUT_TYPE:
     """Mean Interval Non-Conformity Score for Quantile Regression (MINCS_QR).
 
@@ -3805,6 +3915,8 @@ def mincs_qr(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"mincs_qr"`.
 
     Returns
     -------
@@ -3852,6 +3964,7 @@ def accuracy(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "accuracy",
 ) -> METRIC_OUTPUT_TYPE:
     """Accuracy Score [1]_.
 
@@ -3893,6 +4006,8 @@ def accuracy(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"accuracy"`.
 
     Returns
     -------
@@ -3941,6 +4056,7 @@ def precision(
     label_reduction: str | None | _LabelReduction = _LabelReduction.MACRO,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "precision",
 ) -> METRIC_OUTPUT_TYPE:
     """Precision Score [1]_.
 
@@ -3994,6 +4110,8 @@ def precision(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"precision"`.
 
     Returns
     -------
@@ -4056,6 +4174,7 @@ def recall(
     label_reduction: str | None | _LabelReduction = _LabelReduction.MACRO,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "recall",
 ) -> METRIC_OUTPUT_TYPE:
     """Recall Score [1]_.
 
@@ -4109,6 +4228,8 @@ def recall(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"recall"`.
 
     Returns
     -------
@@ -4171,6 +4292,7 @@ def f1(
     label_reduction: str | None | _LabelReduction = _LabelReduction.MACRO,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "f1",
 ) -> METRIC_OUTPUT_TYPE:
     """F1 Score [1]_.
 
@@ -4225,6 +4347,8 @@ def f1(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"f1"`.
 
     Returns
     -------
@@ -4287,6 +4411,7 @@ def confusion_matrix(
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
     verbose: bool = False,
+    name: str = "confusion_matrix",
 ) -> METRIC_OUTPUT_TYPE:
     """Confusion Matrix (CM) [1]_.
 
@@ -4330,6 +4455,8 @@ def confusion_matrix(
         (sequential). Setting the parameter to `-1` means using all the available processors.
     verbose
         Optionally, whether to print operations progress.
+    name
+        The name of the metric. Default: `"confusion_matrix"`.
 
     Returns
     -------

--- a/darts/metrics/utils.py
+++ b/darts/metrics/utils.py
@@ -288,7 +288,7 @@ def multi_ts_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
             iterable=zip(*input_series),
             verbose=verbose,
             total=len(actual_series),
-            desc=f"metric `{name}`",
+            desc=f"metric `{name or func.__name__}`",
         )
 
         # `vals` is a list of series metrics of length `len(actual_series)`. Each metric has shape

--- a/darts/metrics/utils.py
+++ b/darts/metrics/utils.py
@@ -186,6 +186,7 @@ def multi_ts_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
         params = signature(func).parameters
         n_jobs = kwargs.pop("n_jobs", params["n_jobs"].default)
         verbose = kwargs.pop("verbose", params["verbose"].default)
+        name = kwargs.pop("name", params["name"].default)
 
         # sanity check reduction functions
         _ = _get_reduction(
@@ -287,7 +288,7 @@ def multi_ts_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
             iterable=zip(*input_series),
             verbose=verbose,
             total=len(actual_series),
-            desc=f"metric `{func.__name__}()`",
+            desc=f"metric `{name}`",
         )
 
         # `vals` is a list of series metrics of length `len(actual_series)`. Each metric has shape

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -2155,6 +2155,7 @@ class TestMetrics:
             series_reduction=None,
             n_jobs=1,
             verbose=False,
+            name="",
             out_ndim=1,
         ):
             return np.ones(tuple(1 for _ in range(out_ndim)))

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -2155,7 +2155,7 @@ class TestMetrics:
             series_reduction=None,
             n_jobs=1,
             verbose=False,
-            name="",
+            name="custom_name",
             out_ndim=1,
         ):
             return np.ones(tuple(1 for _ in range(out_ndim)))


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #3083 .

### Summary

Added a name parameter to all metric functions (err, mae, mse, rmse, mape, etc.). The parameter defaults to the function's own name (e.g. "mae") and is used as the label in the tqdm progress bar description when iterating over multiple series. This allows users who wrap or partially apply a metric to pass a meaningful custom name that will appear in the progress output, rather than always seeing the underlying function name.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
