### PR TITLE
Feat/insample transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- `InvertibleDataTransformer.inverse_transform()` and `Pipeline.inverse_transform()` accept optional `insample`, so `Diff` can inverse-transform forecasts without manually prepending the transformed history.[#3085](https://github.com/unit8co/darts/pull/3085) by [Jakub Chłapek](https://github.com/jakubchlapek)
 - 🚀🚀 Dramatically reduced import times by deferring heavy third-party dependencies (torch, sklearn, scipy, ...) until they are actually needed. Here are some import speed up examples: [#3066](https://github.com/unit8co/darts/pull/3066) by [Dennis Bader](https://github.com/dennisbader)
   - TimeSeries, metrics, datasets, data transformers: 7x faster (2.4 → 0.3 seconds)
   - Baseline models: 15x faster (5.7 → 0.4 seconds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
-- `InvertibleDataTransformer.inverse_transform()` and `Pipeline.inverse_transform()` accept optional `insample`, so `Diff` can inverse-transform forecasts without manually prepending the transformed history.[#3085](https://github.com/unit8co/darts/pull/3085) by [Jakub Chłapek](https://github.com/jakubchlapek)
 - 🚀🚀 Dramatically reduced import times by deferring heavy third-party dependencies (torch, sklearn, scipy, ...) until they are actually needed. Here are some import speed up examples: [#3066](https://github.com/unit8co/darts/pull/3066) by [Dennis Bader](https://github.com/dennisbader)
   - TimeSeries, metrics, datasets, data transformers: 7x faster (2.4 → 0.3 seconds)
   - Baseline models: 15x faster (5.7 → 0.4 seconds)
   - SKLearn models: 4.5x faster (5.7 → 1.27 seconds)
   - Torch models: 1.9x faster (5.7 → 3.0 seconds)
+- Improvements to `InvertibleDataTransformer` and data `Pipeline`: [#3085](https://github.com/unit8co/darts/pull/3085) by [Jakub Chłapek](https://github.com/jakubchlapek)
+  - Added optional `insample` parameter to `inverse_transform()` to supply the transformed history needed by transformers like `Diff`, removing the need to manually concatenate the in-sample series before inverse-transforming a forecast.
+  - `Diff` can now be properly used inside a target series `Pipeline` with `historical_forecasts()` via the `data_transformers` parameter. The backtested forecasts are correctly inverse-transformed back to the original scale.
 - Added native multi-quantile support for `CatBoostModel` by using CatBoost’s `MultiQuantile` loss for faster training and inference. Set `likelihood="multiquantile"` to enable this feature. [#3032](https://github.com/unit8co/darts/pull/3032) by [Zhihao Dai](https://github.com/daidahao)
 - Added native multi-quantile support for `XGBModel`. Similar to the regular quantile support, it still fits dedicated models per quantile, but it is more efficient due to fewer tabularization operations. Set `likelihood="multiquantile"` to enable this feature. [#3056](https://github.com/unit8co/darts/pull/3056) by [Oswald Zink](https://github.com/ozink-u8)
 - `StatsForecastModel` now accepts `model` as a StatsForecast model name, class, or instance; `model_kwargs` supplies constructor arguments when `model` is a name or class. This simplifies config-driven setups. [#3058](https://github.com/unit8co/darts/pull/3058) by [Trevin Chow](https://github.com/tmchow).

--- a/darts/dataprocessing/pipeline.py
+++ b/darts/dataprocessing/pipeline.py
@@ -6,13 +6,15 @@ Pipeline
 from collections.abc import Iterator, Sequence
 from copy import deepcopy
 
+import numpy as np
+
 from darts import TimeSeries
 from darts.dataprocessing.transformers import (
     BaseDataTransformer,
     FittableDataTransformer,
     InvertibleDataTransformer,
 )
-from darts.logging import get_logger, raise_if_not
+from darts.logging import get_logger, raise_if_not, raise_log
 from darts.typing import TimeSeriesLike
 
 logger = get_logger(__name__)
@@ -178,11 +180,11 @@ class Pipeline:
 
     def inverse_transform(
         self,
-        data: TimeSeriesLike,
+        data: TimeSeriesLike | Sequence[Sequence[TimeSeries]],
         partial: bool = False,
         series_idx: int | Sequence[int] | None = None,
         insample: TimeSeriesLike | None = None,
-    ) -> TimeSeriesLike:
+    ) -> TimeSeriesLike | Sequence[Sequence[TimeSeries]]:
         """
         For each data transformer in the pipeline, inverse-transform data. Then inverse transformed data is passed to
         the next transformer. Transformers are traversed in reverse order. Raises value error if not all transformers
@@ -192,7 +194,7 @@ class Pipeline:
         Parameters
         ----------
         data
-            (Sequence of) TimeSeries to be inverse transformed.
+            (Sequence of) ``TimeSeries`` to inverse-transform.
         partial
             If set to `True`, the inverse transformation is applied even if the pipeline is not fully invertible,
             calling `inverse_transform()` only on transformers of type `InvertibleDataTransformer`.
@@ -200,56 +202,43 @@ class Pipeline:
             Optionally, the index(es) of each series corresponding to their positions within the series used to fit
             the transformer (to retrieve the appropriate transformer parameters).
         insample
-            Optionally, transformed insample history in the same space as ``data`` (after ``transform``). Passed to
-            each invertible step's ``inverse_transform``; between steps the insample series is inverse-transformed so
-            it stays aligned with ``data``. See :meth:`InvertibleDataTransformer.inverse_transform`.
+            Optionally, the transformed historic (insample) part of ``data``. This can be used when ``data`` is
+            only a tail (for example a forecast) and inverse transforming requires information from earlier times
+            (for example the :class:`~darts.dataprocessing.transformers.diff.Diff` transformer). Each ``insample``
+            series must start before the ``data`` start time and extend at least until one step before the start time
+            of the ``data``. If ``data`` is a ``Sequence[Sequence[TimeSeries]]``, then ``insample`` should be a
+            ``Sequence[TimeSeries]`` with the same length. Otherwise, it should have the same type as ``data``. Only
+            used by transformers that require information from earlier times.
 
         Returns
         -------
-        TimeSeriesLike
-            Inverse transformed data.
+        TimeSeriesLike | Sequence[Sequence[TimeSeries]]
+            Inverse-transformed data; same structure as ``data``.
         """
-        if not partial:
-            raise_if_not(
-                self._invertible,
-                "Not all transformers in the pipeline can perform inverse_transform",
+        if not partial and not self._invertible:
+            raise_log(
+                ValueError(
+                    "Not all transformers in the pipeline can perform inverse_transform"
+                ),
                 logger,
             )
 
-            current_insample = insample
-            for transformer in reversed(self._transformers):
-                inv_kw = (
-                    {"insample": current_insample}
-                    if current_insample is not None
-                    else {}
-                )
+        # only inverse-transform insample as long as it is required
+        tfs_with_insample = [tf._uses_insample for tf in reversed(self._transformers)]
+        last_tf_index_with_insample = int(np.argmax(np.cumsum(tfs_with_insample)))
+        current_insample = insample
+        for idx, transformer in enumerate(reversed(self._transformers)):
+            if isinstance(transformer, InvertibleDataTransformer):
                 data = transformer.inverse_transform(
-                    data, series_idx=series_idx, **inv_kw
+                    series=data,
+                    series_idx=series_idx,
+                    insample=current_insample,
                 )
-                if current_insample is not None:
+                if idx < last_tf_index_with_insample and current_insample is not None:
                     current_insample = transformer.inverse_transform(
                         current_insample, series_idx=series_idx
                     )
-            return data
-        else:
-            current_insample = insample
-            for transformer in reversed(self._transformers):
-                if isinstance(transformer, InvertibleDataTransformer):
-                    inv_kw = (
-                        {"insample": current_insample}
-                        if current_insample is not None
-                        else {}
-                    )
-                    data = transformer.inverse_transform(
-                        data,
-                        series_idx=series_idx,
-                        **inv_kw,
-                    )
-                    if current_insample is not None:
-                        current_insample = transformer.inverse_transform(
-                            current_insample, series_idx=series_idx
-                        )
-            return data
+        return data
 
     @property
     def invertible(self) -> bool:

--- a/darts/dataprocessing/pipeline.py
+++ b/darts/dataprocessing/pipeline.py
@@ -181,6 +181,7 @@ class Pipeline:
         data: TimeSeriesLike,
         partial: bool = False,
         series_idx: int | Sequence[int] | None = None,
+        insample: TimeSeriesLike | None = None,
     ) -> TimeSeriesLike:
         """
         For each data transformer in the pipeline, inverse-transform data. Then inverse transformed data is passed to
@@ -198,6 +199,10 @@ class Pipeline:
         series_idx
             Optionally, the index(es) of each series corresponding to their positions within the series used to fit
             the transformer (to retrieve the appropriate transformer parameters).
+        insample
+            Optionally, transformed insample history in the same space as ``data`` (after ``transform``). Passed to
+            each invertible step's ``inverse_transform``; between steps the insample series is inverse-transformed so
+            it stays aligned with ``data``. See :meth:`InvertibleDataTransformer.inverse_transform`.
 
         Returns
         -------
@@ -211,16 +216,39 @@ class Pipeline:
                 logger,
             )
 
+            current_insample = insample
             for transformer in reversed(self._transformers):
-                data = transformer.inverse_transform(data, series_idx=series_idx)
+                inv_kw = (
+                    {"insample": current_insample}
+                    if current_insample is not None
+                    else {}
+                )
+                data = transformer.inverse_transform(
+                    data, series_idx=series_idx, **inv_kw
+                )
+                if current_insample is not None:
+                    current_insample = transformer.inverse_transform(
+                        current_insample, series_idx=series_idx
+                    )
             return data
         else:
+            current_insample = insample
             for transformer in reversed(self._transformers):
                 if isinstance(transformer, InvertibleDataTransformer):
+                    inv_kw = (
+                        {"insample": current_insample}
+                        if current_insample is not None
+                        else {}
+                    )
                     data = transformer.inverse_transform(
                         data,
                         series_idx=series_idx,
+                        **inv_kw,
                     )
+                    if current_insample is not None:
+                        current_insample = transformer.inverse_transform(
+                            current_insample, series_idx=series_idx
+                        )
             return data
 
     @property

--- a/darts/dataprocessing/transformers/base_data_transformer.py
+++ b/darts/dataprocessing/transformers/base_data_transformer.py
@@ -66,6 +66,7 @@ class BaseDataTransformer(ABC):
         parallel_params: bool | Sequence[str] = False,
         mask_components: bool = True,
         columns: str | list[str] | None = None,
+        uses_insample: bool = False,
     ):
         """Abstract class for data transformers.
 
@@ -131,6 +132,12 @@ class BaseDataTransformer(ABC):
             to transform. If specified, only these components will be transformed, and the remaining
             components will be kept untouched. If `None`, all components are transformed. Note that
             if `columns` is provided, the `mask_components` attribute must be set to `True`.
+        uses_insample
+            Whether the transformer requires the in-sample (historic) series during inverse transformation.
+            If `True`, `inverse_transform` will use the ``insample`` argument to pass the transformed
+            historic series to `ts_inverse_transform`. This is needed when inverse transforming a partial
+            series (e.g. a forecast) requires information from earlier times (e.g. for
+            :class:`~darts.dataprocessing.transformers.diff.Diff`).
 
         Example
         --------
@@ -177,9 +184,9 @@ class BaseDataTransformer(ABC):
         self._name = name
         self._verbose = verbose
         self._n_jobs = n_jobs
-
         self._mask_components = mask_components
         self._columns = [columns] if isinstance(columns, str) else columns
+        self._uses_insample = uses_insample
 
     def set_verbose(self, value: bool):
         """Set the verbosity status.

--- a/darts/dataprocessing/transformers/boxcox.py
+++ b/darts/dataprocessing/transformers/boxcox.py
@@ -181,7 +181,10 @@ class BoxCox(FittableDataTransformer, InvertibleDataTransformer):
 
     @staticmethod
     def ts_inverse_transform(
-        series: TimeSeries, params: Mapping[str, Any], **kwargs
+        series: TimeSeries,
+        params: Mapping[str, Any],
+        insample: TimeSeries | None = None,
+        **kwargs,
     ) -> TimeSeries:
         lmbda = params["fitted"]
 

--- a/darts/dataprocessing/transformers/diff.py
+++ b/darts/dataprocessing/transformers/diff.py
@@ -100,6 +100,7 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
          [ nan]
          [ -9.]
          [-22.]]
+
         References
         ----------
         .. [1] https://otexts.com/fpp2/stationarity.html
@@ -122,6 +123,7 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
             verbose=verbose,
             mask_components=False,
             columns=columns,
+            uses_insample=True,
         )
 
     @staticmethod
@@ -173,48 +175,11 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
     def ts_inverse_transform(
         series: TimeSeries,
         params: Mapping[str, Any],
+        insample: TimeSeries | None = None,
         **kwargs,
     ) -> TimeSeries:
         lags, dropna = params["fixed"]["_lags"], params["fixed"]["_dropna"]
         start_vals, fit_component_mask, start_time, freq = params["fitted"]
-        insample = params.get("insample")
-        n_forecast_output = None
-        forecast_start = series.start_time()
-
-        if insample is not None:
-            n_forecast_output = series.n_timesteps
-            if insample.freq != freq:
-                raise_log(
-                    ValueError(
-                        f"`insample` is of frequency {insample.freq}, but "
-                        f"transform was fitted to data of frequency {freq}."
-                    ),
-                    logger,
-                )
-            expected_insample_start = (
-                start_time + sum(lags) * freq if dropna else start_time
-            )
-            if insample.start_time() != expected_insample_start:
-                raise_log(
-                    ValueError(
-                        f"`insample` must start at time {expected_insample_start}; "
-                        f"instead, it starts at time {insample.start_time()}."
-                    ),
-                    logger,
-                )
-            min_end = forecast_start - series.freq
-            if insample.end_time() < min_end:
-                raise_log(
-                    ValueError(
-                        "The `insample` series must start before the series to inverse-transform "
-                        "and extend at least until one time step before the start of that series "
-                        f"(need `insample.end_time()` >= {min_end}, got {insample.end_time()})."
-                    ),
-                    logger,
-                )
-            insample_trim = insample.drop_after(min_end, keep_point=True)
-            series = insample_trim.append(series)
-
         if series.freq != freq:
             raise_log(
                 ValueError(
@@ -223,13 +188,20 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
                 ),
                 logger,
             )
+
+        # if given, add the historic part of `insample` to the `series`
+        series, n_forecast_output = InvertibleDataTransformer._maybe_prepend_insample(
+            series=series,
+            insample=insample,
+        )
+
         # Start dates 'missing' from differenced series if dropna = True, so need to shift forward:
         expected_start = start_time + sum(lags) * series.freq if dropna else start_time
         if series.start_time() != expected_start:
             raise_log(
                 ValueError(
-                    f"Expected series to begin at time {expected_start}; "
-                    f"instead, it begins at time {series.start_time()}."
+                    f"Expected the {'`insample` series' if n_forecast_output else '`series`'} "
+                    f"to begin at time {expected_start}; instead, it begins at time {series.start_time()}."
                 ),
                 logger,
             )
@@ -291,5 +263,5 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
             **series._attrs,
         )
         if n_forecast_output is not None:
-            result = result.slice_n_points_after(forecast_start, n_forecast_output)
+            result = result[-n_forecast_output:]
         return result

--- a/darts/dataprocessing/transformers/diff.py
+++ b/darts/dataprocessing/transformers/diff.py
@@ -100,7 +100,6 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
          [ nan]
          [ -9.]
          [-22.]]
-
         References
         ----------
         .. [1] https://otexts.com/fpp2/stationarity.html
@@ -178,6 +177,44 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
     ) -> TimeSeries:
         lags, dropna = params["fixed"]["_lags"], params["fixed"]["_dropna"]
         start_vals, fit_component_mask, start_time, freq = params["fitted"]
+        insample = params.get("insample")
+        n_forecast_output = None
+        forecast_start = series.start_time()
+
+        if insample is not None:
+            n_forecast_output = series.n_timesteps
+            if insample.freq != freq:
+                raise_log(
+                    ValueError(
+                        f"`insample` is of frequency {insample.freq}, but "
+                        f"transform was fitted to data of frequency {freq}."
+                    ),
+                    logger,
+                )
+            expected_insample_start = (
+                start_time + sum(lags) * freq if dropna else start_time
+            )
+            if insample.start_time() != expected_insample_start:
+                raise_log(
+                    ValueError(
+                        f"`insample` must start at time {expected_insample_start}; "
+                        f"instead, it starts at time {insample.start_time()}."
+                    ),
+                    logger,
+                )
+            min_end = forecast_start - series.freq
+            if insample.end_time() < min_end:
+                raise_log(
+                    ValueError(
+                        "The `insample` series must start before the series to inverse-transform "
+                        "and extend at least until one time step before the start of that series "
+                        f"(need `insample.end_time()` >= {min_end}, got {insample.end_time()})."
+                    ),
+                    logger,
+                )
+            insample_trim = insample.drop_after(min_end, keep_point=True)
+            series = insample_trim.append(series)
+
         if series.freq != freq:
             raise_log(
                 ValueError(
@@ -246,10 +283,13 @@ class Diff(FittableDataTransformer, InvertibleDataTransformer):
                 to_undiff[i::lag, :, :] = np.cumsum(to_undiff[i::lag, :, :], axis=0)
             vals[cutoff:, :, :] = to_undiff
         vals = Diff.unapply_component_mask(series, vals, component_mask)
-        return TimeSeries(
+        result = TimeSeries(
             times=series.time_index,
             values=vals,
             components=series.components,
             copy=False,
             **series._attrs,
         )
+        if n_forecast_output is not None:
+            result = result.slice_n_points_after(forecast_start, n_forecast_output)
+        return result

--- a/darts/dataprocessing/transformers/fittable_data_transformer.py
+++ b/darts/dataprocessing/transformers/fittable_data_transformer.py
@@ -31,6 +31,7 @@ class FittableDataTransformer(BaseDataTransformer):
         mask_components: bool = True,
         columns: str | list[str] | None = None,
         global_fit: bool = False,
+        uses_insample: bool = False,
     ):
         """Base class for fittable transformers.
 
@@ -80,6 +81,12 @@ class FittableDataTransformer(BaseDataTransformer):
             and a single set of parameters is fitted using all provided `TimeSeries`. If `False`, then
             each `TimeSeries` is individually passed to `ts_fit`, and a different set of fitted parameters
             if yielded for each of these fitting operations. See `ts_fit` for further details.
+        uses_insample
+            Whether the transformer requires the in-sample (historic) series during inverse transformation.
+            If `True`, `inverse_transform` will use the ``insample`` argument to pass the transformed
+            historic series to `ts_inverse_transform`. This is needed when inverse transforming a partial
+            series (e.g. a forecast) requires information from earlier times (e.g. for
+            :class:`~darts.dataprocessing.transformers.diff.Diff`).
 
         Notes
         -----
@@ -154,6 +161,7 @@ class FittableDataTransformer(BaseDataTransformer):
             parallel_params=parallel_params,
             mask_components=mask_components,
             columns=columns,
+            uses_insample=uses_insample,
         )
 
         self._fit_called = False

--- a/darts/dataprocessing/transformers/invertible_data_transformer.py
+++ b/darts/dataprocessing/transformers/invertible_data_transformer.py
@@ -30,6 +30,7 @@ class InvertibleDataTransformer(BaseDataTransformer):
         parallel_params: bool | Sequence[str] = False,
         mask_components: bool = True,
         columns: str | list[str] | None = None,
+        uses_insample: bool = False,
     ):
         """Abstract class for invertible transformers.
 
@@ -82,6 +83,12 @@ class InvertibleDataTransformer(BaseDataTransformer):
             If specified, only these components will be transformed, and the remaining components will be kept
             untouched. For more information refer to the `BaseDataTransformer` documentation. In case the transformer
             is applied on multiple TimeSeries, it is expected that all series have the same column order.
+        uses_insample
+            Whether the transformer requires the in-sample (historic) series during inverse transformation.
+            If `True`, `inverse_transform` will use the ``insample`` argument to pass the transformed
+            historic series to `ts_inverse_transform`. This is needed when inverse transforming a partial
+            series (e.g. a forecast) requires information from earlier times (e.g. for
+            :class:`~darts.dataprocessing.transformers.diff.Diff`).
 
         Notes
         -----
@@ -144,6 +151,7 @@ class InvertibleDataTransformer(BaseDataTransformer):
             parallel_params=parallel_params,
             mask_components=mask_components,
             columns=columns,
+            uses_insample=uses_insample,
         )
 
     @classmethod
@@ -155,7 +163,9 @@ class InvertibleDataTransformer(BaseDataTransformer):
     @staticmethod
     @abstractmethod
     def ts_inverse_transform(
-        series: TimeSeries, params: Mapping[str, Any]
+        series: TimeSeries,
+        params: Mapping[str, Any],
+        insample: TimeSeries | None = None,
     ) -> TimeSeries:
         """The function that will be applied to each series when :func:`inverse_transform` is called.
 
@@ -210,6 +220,11 @@ class InvertibleDataTransformer(BaseDataTransformer):
             inherits from the `FittableDataTransformer` class, then the fitted parameters of the
             transformation (i.e. the values returned by `ts_fit`) are stored under the
             `'fitted'` key.
+        insample
+            Optionally, the transformed historic (insample) part of ``series``. This can be used when ``series`` is
+            only a tail (for example a forecast) and inverse transforming requires information from earlier times
+            (for example the :class:`~darts.dataprocessing.transformers.diff.Diff` transformer). Only used by
+            transformers that require information from earlier times.
         args
             Any additional keyword arguments provided to `inverse_transform`.
         kwargs
@@ -234,7 +249,7 @@ class InvertibleDataTransformer(BaseDataTransformer):
         series_idx: int | Sequence[int] | None = None,
         insample: TimeSeriesLike | None = None,
         **kwargs,
-    ) -> TimeSeries | list[TimeSeries] | list[list[TimeSeries]]:
+    ) -> TimeSeriesLike | Sequence[Sequence[TimeSeries]]:
         """Inverse transforms a (sequence of) series by calling the user-implemented `ts_inverse_transform` method.
 
         In case a sequence or list of lists is passed as input data, this function takes care of parallelising the
@@ -265,10 +280,13 @@ class InvertibleDataTransformer(BaseDataTransformer):
             Optionally, the index(es) of each series corresponding to their positions within the series used to fit
             the transformer (to retrieve the appropriate transformer parameters).
         insample
-            Transformed target history in the same representation as ``series`` (omit with ``None``, the default).
-            Match how ``series`` is grouped: one ``TimeSeries``, one per series in a sequence, or one per outer group
-            for nested list-of-lists; a single ``TimeSeries`` may be given and is reused for each. Only
-            :class:`~darts.dataprocessing.transformers.Diff` uses this argument; other transformers ignore it.
+            Optionally, the transformed historic (insample) part of ``series``. This can be used when ``series`` is
+            only a tail (for example a forecast) and inverse transforming requires information from earlier times
+            (for example the :class:`~darts.dataprocessing.transformers.diff.Diff` transformer). Each ``insample``
+            series must start before the ``series`` start time and extend at least until one step before the start time
+            of the ``series``. If ``series`` is a ``Sequence[Sequence[TimeSeries]]``, then ``insample`` should be a
+            ``Sequence[TimeSeries]`` with the same length. Otherwise, it should have the same type as ``series``. Only
+            used by transformers that require information from earlier times.
         kwargs
             Additional keyword arguments for the :func:`ts_inverse_transform()` method
 
@@ -303,6 +321,22 @@ class InvertibleDataTransformer(BaseDataTransformer):
 
         desc = f"Inverse ({self._name})"
 
+        if self._uses_insample and insample is not None:
+            insample = [insample] if isinstance(insample, TimeSeries) else insample
+            outer_len = 1 if isinstance(series, TimeSeries) else len(series)
+            if len(insample) != outer_len:
+                raise_log(
+                    ValueError(
+                        f"`insample` must have the same number of TimeSeries as `series` "
+                        f"(expected {outer_len}, got {len(insample)})."
+                    ),
+                    logger=logger,
+                )
+            use_insample = True
+        else:
+            insample = None
+            use_insample = False
+
         # Take note of original input for unmasking purposes:
         called_with_single_series = False
         called_with_sequence_series = False
@@ -313,6 +347,7 @@ class InvertibleDataTransformer(BaseDataTransformer):
                 transformer_selector = self._process_series_idx(series_idx)
             else:
                 transformer_selector = [0]
+            insample_list = insample if use_insample else [None]
             called_with_single_series = True
         elif isinstance(series[0], TimeSeries):  # Sequence[TimeSeries]
             data = series
@@ -320,10 +355,12 @@ class InvertibleDataTransformer(BaseDataTransformer):
                 transformer_selector = self._process_series_idx(series_idx)
             else:
                 transformer_selector = range(len(series))
+            insample_list = insample if use_insample else [None] * len(series)
             called_with_sequence_series = True
         else:  # Sequence[Sequence[TimeSeries]]
             data = []
             transformer_selector = []
+            insample_list = []
             if series_specified:
                 iterator_ = zip(self._process_series_idx(series_idx), series)
             else:
@@ -331,39 +368,18 @@ class InvertibleDataTransformer(BaseDataTransformer):
             for idx, series_list in iterator_:
                 data.extend(series_list)
                 transformer_selector += [idx] * len(series_list)
-
-        if insample is None:
-            insample_list = [None] * len(data)
-        else:
-            insample_seq = (
-                [insample] if isinstance(insample, TimeSeries) else list(insample)
-            )
-            outer_len = (
-                1 if called_with_single_series else max(transformer_selector) + 1
-            )
-            if len(insample_seq) != outer_len:
-                raise_log(
-                    ValueError(
-                        f"`insample` must have the same outer length as `series` "
-                        f"(expected {outer_len}, got {len(insample_seq)})."
-                    ),
-                    logger=logger,
+                insample_list += [insample[idx] if use_insample else None] * len(
+                    series_list
                 )
-            insample_list = [insample_seq[idx] for idx in transformer_selector]
 
         input_iterator = _build_tqdm_iterator(
             zip(
                 data,
-                (
-                    {**(p or {}), "insample": ins}
-                    for p, ins in zip(
-                        self._get_params(
-                            transformer_selector=transformer_selector,
-                            series_specified=series_specified,
-                        ),
-                        insample_list,
-                    )
+                self._get_params(
+                    transformer_selector=transformer_selector,
+                    series_specified=series_specified,
                 ),
+                insample_list,
             ),
             verbose=self._verbose,
             desc=desc,
@@ -399,3 +415,47 @@ class InvertibleDataTransformer(BaseDataTransformer):
                 transformed_data[cum_len[i] : cum_len[i + 1]]
                 for i in range(len(cum_len) - 1)
             ]
+
+    @staticmethod
+    def _maybe_prepend_insample(
+        series: TimeSeries,
+        insample: TimeSeries | None = None,
+    ) -> tuple[TimeSeries, int]:
+        """Prepend the historic part of the `insample` series to the `series` if it is not None."""
+        if insample is None:
+            return series, 0
+
+        # when ``insample`` is set, it is the transformed insample data of `series`
+        freq = series.freq
+        n_forecast_output = len(series)
+        forecast_start = series.start_time()
+        if insample.freq != series.freq:
+            raise_log(
+                ValueError(
+                    f"`insample` is of frequency {insample.freq}, but "
+                    f"transform was fitted to data of frequency {freq}."
+                ),
+                logger,
+            )
+        if insample.start_time() >= forecast_start:
+            raise_log(
+                ValueError(
+                    f"`insample` must start before the `series` start time."
+                    f"Expected `insample.start_time()` <= {forecast_start}, "
+                    f"got {insample.start_time()}."
+                ),
+                logger,
+            )
+        expected_end = forecast_start - freq
+        if insample.end_time() < expected_end:
+            raise_log(
+                ValueError(
+                    "The `insample` series must start before the series to inverse-transform "
+                    "and extend at least until one time step before the start of that series. "
+                    f"Expected `insample.end_time()` >= {expected_end}, "
+                    f"got {insample.end_time()}."
+                ),
+                logger,
+            )
+        series = insample[:expected_end].append(series)
+        return series, n_forecast_output

--- a/darts/dataprocessing/transformers/invertible_data_transformer.py
+++ b/darts/dataprocessing/transformers/invertible_data_transformer.py
@@ -232,6 +232,7 @@ class InvertibleDataTransformer(BaseDataTransformer):
         *args,
         component_mask: np.ndarray | None = None,
         series_idx: int | Sequence[int] | None = None,
+        insample: TimeSeriesLike | None = None,
         **kwargs,
     ) -> TimeSeries | list[TimeSeries] | list[list[TimeSeries]]:
         """Inverse transforms a (sequence of) series by calling the user-implemented `ts_inverse_transform` method.
@@ -263,6 +264,11 @@ class InvertibleDataTransformer(BaseDataTransformer):
         series_idx
             Optionally, the index(es) of each series corresponding to their positions within the series used to fit
             the transformer (to retrieve the appropriate transformer parameters).
+        insample
+            Transformed target history in the same representation as ``series`` (omit with ``None``, the default).
+            Match how ``series`` is grouped: one ``TimeSeries``, one per series in a sequence, or one per outer group
+            for nested list-of-lists; a single ``TimeSeries`` may be given and is reused for each. Only
+            :class:`~darts.dataprocessing.transformers.Diff` uses this argument; other transformers ignore it.
         kwargs
             Additional keyword arguments for the :func:`ts_inverse_transform()` method
 
@@ -326,12 +332,37 @@ class InvertibleDataTransformer(BaseDataTransformer):
                 data.extend(series_list)
                 transformer_selector += [idx] * len(series_list)
 
+        if insample is None:
+            insample_list = [None] * len(data)
+        else:
+            insample_seq = (
+                [insample] if isinstance(insample, TimeSeries) else list(insample)
+            )
+            outer_len = (
+                1 if called_with_single_series else max(transformer_selector) + 1
+            )
+            if len(insample_seq) != outer_len:
+                raise_log(
+                    ValueError(
+                        f"`insample` must have the same outer length as `series` "
+                        f"(expected {outer_len}, got {len(insample_seq)})."
+                    ),
+                    logger=logger,
+                )
+            insample_list = [insample_seq[idx] for idx in transformer_selector]
+
         input_iterator = _build_tqdm_iterator(
             zip(
                 data,
-                self._get_params(
-                    transformer_selector=transformer_selector,
-                    series_specified=series_specified,
+                (
+                    {**(p or {}), "insample": ins}
+                    for p, ins in zip(
+                        self._get_params(
+                            transformer_selector=transformer_selector,
+                            series_specified=series_specified,
+                        ),
+                        insample_list,
+                    )
                 ),
             ),
             verbose=self._verbose,

--- a/darts/dataprocessing/transformers/mappers.py
+++ b/darts/dataprocessing/transformers/mappers.py
@@ -151,6 +151,8 @@ class InvertibleMapper(InvertibleDataTransformer):
 
     @staticmethod
     def ts_inverse_transform(
-        series: TimeSeries, params: Mapping[str, Mapping[str, MapperFn]]
+        series: TimeSeries,
+        params: Mapping[str, Mapping[str, MapperFn]],
+        insample: TimeSeries | None = None,
     ) -> TimeSeries:
         return series.map(params["fixed"]["_inverse_fn"])

--- a/darts/dataprocessing/transformers/midas.py
+++ b/darts/dataprocessing/transformers/midas.py
@@ -322,6 +322,7 @@ class MIDAS(FittableDataTransformer, InvertibleDataTransformer):
     def ts_inverse_transform(
         series: TimeSeries,
         params: Mapping[str, Any],
+        insample: TimeSeries | None = None,
     ) -> TimeSeries:
         """
         Transforms series back to high frequency by retrieving the original high frequency and reshaping the values.

--- a/darts/dataprocessing/transformers/scaler.py
+++ b/darts/dataprocessing/transformers/scaler.py
@@ -145,7 +145,10 @@ class Scaler(FittableDataTransformer, InvertibleDataTransformer):
 
     @staticmethod
     def ts_inverse_transform(
-        series: TimeSeries, params: Mapping[str, Any], *args, **kwargs
+        series: TimeSeries,
+        params: Mapping[str, Any],
+        insample: TimeSeries | None = None,
+        **kwargs,
     ) -> TimeSeries:
         transformer = params["fitted"]
 

--- a/darts/dataprocessing/transformers/static_covariates_transformer.py
+++ b/darts/dataprocessing/transformers/static_covariates_transformer.py
@@ -4,7 +4,7 @@ Static Covariates Transformer
 """
 
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
 import numpy as np
@@ -381,7 +381,10 @@ class StaticCovariatesTransformer(FittableDataTransformer, InvertibleDataTransfo
 
     @staticmethod
     def ts_inverse_transform(
-        series: TimeSeries, params: dict[str, Any], *args, **kwargs
+        series: TimeSeries,
+        params: Mapping[str, Any],
+        insample: TimeSeries | None = None,
+        **kwargs,
     ) -> TimeSeries:
         return StaticCovariatesTransformer._transform_static_covs(
             series, params["fitted"], method="inverse_transform"

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -1919,6 +1919,7 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
                         forecasts=fitted_values,
                         data_transformers=data_transformers,
                         series_idx=None,
+                        pass_insample=False,
                     )
                 error = metric(series, fitted_values)
             elif val_series is None:  # expanding window mode

--- a/darts/tests/dataprocessing/test_pipeline.py
+++ b/darts/tests/dataprocessing/test_pipeline.py
@@ -8,6 +8,7 @@ from darts import TimeSeries
 from darts.dataprocessing import Pipeline
 from darts.dataprocessing.transformers import (
     BaseDataTransformer,
+    Diff,
     FittableDataTransformer,
     InvertibleDataTransformer,
     InvertibleMapper,
@@ -15,7 +16,7 @@ from darts.dataprocessing.transformers import (
     Scaler,
 )
 from darts.typing import TimeSeriesLike
-from darts.utils.timeseries_generation import constant_timeseries
+from darts.utils.timeseries_generation import constant_timeseries, linear_timeseries
 
 
 class TestPipeline:
@@ -324,6 +325,41 @@ class TestPipeline:
 
         # then
         assert data == back
+
+    def test_inverse_transform_insample_diff(self):
+        """Pipeline([Diff]) inverse with ``insample`` matches manual prepend + slice."""
+        # given
+        series = linear_timeseries(length=50, start_value=1.0, end_value=5.0)
+        pipeline = Pipeline([Diff(lags=1, dropna=True)])
+        series_tf = pipeline.fit_transform(series)
+        n_forecast = 10
+        insample_tf = series_tf[:-n_forecast]
+        forecast_tf = series_tf[-n_forecast:]
+        diff = pipeline._transformers[0]
+        manual_full = diff.inverse_transform(insample_tf.append(forecast_tf))
+        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
+        # when
+        got = pipeline.inverse_transform(forecast_tf, insample=insample_tf)
+        # then
+        np.testing.assert_array_almost_equal(got.values(), manual.values())
+        assert got.time_index.equals(manual.time_index)
+
+    def test_inverse_transform_insample_scaler_diff(self):
+        """Pipeline([Scaler, Diff]) keeps insample aligned through inverse steps."""
+        # given
+        series = linear_timeseries(length=50, start_value=1.0, end_value=5.0)
+        pipeline = Pipeline([Scaler(), Diff(lags=1, dropna=True)])
+        series_tf = pipeline.fit_transform(series)
+        n_forecast = 10
+        insample_tf = series_tf[:-n_forecast]
+        forecast_tf = series_tf[-n_forecast:]
+        manual_full = pipeline.inverse_transform(insample_tf.append(forecast_tf))
+        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
+        # when
+        got = pipeline.inverse_transform(forecast_tf, insample=insample_tf)
+        # then
+        np.testing.assert_array_almost_equal(got.values(), manual.values())
+        assert got.time_index.equals(manual.time_index)
 
     def test_inverse_transform_prefitted(self):
         """Check that when multiple series are passed to fit transformers with global_fit=False,

--- a/darts/tests/dataprocessing/test_pipeline.py
+++ b/darts/tests/dataprocessing/test_pipeline.py
@@ -53,7 +53,9 @@ class TestPipeline:
 
         @staticmethod
         def ts_inverse_transform(
-            series: TimeSeries, params: Mapping[str, Any]
+            series: TimeSeries,
+            params: Mapping[str, Any],
+            insample: TimeSeries | None = None,
         ) -> TimeSeries:
             return series
 
@@ -84,7 +86,9 @@ class TestPipeline:
 
         @staticmethod
         def ts_inverse_transform(
-            series: TimeSeries, params: Mapping[str, Any]
+            series: TimeSeries,
+            params: Mapping[str, Any],
+            insample: TimeSeries | None = None,
         ) -> TimeSeries:
             return series.map(lambda x: x - 10)
 
@@ -93,14 +97,16 @@ class TestPipeline:
             super().__init__(name="*2 transformer")
 
         @staticmethod
-        def ts_transform(data: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
-            return data.map(lambda x: x * 2)
+        def ts_transform(series: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
+            return series.map(lambda x: x * 2)
 
         @staticmethod
         def ts_inverse_transform(
-            data: TimeSeries, params: Mapping[str, Any]
+            series: TimeSeries,
+            params: Mapping[str, Any],
+            insample: TimeSeries | None = None,
         ) -> TimeSeries:
-            return data.map(lambda x: x / 2)
+            return series.map(lambda x: x / 2)
 
     class ExtendTransformer(FittableDataTransformer, InvertibleDataTransformer):
         def __init__(self, global_fit: bool, coef: int):
@@ -123,14 +129,16 @@ class TestPipeline:
                 return series.values()[0] + coef
 
         @staticmethod
-        def ts_transform(data: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
-            return data + params["fitted"]
+        def ts_transform(series: TimeSeries, params: Mapping[str, Any]) -> TimeSeries:
+            return series + params["fitted"]
 
         @staticmethod
         def ts_inverse_transform(
-            data: TimeSeries, params: Mapping[str, Any]
+            series: TimeSeries,
+            params: Mapping[str, Any],
+            insample: TimeSeries | None = None,
         ) -> TimeSeries:
-            return data - params["fitted"]
+            return series - params["fitted"]
 
     def test_transform(self):
         # given
@@ -329,37 +337,52 @@ class TestPipeline:
     def test_inverse_transform_insample_diff(self):
         """Pipeline([Diff]) inverse with ``insample`` matches manual prepend + slice."""
         # given
+        n_forecast = 10
         series = linear_timeseries(length=50, start_value=1.0, end_value=5.0)
+
         pipeline = Pipeline([Diff(lags=1, dropna=True)])
         series_tf = pipeline.fit_transform(series)
-        n_forecast = 10
+
         insample_tf = series_tf[:-n_forecast]
         forecast_tf = series_tf[-n_forecast:]
-        diff = pipeline._transformers[0]
-        manual_full = diff.inverse_transform(insample_tf.append(forecast_tf))
-        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
-        # when
-        got = pipeline.inverse_transform(forecast_tf, insample=insample_tf)
-        # then
-        np.testing.assert_array_almost_equal(got.values(), manual.values())
-        assert got.time_index.equals(manual.time_index)
 
-    def test_inverse_transform_insample_scaler_diff(self):
+        diff = pipeline._transformers[0]
+        result_manual = diff.inverse_transform(insample_tf.append(forecast_tf))[
+            -n_forecast:
+        ]
+        result_insample = pipeline.inverse_transform(forecast_tf, insample=insample_tf)
+
+        np.testing.assert_array_almost_equal(
+            result_insample.values(), result_manual.values()
+        )
+        assert result_insample.time_index.equals(result_manual.time_index)
+
+    @pytest.mark.parametrize("reverse_order", [False, True])
+    def test_inverse_transform_insample_scaler_diff(self, reverse_order):
         """Pipeline([Scaler, Diff]) keeps insample aligned through inverse steps."""
         # given
-        series = linear_timeseries(length=50, start_value=1.0, end_value=5.0)
-        pipeline = Pipeline([Scaler(), Diff(lags=1, dropna=True)])
-        series_tf = pipeline.fit_transform(series)
         n_forecast = 10
+        series = linear_timeseries(length=50, start_value=1.0, end_value=5.0)
+
+        tfs = [Scaler(), Diff(lags=1, dropna=True)]
+        if reverse_order:
+            tfs = tfs[::-1]
+
+        pipeline = Pipeline(tfs)
+        series_tf = pipeline.fit_transform(series)
+
         insample_tf = series_tf[:-n_forecast]
         forecast_tf = series_tf[-n_forecast:]
-        manual_full = pipeline.inverse_transform(insample_tf.append(forecast_tf))
-        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
-        # when
-        got = pipeline.inverse_transform(forecast_tf, insample=insample_tf)
-        # then
-        np.testing.assert_array_almost_equal(got.values(), manual.values())
-        assert got.time_index.equals(manual.time_index)
+
+        result_manual = pipeline.inverse_transform(insample_tf.append(forecast_tf))[
+            -n_forecast:
+        ]
+        result_insample = pipeline.inverse_transform(forecast_tf, insample=insample_tf)
+
+        np.testing.assert_array_almost_equal(
+            result_insample.values(), result_manual.values()
+        )
+        assert result_insample.time_index.equals(result_manual.time_index)
 
     def test_inverse_transform_prefitted(self):
         """Check that when multiple series are passed to fit transformers with global_fit=False,

--- a/darts/tests/dataprocessing/transformers/test_diff.py
+++ b/darts/tests/dataprocessing/transformers/test_diff.py
@@ -262,6 +262,134 @@ class TestDiff:
             f"has {self.sine_series.n_timesteps} timesteps."
         ) == str(e.value)
 
+    @pytest.mark.parametrize(
+        "lags,dropna",
+        [
+            (1, True),
+            (1, False),
+            ([1, 12], True),
+            ([1, 12], False),
+        ],
+    )
+    def test_diff_inverse_transform_with_insample(self, lags, dropna):
+        """
+        Tests that ``inverse_transform(..., insample=...)`` matches prepending the transformed
+        insample to the forecast in diff space, then slicing the inverse result.
+        """
+        diff = Diff(lags=lags, dropna=dropna)
+        series_tf = diff.fit_transform(self.sine_series)
+        n_forecast = 10
+        insample_tf = series_tf[:-n_forecast]
+        forecast_tf = series_tf[-n_forecast:]
+        expected = self.sine_series[-n_forecast:]
+        manual_full = diff.inverse_transform(insample_tf.append(forecast_tf))
+        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
+        got = diff.inverse_transform(forecast_tf, insample=insample_tf)
+        self.assert_series_equal(expected, got, equal_nan=(not dropna))
+        self.assert_series_equal(manual, got, equal_nan=(not dropna))
+
+    def test_diff_inverse_transform_insample_extends_beyond_fit(self):
+        """
+        Tests ``insample`` that extends beyond the fitted range still inverse-transforms
+        the forecast correctly (trim-before-append logic).
+        """
+        short_sine = self.sine_series.copy().drop_after(10)
+        diff = Diff(lags=1, dropna=True)
+        diff.fit(short_sine)
+        full_tf = diff.transform(self.sine_series)
+        n_forecast = 5
+        insample_tf = full_tf[:-n_forecast]
+        forecast_tf = full_tf[-n_forecast:]
+        expected = self.sine_series[-n_forecast:]
+        got = diff.inverse_transform(forecast_tf, insample=insample_tf)
+        self.assert_series_equal(expected, got, equal_nan=True)
+
+    def test_diff_inverse_transform_insample_errors(self):
+        """
+        Tests validation errors for invalid ``insample`` (start time, length, frequency).
+        """
+        diff = Diff(lags=1, dropna=True)
+        vals = np.random.rand(20, 2)
+        times = pd.date_range(start="2018-01-01", freq="D", periods=20)
+        series = TimeSeries.from_times_and_values(times, vals)
+        series_tf = diff.fit_transform(series)
+        forecast_tf = series_tf[-5:]
+        insample_ok = series_tf[:-5]
+
+        insample_bad_start = insample_ok.with_times_and_values(
+            times=insample_ok.time_index + insample_ok.freq,
+            values=insample_ok.values(),
+        )
+        with pytest.raises(ValueError) as e:
+            diff.inverse_transform(forecast_tf, insample=insample_bad_start)
+        assert "`insample` must start at time" in str(
+            e.value
+        ) and "instead, it starts at time" in str(e.value)
+
+        insample_too_short = insample_ok[: insample_ok.n_timesteps - 2]
+        with pytest.raises(ValueError) as e:
+            diff.inverse_transform(forecast_tf, insample=insample_too_short)
+        assert (
+            "The `insample` series must start before the series to inverse-transform"
+            in str(e.value)
+        )
+
+        insample_bad_freq = TimeSeries.from_times_and_values(
+            values=insample_ok.all_values(copy=False),
+            times=pd.date_range(
+                start=insample_ok.start_time(), freq="W", periods=len(insample_ok)
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            diff.inverse_transform(forecast_tf, insample=insample_bad_freq)
+        assert "`insample` is of frequency" in str(e.value)
+
+    @pytest.mark.parametrize("dropna", [False, True])
+    def test_diff_inverse_transform_with_insample_sine(self, dropna):
+        """
+        ``inverse_transform(..., insample=...)`` on multivariate ``self.sine_series``.
+        """
+        s = self.sine_series
+        diff = Diff(lags=1, dropna=dropna)
+        series_tf = diff.fit_transform(s)
+        n_forecast = 12
+        insample_tf = series_tf[:-n_forecast]
+        forecast_tf = series_tf[-n_forecast:]
+        expected = s[-n_forecast:]
+        manual_full = diff.inverse_transform(insample_tf.append(forecast_tf))
+        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
+        got = diff.inverse_transform(forecast_tf, insample=insample_tf)
+        self.assert_series_equal(expected, got, equal_nan=(not dropna))
+        self.assert_series_equal(manual, got, equal_nan=(not dropna))
+
+    @pytest.mark.parametrize("dropna", [False, True])
+    def test_diff_inverse_transform_with_insample_nested_sequence(self, dropna):
+        """
+        ``inverse_transform(..., insample=...)`` with nested ``Sequence[Sequence[TimeSeries]]``:
+        two outer groups (fit on two series) and multiple inner forecast chunks.
+        """
+        s = self.sine_series
+        n1, n2, n3 = 8, 6, 7
+        diff_n = Diff(lags=1, dropna=dropna)
+        tf = diff_n.fit_transform([s, s])
+        fc1, fc2 = tf[0][-(n1 + n2) : -n2], tf[0][-n2:]
+        fc3 = tf[1][-n3:]
+        insample_nested = [tf[0][:-n2], tf[1][:-n3]]
+        nested = [[fc1, fc2], [fc3]]
+        got_nested = diff_n.inverse_transform(nested, insample=insample_nested)
+        # Manual baselines: ``fc1`` lies inside ``tf[0][:-n2]``, so use a shorter prefix for ``fc1`` only.
+        for i, j, fc, ins_m in (
+            (0, 0, fc1, tf[0][: -(n1 + n2)]),
+            (0, 1, fc2, tf[0][:-n2]),
+            (1, 0, fc3, tf[1][:-n3]),
+        ):
+            manual_ij = diff_n.inverse_transform(fc, insample=ins_m)
+            expected_ij = s.slice_n_points_after(fc.start_time(), fc.n_timesteps)
+            self.assert_series_equal(expected_ij, manual_ij, equal_nan=(not dropna))
+            self.assert_series_equal(
+                manual_ij, got_nested[i][j], equal_nan=(not dropna)
+            )
+
     def test_diff_incompatible_inverse_transform_date(self):
         """
         Tests that `Diff` throws error when given series to `inverse_transform`

--- a/darts/tests/dataprocessing/transformers/test_diff.py
+++ b/darts/tests/dataprocessing/transformers/test_diff.py
@@ -276,33 +276,40 @@ class TestDiff:
         Tests that ``inverse_transform(..., insample=...)`` matches prepending the transformed
         insample to the forecast in diff space, then slicing the inverse result.
         """
+        n_forecast = 10
+
         diff = Diff(lags=lags, dropna=dropna)
         series_tf = diff.fit_transform(self.sine_series)
-        n_forecast = 10
+
         insample_tf = series_tf[:-n_forecast]
         forecast_tf = series_tf[-n_forecast:]
         expected = self.sine_series[-n_forecast:]
-        manual_full = diff.inverse_transform(insample_tf.append(forecast_tf))
-        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
-        got = diff.inverse_transform(forecast_tf, insample=insample_tf)
-        self.assert_series_equal(expected, got, equal_nan=(not dropna))
-        self.assert_series_equal(manual, got, equal_nan=(not dropna))
+
+        result_full_series = diff.inverse_transform(series_tf)[-n_forecast:]
+        result_insample = diff.inverse_transform(forecast_tf, insample=insample_tf)
+
+        self.assert_series_equal(expected, result_insample, equal_nan=(not dropna))
+        self.assert_series_equal(expected, result_full_series, equal_nan=(not dropna))
 
     def test_diff_inverse_transform_insample_extends_beyond_fit(self):
         """
         Tests ``insample`` that extends beyond the fitted range still inverse-transforms
         the forecast correctly (trim-before-append logic).
         """
+        n_forecast = 5
         short_sine = self.sine_series.copy().drop_after(10)
+
         diff = Diff(lags=1, dropna=True)
         diff.fit(short_sine)
         full_tf = diff.transform(self.sine_series)
-        n_forecast = 5
-        insample_tf = full_tf[:-n_forecast]
+
+        # insample end intersects with `series`
+        insample_tf = full_tf[: -(n_forecast - 1)]
         forecast_tf = full_tf[-n_forecast:]
+
         expected = self.sine_series[-n_forecast:]
-        got = diff.inverse_transform(forecast_tf, insample=insample_tf)
-        self.assert_series_equal(expected, got, equal_nan=True)
+        result = diff.inverse_transform(forecast_tf, insample=insample_tf)
+        self.assert_series_equal(expected, result, equal_nan=True)
 
     def test_diff_inverse_transform_insample_errors(self):
         """
@@ -316,23 +323,15 @@ class TestDiff:
         forecast_tf = series_tf[-5:]
         insample_ok = series_tf[:-5]
 
-        insample_bad_start = insample_ok.with_times_and_values(
-            times=insample_ok.time_index + insample_ok.freq,
-            values=insample_ok.values(),
-        )
+        insample_bad_start = insample_ok[1:]
         with pytest.raises(ValueError) as e:
             diff.inverse_transform(forecast_tf, insample=insample_bad_start)
-        assert "`insample` must start at time" in str(
-            e.value
-        ) and "instead, it starts at time" in str(e.value)
+        assert "Expected the `insample` series to begin at time" in str(e.value)
 
-        insample_too_short = insample_ok[: insample_ok.n_timesteps - 2]
+        insample_too_short = insample_ok[:-1]
         with pytest.raises(ValueError) as e:
             diff.inverse_transform(forecast_tf, insample=insample_too_short)
-        assert (
-            "The `insample` series must start before the series to inverse-transform"
-            in str(e.value)
-        )
+        assert "extend at least until one time step before" in str(e.value)
 
         insample_bad_freq = TimeSeries.from_times_and_values(
             values=insample_ok.all_values(copy=False),
@@ -345,49 +344,36 @@ class TestDiff:
         assert "`insample` is of frequency" in str(e.value)
 
     @pytest.mark.parametrize("dropna", [False, True])
-    def test_diff_inverse_transform_with_insample_sine(self, dropna):
-        """
-        ``inverse_transform(..., insample=...)`` on multivariate ``self.sine_series``.
-        """
-        s = self.sine_series
-        diff = Diff(lags=1, dropna=dropna)
-        series_tf = diff.fit_transform(s)
-        n_forecast = 12
-        insample_tf = series_tf[:-n_forecast]
-        forecast_tf = series_tf[-n_forecast:]
-        expected = s[-n_forecast:]
-        manual_full = diff.inverse_transform(insample_tf.append(forecast_tf))
-        manual = manual_full.slice_n_points_after(forecast_tf.start_time(), n_forecast)
-        got = diff.inverse_transform(forecast_tf, insample=insample_tf)
-        self.assert_series_equal(expected, got, equal_nan=(not dropna))
-        self.assert_series_equal(manual, got, equal_nan=(not dropna))
-
-    @pytest.mark.parametrize("dropna", [False, True])
     def test_diff_inverse_transform_with_insample_nested_sequence(self, dropna):
         """
         ``inverse_transform(..., insample=...)`` with nested ``Sequence[Sequence[TimeSeries]]``:
         two outer groups (fit on two series) and multiple inner forecast chunks.
         """
-        s = self.sine_series
-        n1, n2, n3 = 8, 6, 7
+        s1, s2 = self.sine_series, self.sine_series / 10.0
         diff_n = Diff(lags=1, dropna=dropna)
-        tf = diff_n.fit_transform([s, s])
-        fc1, fc2 = tf[0][-(n1 + n2) : -n2], tf[0][-n2:]
-        fc3 = tf[1][-n3:]
-        insample_nested = [tf[0][:-n2], tf[1][:-n3]]
-        nested = [[fc1, fc2], [fc3]]
-        got_nested = diff_n.inverse_transform(nested, insample=insample_nested)
-        # Manual baselines: ``fc1`` lies inside ``tf[0][:-n2]``, so use a shorter prefix for ``fc1`` only.
-        for i, j, fc, ins_m in (
-            (0, 0, fc1, tf[0][: -(n1 + n2)]),
-            (0, 1, fc2, tf[0][:-n2]),
-            (1, 0, fc3, tf[1][:-n3]),
+        tf = diff_n.fit_transform([s1, s2])
+
+        fc1, fc2 = tf[0][-14:-6], tf[0][-6:]
+        fc3 = tf[1][-7:]
+
+        insample = tf
+        fc_nested = [[fc1, fc2], [fc3]]
+
+        result_insample = diff_n.inverse_transform(fc_nested, insample=insample)
+        # Manual baselines: ``fc1`` lies inside ``tf[0][:-6]``, so use a shorter prefix for ``fc1`` only.
+        for i, j, fc, expected_ij, ins_m in (
+            (0, 0, fc1, s1[-14:-6], tf[0][:-14]),
+            (0, 1, fc2, s1[-6:], tf[0][:-6]),
+            (1, 0, fc3, s2[-7:], tf[1][:-7]),
         ):
-            manual_ij = diff_n.inverse_transform(fc, insample=ins_m)
-            expected_ij = s.slice_n_points_after(fc.start_time(), fc.n_timesteps)
-            self.assert_series_equal(expected_ij, manual_ij, equal_nan=(not dropna))
+            result_insample_ij = diff_n.inverse_transform(
+                fc, insample=ins_m, series_idx=i
+            )
             self.assert_series_equal(
-                manual_ij, got_nested[i][j], equal_nan=(not dropna)
+                expected_ij, result_insample_ij, equal_nan=(not dropna)
+            )
+            self.assert_series_equal(
+                expected_ij, result_insample[i][j], equal_nan=(not dropna)
             )
 
     def test_diff_incompatible_inverse_transform_date(self):
@@ -414,7 +400,7 @@ class TestDiff:
                 else series1.start_time() + series1.freq
             )
             assert (
-                f"Expected series to begin at time {expected_start}; "
+                f"Expected the `series` to begin at time {expected_start}; "
                 f"instead, it begins at time {series2_diffed.start_time()}."
             ) == str(e.value)
 

--- a/darts/tests/dataprocessing/transformers/test_diff.py
+++ b/darts/tests/dataprocessing/transformers/test_diff.py
@@ -323,15 +323,24 @@ class TestDiff:
         forecast_tf = series_tf[-5:]
         insample_ok = series_tf[:-5]
 
-        insample_bad_start = insample_ok[1:]
         with pytest.raises(ValueError) as e:
-            diff.inverse_transform(forecast_tf, insample=insample_bad_start)
+            diff.inverse_transform(forecast_tf, insample=forecast_tf)
+        assert "`insample` must start before the `series` start time." in str(e.value)
+        "`insample` must start before the `series` start time."
+
+        with pytest.raises(ValueError) as e:
+            diff.inverse_transform(forecast_tf, insample=insample_ok[1:])
         assert "Expected the `insample` series to begin at time" in str(e.value)
 
-        insample_too_short = insample_ok[:-1]
         with pytest.raises(ValueError) as e:
-            diff.inverse_transform(forecast_tf, insample=insample_too_short)
+            diff.inverse_transform(forecast_tf, insample=insample_ok[:-1])
         assert "extend at least until one time step before" in str(e.value)
+
+        with pytest.raises(ValueError) as e:
+            diff.inverse_transform(forecast_tf, insample=[insample_ok, insample_ok])
+        assert "`insample` must have the same number of TimeSeries as `series`" in str(
+            e.value
+        )
 
         insample_bad_freq = TimeSeries.from_times_and_values(
             values=insample_ok.all_values(copy=False),

--- a/darts/tests/dataprocessing/transformers/test_invertible_data_transformer.py
+++ b/darts/tests/dataprocessing/transformers/test_invertible_data_transformer.py
@@ -105,7 +105,10 @@ class TestInvertibleDataTransformer:
 
         @staticmethod
         def ts_inverse_transform(
-            series: TimeSeries, params: Mapping[str, Any], **kwargs
+            series: TimeSeries,
+            params: Mapping[str, Any],
+            insample: TimeSeries | None = None,
+            **kwargs,
         ) -> TimeSeries:
             """
             Implements the inverse transform `(series - translation) / scale`.

--- a/darts/tests/dataprocessing/transformers/test_invertible_fittable_data_transformer.py
+++ b/darts/tests/dataprocessing/transformers/test_invertible_fittable_data_transformer.py
@@ -494,6 +494,32 @@ class TestLocalFittableInvertibleDataTransformer:
         inv = mock.inverse_transform(transformed, component_mask=mask)
         assert inv == test_input
 
+    def test_inverse_tf_on_nested_series_with_series_idx(self):
+        """
+        Tests for correct (inverse) transformation for nested lists of input series with `series_idx`.
+        """
+        inp_1 = constant_timeseries(value=1, length=10)
+        inp_2 = constant_timeseries(value=2, length=10)
+
+        mock = self.DataTransformerMock(scale=2, translation=10)
+
+        tf_1, tf_2 = mock.fit_transform([inp_1, inp_2])
+
+        nested_inp = [[tf_1[1:], tf_1[2:]], [tf_2[1:]]]
+        inv_tf_direct = mock.inverse_transform(nested_inp)
+        inv_tf_direct_reversed = mock.inverse_transform(
+            nested_inp[::-1], series_idx=[1, 0]
+        )[::-1]
+        inv_tf_separate = [
+            mock.inverse_transform([nested_inp[idx]], series_idx=idx)[0]
+            for idx in range(2)
+        ]
+        assert inv_tf_direct == inv_tf_direct_reversed
+        assert inv_tf_separate == inv_tf_direct
+        assert inv_tf_separate[0][0] == inp_1[1:]
+        assert inv_tf_separate[0][1] == inp_1[2:]
+        assert inv_tf_separate[1][0] == inp_2[1:]
+
 
 class TestGlobalFittableInvertibleDataTransformer:
     """

--- a/darts/tests/dataprocessing/transformers/test_invertible_fittable_data_transformer.py
+++ b/darts/tests/dataprocessing/transformers/test_invertible_fittable_data_transformer.py
@@ -136,7 +136,10 @@ class TestLocalFittableInvertibleDataTransformer:
 
         @staticmethod
         def ts_inverse_transform(
-            series: TimeSeries, params: Mapping[str, Any], **kwargs
+            series: TimeSeries,
+            params: Mapping[str, Any],
+            insample: TimeSeries | None = None,
+            **kwargs,
         ) -> TimeSeries:
             """
             Implements the inverse transform `(series - translation) / scale`.
@@ -560,11 +563,12 @@ class TestGlobalFittableInvertibleDataTransformer:
 
         @staticmethod
         def ts_inverse_transform(
-            series: TimeSeries, params: Mapping[str, Any], **kwargs
+            series: TimeSeries,
+            params: Mapping[str, Any],
+            insample: TimeSeries | None = None,
+            **kwargs,
         ) -> TimeSeries:
-            """
-            Implements the inverse transform `series + mean`.
-            """
+            """Implements the inverse transform `series + mean`."""
             mean = params["fitted"]
             vals = series.all_values()
             vals += mean

--- a/darts/utils/historical_forecasts/utils.py
+++ b/darts/utils/historical_forecasts/utils.py
@@ -1434,26 +1434,31 @@ def _apply_data_transformers(
 
 def _apply_inverse_data_transformers(
     series: TimeSeriesLike,
-    forecasts: TimeSeries | list[TimeSeries] | list[list[TimeSeries]],
+    forecasts: TimeSeriesLike | Sequence[Sequence[TimeSeries]],
     data_transformers: dict[str, Pipeline],
     series_idx: int | None = None,
-    *,
     pass_insample: bool = True,
-) -> TimeSeries | list[TimeSeries] | list[list[TimeSeries]]:
+) -> TimeSeriesLike | Sequence[Sequence[TimeSeries]]:
     """
-    Apply the inverse transform to the forecasts when defined.
+    If a preprocessing pipeline is registered under ``"series"`` and can be reversed, convert ``forecasts`` from
+    preprocessed form back to the original one; if not, leave ``forecasts`` as they are.
 
-    `series_idx` is used to retrieve the appropriate transformer when the data transformer was
-    fitted with several series and global_fit=False.
+    ``pass_insample`` (default ``True``): also hand the (already transformed) training target ``series`` to that
+    reverse step, so a **short** forecast can be turned back correctly when the method needs recent history (as with
+    :class:`~darts.dataprocessing.transformers.diff.Diff`). Set it to ``False`` when ``forecasts`` is a **full-length**
+    series that already contains everything needed to invert (for example in-sample fitted values). Only the
+    ``"series"`` pipeline is inverted; other keys in ``data_transformers`` are unchanged. Arguments line up with
+    :meth:`~darts.dataprocessing.pipeline.Pipeline.inverse_transform`.
     """
     if "series" in data_transformers and data_transformers["series"].invertible:
         called_with_single_series = get_series_seq_type(series) == SeriesType.SINGLE
         if called_with_single_series:
             forecasts = [forecasts]
-        inv_kw = {"series_idx": series_idx}
-        if pass_insample:
-            inv_kw["insample"] = series
-        forecasts = data_transformers["series"].inverse_transform(forecasts, **inv_kw)
+        forecasts = data_transformers["series"].inverse_transform(
+            data=forecasts,
+            series_idx=series_idx,
+            insample=series if pass_insample else None,
+        )
         return forecasts[0] if called_with_single_series else forecasts
     else:
         return forecasts

--- a/darts/utils/historical_forecasts/utils.py
+++ b/darts/utils/historical_forecasts/utils.py
@@ -1437,6 +1437,8 @@ def _apply_inverse_data_transformers(
     forecasts: TimeSeries | list[TimeSeries] | list[list[TimeSeries]],
     data_transformers: dict[str, Pipeline],
     series_idx: int | None = None,
+    *,
+    pass_insample: bool = True,
 ) -> TimeSeries | list[TimeSeries] | list[list[TimeSeries]]:
     """
     Apply the inverse transform to the forecasts when defined.
@@ -1448,9 +1450,10 @@ def _apply_inverse_data_transformers(
         called_with_single_series = get_series_seq_type(series) == SeriesType.SINGLE
         if called_with_single_series:
             forecasts = [forecasts]
-        forecasts = data_transformers["series"].inverse_transform(
-            forecasts, series_idx=series_idx
-        )
+        inv_kw = {"series_idx": series_idx}
+        if pass_insample:
+            inv_kw["insample"] = series
+        forecasts = data_transformers["series"].inverse_transform(forecasts, **inv_kw)
         return forecasts[0] if called_with_single_series else forecasts
     else:
         return forecasts


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #3045.

### Summary
This PR adds an optional `insample` parameter to `inverse_transform()` in `InvertibleDataTransformer` and `Pipeline`, to avoid manually prepending the transformed insample target series to the forecasts for inverse_transform() to work. As it's None by default, it's currently used only by the `Diff` transformer.