### PR TITLE
Security: install only binary dependency wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Dependencies**
 
 - Added a `uv` 7-day cooldown period to reduce supply-chain risk from newly published packages during dependency resolution. [#3096](https://github.com/unit8co/darts/pull/3096) by [Zhihao Dai](https://github.com/daidahao)
+- Configured `uv pip` to install only binary wheels (`only-binary = [":all:"]`) to reduce supply-chain risk from source-distribution build execution.
 
 ## [0.44.0](https://github.com/unit8co/darts/tree/0.44.0) (2026-04-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Dependencies**
 
 - Added a `uv` 7-day cooldown period to reduce supply-chain risk from newly published packages during dependency resolution. [#3096](https://github.com/unit8co/darts/pull/3096) by [Zhihao Dai](https://github.com/daidahao)
-- Configured `uv pip` to install only binary wheels (`only-binary = [":all:"]`) to reduce supply-chain risk from source-distribution build execution.
+- Configured `uv` to install only binary wheels for all dependencies to reduce supply-chain risk from source-distribution build execution. [#3099](https://github.com/unit8co/darts/pull/3099) by [Zhihao Dai](https://github.com/daidahao)
 
 ## [0.44.0](https://github.com/unit8co/darts/tree/0.44.0) (2026-04-30)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ required-environments = [
     "sys_platform == 'win32'",
 ]
 
+[tool.uv.pip]
+# Use only binary dependency wheels to prevent arbitrary code execution
+only-binary = [":all:"]
+
 [tool.uv.sources]
 # Use PyTorch CPU-only index when torch-cpu group is enabled
 torch = { index = "pytorch-cpu", group = "torch-cpu" }


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #.

### Summary

Configured `uv` to install only binary wheels for all dependencies to reduce supply-chain risk from source-distribution build execution.

This is one of the [best practices](https://github.com/lirantal/pypi-security-best-practices#1-prefer-binary-only-installs) recommended. I have restricted the scope to `tool.uv.pip` so it only affects Darts developers.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
