### PR TITLE
Feat/metric crps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - 🔴 We moved `NaiveEnsembleModel` from `darts.models.forecasting.baselines` into a dedicated module `darts.models.forecasting.naive_ensemble_model` to separate the heavier dependencies from the baseline models and improve import times. Models that were saved in older Darts versions (pickled) cannot be loaded anymore. To fix it, simply re-create the model and store it again. [#3066](https://github.com/unit8co/darts/pull/3066) by [Dennis Bader](https://github.com/dennisbader)
 - Added parameter `name` to all metric functions for customizing the displayed name. [#3084](https://github.com/unit8co/darts/pull/3084)
   by [Bruno Da Costa](https://github.com/BrunoDaC).
+- Added new probabilistic metrics `crps()` (Continuous Ranked Probability Score) and `mcrps()` (Mean CRPS): a proper scoring rule that generalises the Mean Absolute Error (MAE) to probabilistic forecasts. [#3089](https://github.com/unit8co/darts/pull/3089) by [Boubker Bennani](https://github.com/Boubker10)
 
 **Fixed**
 

--- a/darts/metrics/__init__.py
+++ b/darts/metrics/__init__.py
@@ -108,7 +108,6 @@ from darts.utils._lazy import setup_lazy_imports
 if TYPE_CHECKING:
     from darts.metrics.metrics import accuracy as accuracy
     from darts.metrics.metrics import ae as ae
-    from darts.metrics.metrics import crps as crps
     from darts.metrics.metrics import ape as ape
     from darts.metrics.metrics import arre as arre
     from darts.metrics.metrics import ase as ase
@@ -117,6 +116,7 @@ if TYPE_CHECKING:
         coefficient_of_variation as coefficient_of_variation,
     )
     from darts.metrics.metrics import confusion_matrix as confusion_matrix
+    from darts.metrics.metrics import crps as crps
     from darts.metrics.metrics import dtw_metric as dtw_metric
     from darts.metrics.metrics import err as err
     from darts.metrics.metrics import f1 as f1
@@ -126,9 +126,9 @@ if TYPE_CHECKING:
     from darts.metrics.metrics import iws as iws
     from darts.metrics.metrics import mae as mae
     from darts.metrics.metrics import mape as mape
-    from darts.metrics.metrics import mcrps as mcrps
     from darts.metrics.metrics import marre as marre
     from darts.metrics.metrics import mase as mase
+    from darts.metrics.metrics import mcrps as mcrps
     from darts.metrics.metrics import merr as merr
     from darts.metrics.metrics import mic as mic
     from darts.metrics.metrics import mincs_qr as mincs_qr

--- a/darts/metrics/__init__.py
+++ b/darts/metrics/__init__.py
@@ -49,6 +49,9 @@ compute the deterministic metrics on:
 For probabilistic forecasts (storchastic predictions with `num_samples >> 1`) and quantile forecasts:
 
 - Aggregated over time:
+    Probabilistic metrics:
+        - :func:`MCRPS <darts.metrics.metrics.mcrps>`: Mean Continuous Ranked Probability Score
+
     Quantile metrics:
         - :func:`MQL <darts.metrics.metrics.mql>`: Mean Quantile Loss
         - :func:`QR <darts.metrics.metrics.qr>`: Quantile Risk
@@ -60,6 +63,9 @@ For probabilistic forecasts (storchastic predictions with `num_samples >> 1`) an
         - :func:`MINCS_QR <darts.metrics.metrics.mincs_qr>`: Mean Interval Non-Conformity Score for Quantile Regression
 
 - Per time step:
+    Probabilistic metrics:
+        - :func:`CRPS <darts.metrics.metrics.crps>`: Continuous Ranked Probability Score
+
     Quantile metrics:
         - :func:`QL <darts.metrics.metrics.ql>`: Quantile Loss
 
@@ -102,6 +108,7 @@ from darts.utils._lazy import setup_lazy_imports
 if TYPE_CHECKING:
     from darts.metrics.metrics import accuracy as accuracy
     from darts.metrics.metrics import ae as ae
+    from darts.metrics.metrics import crps as crps
     from darts.metrics.metrics import ape as ape
     from darts.metrics.metrics import arre as arre
     from darts.metrics.metrics import ase as ase
@@ -119,6 +126,7 @@ if TYPE_CHECKING:
     from darts.metrics.metrics import iws as iws
     from darts.metrics.metrics import mae as mae
     from darts.metrics.metrics import mape as mape
+    from darts.metrics.metrics import mcrps as mcrps
     from darts.metrics.metrics import marre as marre
     from darts.metrics.metrics import mase as mase
     from darts.metrics.metrics import merr as merr
@@ -148,6 +156,7 @@ if TYPE_CHECKING:
 _LAZY_IMPORTS: dict[str, str] = {
     "accuracy": "darts.metrics.metrics",
     "ae": "darts.metrics.metrics",
+    "crps": "darts.metrics.metrics",
     "ape": "darts.metrics.metrics",
     "arre": "darts.metrics.metrics",
     "ase": "darts.metrics.metrics",
@@ -163,6 +172,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "iws": "darts.metrics.metrics",
     "mae": "darts.metrics.metrics",
     "mape": "darts.metrics.metrics",
+    "mcrps": "darts.metrics.metrics",
     "marre": "darts.metrics.metrics",
     "mase": "darts.metrics.metrics",
     "merr": "darts.metrics.metrics",
@@ -195,6 +205,7 @@ _TIME_DEPENDENT_METRIC_NAMES = {
     "ape",
     "arre",
     "ase",
+    "crps",
     "err",
     "ql",
     "sape",

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -3197,7 +3197,7 @@ def crps(
     if not pred_series.is_stochastic:
         raise_log(
             ValueError(
-                "CRPS should only be computed for stochastic predicted TimeSeries."
+                "`pred_series` must be a stochastic (contain multiple predicted samples)."
             ),
             logger=logger,
         )
@@ -3211,8 +3211,14 @@ def crps(
     # y_true: (T, C, 1), y_pred: (T, C, N)
     n = y_pred.shape[SMPL_AX]
     term1 = np.mean(np.abs(y_pred - y_true), axis=SMPL_AX)  # (T, C)
-    pairwise = np.abs(y_pred[:, :, :, None] - y_pred[:, :, None, :])  # (T, C, N, N)
-    term2 = 0.5 * np.sum(pairwise, axis=(-2, -1)) / (n**2)  # (T, C)
+
+    # term2: `sum of |x_i - x_j| over i,j` has complexity O(N^2);
+    # instead we can compute `2 * sum_k (2k - (n - 1)) * x_{(k)}` for sorted x and 0-based k;
+    # it gives identical result but more efficient with O(N log N) time and O(N) memory per (T, C) slice.
+    y_sorted = np.sort(y_pred, axis=SMPL_AX)
+    k = np.arange(n, dtype=y_pred.dtype)
+    coeff = 2.0 * k - (n - 1.0)
+    term2 = np.sum(coeff * y_sorted, axis=SMPL_AX) / (n**2)  # (T, C)
     return (term1 - term2)[:, :, np.newaxis]  # (T, C, 1)
 
 

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -3102,6 +3102,222 @@ def mql(
     )
 
 
+@multi_ts_support
+@multivariate_support
+def crps(
+    actual_series: TimeSeriesLike,
+    pred_series: TimeSeriesLike,
+    intersect: bool = True,
+    *,
+    time_reduction: Callable[..., np.ndarray] | None = None,
+    component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
+    series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
+    n_jobs: int = 1,
+    verbose: bool = False,
+    name: str | None = None,
+) -> METRIC_OUTPUT_TYPE:
+    """Continuous Ranked Probability Score (CRPS).
+
+    CRPS is a proper scoring rule that generalises the Mean Absolute Error (MAE) to probabilistic forecasts.
+    It measures the compatibility of a predictive sample distribution with a scalar observation.
+
+    For the true series :math:`y` and predicted stochastic series (containing N samples) :math:`\\hat{y}`
+    of shape :math:`T \\times N`, it is computed per column/component and time step :math:`t` as:
+
+    .. math:: \\frac{1}{N}\\sum_{i=1}^{N}|\\hat{y}_{t,i} - y_t|
+              - \\frac{1}{2N^2}\\sum_{i=1}^{N}\\sum_{j=1}^{N}|\\hat{y}_{t,i} - \\hat{y}_{t,j}|,
+
+    where :math:`\\hat{y}_{t,i}` is the :math:`i`-th sample at time :math:`t`.
+
+    A CRPS of 0 indicates a perfect forecast. When all N samples are identical, CRPS reduces to the
+    Absolute Error (:func:`~darts.metrics.metrics.ae`).
+
+    Parameters
+    ----------
+    actual_series
+        The (sequence of) actual series.
+    pred_series
+        The (sequence of) predicted series.
+    intersect
+        For time series that are overlapping in time without having the same time index, setting `True`
+        will consider the values only over their common time interval (intersection in time).
+    time_reduction
+        Optionally, a function to aggregate the metrics over the time axis. It must reduce a `np.ndarray`
+        of shape `(t, c)` to a `np.ndarray` of shape `(c,)`. The function takes as input a ``np.ndarray`` and a
+        parameter named `axis`, and returns the reduced array. The `axis` receives value `0` corresponding to the
+        time axis. If `None`, will return a metric per time step.
+    component_reduction
+        Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
+        of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
+        parameter named `axis`, and returns the reduced array. The `axis` receives value `1` corresponding to the
+        component axis. If `None`, will return a metric per component.
+    series_reduction
+        Optionally, a function to aggregate the metrics over multiple series. It must reduce a `np.ndarray`
+        of shape `(s, t, c)` to a `np.ndarray` of shape `(t, c)` The function takes as input a ``np.ndarray`` and a
+        parameter named `axis`, and returns the reduced array. The `axis` receives value `0` corresponding to the
+        series axis. For example with `np.nanmean`, will return the average over all series metrics. If `None`, will
+        return a metric per component.
+    n_jobs
+        The number of jobs to run in parallel. Parallel jobs are created only when a ``Sequence[TimeSeries]`` is
+        passed as input, parallelising operations regarding different ``TimeSeries``. Defaults to `1`
+        (sequential). Setting the parameter to `-1` means using all the available processors.
+    verbose
+        Optionally, whether to print operations progress.
+    name
+        Optionally, the metric name to display. If `None`, will use the metric function name.
+
+    Returns
+    -------
+    float
+        A single metric score for:
+
+        - a single univariate series.
+        - a single multivariate series with `component_reduction`.
+        - a sequence (list) of uni/multivariate series with `series_reduction`, `component_reduction` and
+          `time_reduction`.
+    np.ndarray
+        A numpy array of metric scores. The array has shape (n time steps, n components) without time- and
+        component reductions. For:
+
+        - the same input arguments that result in the `float` return case from above but with ``time_reduction=None``.
+        - a single multivariate series and at least `component_reduction=None`.
+        - a single uni/multivariate series and at least `time_reduction=None`.
+        - a sequence of uni/multivariate series including `series_reduction` and at least one of
+          `component_reduction=None` or `time_reduction=None`.
+    list[float]
+        Same as for type `float` but for a sequence of series.
+    list[np.ndarray]
+        Same as for type `np.ndarray` but for a sequence of series.
+
+    Raises
+    ------
+    ValueError
+        If `pred_series` is not stochastic (i.e., does not contain multiple samples).
+    """
+    if not pred_series.is_stochastic:
+        raise_log(
+            ValueError(
+                "CRPS should only be computed for stochastic predicted TimeSeries."
+            ),
+            logger=logger,
+        )
+    y_true, y_pred = _get_values_or_raise(
+        actual_series,
+        pred_series,
+        intersect,
+        q=None,
+        remove_nan_union=True,
+    )
+    # y_true: (T, C, 1), y_pred: (T, C, N)
+    n = y_pred.shape[SMPL_AX]
+    term1 = np.mean(np.abs(y_pred - y_true), axis=SMPL_AX)  # (T, C)
+    pairwise = np.abs(
+        y_pred[:, :, :, None] - y_pred[:, :, None, :]
+    )  # (T, C, N, N)
+    term2 = 0.5 * np.sum(pairwise, axis=(-2, -1)) / (n**2)  # (T, C)
+    return (term1 - term2)[:, :, np.newaxis]  # (T, C, 1)
+
+
+@multi_ts_support
+@multivariate_support
+def mcrps(
+    actual_series: TimeSeriesLike,
+    pred_series: TimeSeriesLike,
+    intersect: bool = True,
+    *,
+    component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
+    series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
+    n_jobs: int = 1,
+    verbose: bool = False,
+    name: str | None = None,
+) -> METRIC_OUTPUT_TYPE:
+    """Mean Continuous Ranked Probability Score (MCRPS).
+
+    MCRPS is a proper scoring rule that generalises the Mean Absolute Error (MAE) to probabilistic forecasts.
+    It measures the compatibility of a predictive sample distribution with scalar observations, averaged over
+    all time steps.
+
+    MCRPS first computes the CRPS per time step (:func:`~darts.metrics.metrics.crps`), and then takes the
+    mean over the time axis.
+
+    For the true series :math:`y` and predicted stochastic series (containing N samples) :math:`\\hat{y}`
+    of shape :math:`T \\times N`, it is computed per column/component as:
+
+    .. math:: \\frac{1}{T}\\sum_{t=1}^{T}\\left(
+              \\frac{1}{N}\\sum_{i=1}^{N}|\\hat{y}_{t,i} - y_t|
+              - \\frac{1}{2N^2}\\sum_{i=1}^{N}\\sum_{j=1}^{N}|\\hat{y}_{t,i} - \\hat{y}_{t,j}|
+              \\right),
+
+    where :math:`\\hat{y}_{t,i}` is the :math:`i`-th sample at time :math:`t`.
+
+    A MCRPS of 0 indicates a perfect forecast. When all N samples are identical, MCRPS reduces to the
+    Mean Absolute Error (:func:`~darts.metrics.metrics.mae`).
+
+    Parameters
+    ----------
+    actual_series
+        The (sequence of) actual series.
+    pred_series
+        The (sequence of) predicted series.
+    intersect
+        For time series that are overlapping in time without having the same time index, setting `True`
+        will consider the values only over their common time interval (intersection in time).
+    component_reduction
+        Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
+        of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
+        parameter named `axis`, and returns the reduced array. The `axis` receives value `1` corresponding to the
+        component axis. If `None`, will return a metric per component.
+    series_reduction
+        Optionally, a function to aggregate the metrics over multiple series. It must reduce a `np.ndarray`
+        of shape `(s, t, c)` to a `np.ndarray` of shape `(t, c)` The function takes as input a ``np.ndarray`` and a
+        parameter named `axis`, and returns the reduced array. The `axis` receives value `0` corresponding to the
+        series axis. For example with `np.nanmean`, will return the average over all series metrics. If `None`, will
+        return a metric per component.
+    n_jobs
+        The number of jobs to run in parallel. Parallel jobs are created only when a ``Sequence[TimeSeries]`` is
+        passed as input, parallelising operations regarding different ``TimeSeries``. Defaults to `1`
+        (sequential). Setting the parameter to `-1` means using all the available processors.
+    verbose
+        Optionally, whether to print operations progress.
+    name
+        Optionally, the metric name to display. If `None`, will use the metric function name.
+
+    Returns
+    -------
+    float
+        A single metric score for:
+
+        - a single univariate series.
+        - a single multivariate series with `component_reduction`.
+        - a sequence (list) of uni/multivariate series with `series_reduction` and `component_reduction`.
+    np.ndarray
+        A numpy array of metric scores. The array has shape (n components,) without component reduction.
+        For:
+
+        - the same input arguments that result in the `float` return case from above but with
+          `component_reduction=None`.
+        - a single multivariate series and `component_reduction=None`.
+        - a sequence of uni/multivariate series including `series_reduction` and `component_reduction=None`.
+    list[float]
+        Same as for type `float` but for a sequence of series.
+    list[np.ndarray]
+        Same as for type `np.ndarray` but for a sequence of series.
+
+    Raises
+    ------
+    ValueError
+        If `pred_series` is not stochastic (i.e., does not contain multiple samples).
+    """
+    return np.nanmean(
+        _get_wrapped_metric(crps)(
+            actual_series,
+            pred_series,
+            intersect=intersect,
+        ),
+        axis=TIME_AX,
+    )
+
+
 @interval_support
 @multi_ts_support
 @multivariate_support

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -3211,9 +3211,7 @@ def crps(
     # y_true: (T, C, 1), y_pred: (T, C, N)
     n = y_pred.shape[SMPL_AX]
     term1 = np.mean(np.abs(y_pred - y_true), axis=SMPL_AX)  # (T, C)
-    pairwise = np.abs(
-        y_pred[:, :, :, None] - y_pred[:, :, None, :]
-    )  # (T, C, N, N)
+    pairwise = np.abs(y_pred[:, :, :, None] - y_pred[:, :, None, :])  # (T, C, N, N)
     term2 = 0.5 * np.sum(pairwise, axis=(-2, -1)) / (n**2)  # (T, C)
     return (term1 - term2)[:, :, np.newaxis]  # (T, C, 1)
 

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -1558,6 +1558,56 @@ class TestMetrics:
             metric(s2, s12_stochastic, q=0.0, **kwargs), 0.0
         )
 
+    @pytest.mark.parametrize(
+        "config",
+        [
+            (metrics.crps, False, {"time_reduction": np.nanmean}),
+            (metrics.mcrps, True, {}),
+        ],
+    )
+    def test_crps(self, config):
+        metric, is_aggregate, kwargs = config
+
+        # deterministic not supported
+        with pytest.raises(ValueError):
+            metric(self.series1, self.series1, **kwargs)
+
+        # general univariate, multivariate and multi-ts tests
+        self.helper_test_multivariate_duplication_equality(
+            metric, is_stochastic=True, **kwargs
+        )
+        self.helper_test_multiple_ts_duplication_equality(
+            metric, is_stochastic=True, **kwargs
+        )
+        self.helper_test_nan(metric, is_stochastic=True, **kwargs)
+
+        # perfect predictions (all samples equal to actual) -> CRPS = 0
+        np.testing.assert_array_almost_equal(
+            metric(self.series1, self.series11_stochastic, **kwargs), 0.0
+        )
+
+        # manual numerical check: y_true = 0, samples = [-1, 0, 1]
+        # term1 = mean(|x_i - 0|) = (1 + 0 + 1) / 3 = 2/3
+        # pairwise |x_i - x_j| sum = 2*(1+2+1) = 8  (upper tri * 2 + diag)
+        # term2 = 0.5 * 8 / 9 = 4/9
+        # crps = 2/3 - 4/9 = 2/9
+        y_true = TimeSeries.from_values(np.zeros((5, 1, 1)))
+        samples = np.array([-1.0, 0.0, 1.0])
+        y_pred = TimeSeries.from_values(
+            np.tile(samples, (5, 1, 1)).reshape(5, 1, 3)
+        )
+        expected_crps = 2.0 / 9.0
+        np.testing.assert_almost_equal(
+            metric(y_true, y_pred, **kwargs), expected_crps, decimal=10
+        )
+
+        # CRPS should be <= MAE: a spread-out distribution centered on truth is better than a point prediction
+        # Use series1 as truth; stochastic series centered on truth has lower CRPS than a biased one
+        np.testing.assert_array_less(
+            metric(self.series1, self.series11_stochastic, **kwargs),
+            metric(self.series1, self.series22_stochastic, **kwargs) + 1e-10,
+        )
+
     def test_metrics_arguments(self):
         series00 = self.series0.stack(self.series0)
         series11 = self.series1.stack(self.series1)

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -264,6 +264,7 @@ class TestMetrics:
             (metrics.sape, False, {"time_reduction": np.mean}),
             (metrics.arre, False, {"time_reduction": np.mean}),
             (metrics.ql, True, {"time_reduction": np.mean}),
+            (metrics.crps, True, {"time_reduction": np.mean}),
             # time aggregates
             (metrics.merr, False, {}),
             (metrics.mae, False, {}),
@@ -283,6 +284,7 @@ class TestMetrics:
             (metrics.coefficient_of_variation, False, {}),
             (metrics.qr, True, {}),
             (metrics.mql, True, {}),
+            (metrics.mcrps, True, {}),
             (metrics.dtw_metric, False, {}),
             (metrics.accuracy, False, {}),
             (metrics.precision, False, {}),
@@ -577,6 +579,7 @@ class TestMetrics:
             (metrics.sape, False),
             (metrics.arre, False),
             (metrics.ql, True),
+            (metrics.crps, True),
         ],
     )
     def test_output_type_time_dependent(self, config):
@@ -862,6 +865,7 @@ class TestMetrics:
                 (metrics.sape, False),
                 (metrics.arre, False),
                 (metrics.ql, True),
+                (metrics.crps, True),
                 # time aggregates
                 (metrics.merr, False),
                 (metrics.mae, False),
@@ -881,6 +885,7 @@ class TestMetrics:
                 (metrics.coefficient_of_variation, False),
                 (metrics.qr, True),
                 (metrics.mql, True),
+                (metrics.mcrps, True),
                 (metrics.dtw_metric, False),
                 (metrics.accuracy, False),
                 (metrics.precision, False),
@@ -970,6 +975,7 @@ class TestMetrics:
             (metrics.sape, 0, False, {"time_reduction": np.mean}),
             (metrics.arre, 0, False, {"time_reduction": np.mean}),
             (metrics.ql, 0, True, {"time_reduction": np.mean}),
+            (metrics.crps, 0, True, {"time_reduction": np.mean}),
             # time aggregates
             (metrics.merr, 0, False, {}),
             (metrics.mae, 0, False, {}),
@@ -989,6 +995,7 @@ class TestMetrics:
             (metrics.coefficient_of_variation, 0, False, {}),
             (metrics.qr, 0, True, {}),
             (metrics.mql, 0, True, {}),
+            (metrics.mcrps, 0, True, {}),
             (metrics.dtw_metric, 0, False, {}),
             (metrics.accuracy, 1, False, {}),
             (metrics.precision, 1, False, {}),

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -1593,9 +1593,7 @@ class TestMetrics:
         # crps = 2/3 - 4/9 = 2/9
         y_true = TimeSeries.from_values(np.zeros((5, 1, 1)))
         samples = np.array([-1.0, 0.0, 1.0])
-        y_pred = TimeSeries.from_values(
-            np.tile(samples, (5, 1, 1)).reshape(5, 1, 3)
-        )
+        y_pred = TimeSeries.from_values(np.tile(samples, (5, 1, 1)).reshape(5, 1, 3))
         expected_crps = 2.0 / 9.0
         np.testing.assert_almost_equal(
             metric(y_true, y_pred, **kwargs), expected_crps, decimal=10


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Note: this is a continuation of @Boubker10 's work on #3088.

Fixes #1112.

### Summary
                                                                                                                                                                              
Added two new metrics for probabilistic time series forecasting:

- `crps` (Continuous Ranked Probability Score): a per-time-step proper scoring rule that measures the compatibility of a predictive sample distribution with a scalar observation. Reduces to the Absolute Error (AE) when all samples are identical.
- `mcrps` (Mean CRPS): mean of `crps` over the time axis, analogous to MAE for probabilistic forecasts.

Both metrics follow the existing metric API (support for `component_reduction`, `series_reduction`, `time_reduction`, multi-ts, multivariate).

### Other Information

Formula used (energy score formulation):

CRPS = (1/N) * Σ|x_i - y| - (1/(2N²)) * Σ_i Σ_j |x_i - x_j|

Tests added in `darts/tests/metrics/test_metrics.py` covering:
- raises ValueError for deterministic input
- perfect prediction → CRPS = 0
- numerical correctness against manual calculation
- multivariate and multi-ts consistency