### PR TITLE
publish to pypi from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
   publish-pypi:
     needs: [build-package]
     runs-on: ubuntu-latest
-    environment: release-env
+    environment: pypi
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump_version.outputs.current-version }}
     steps:
       - name: "Clone repository"
         uses: actions/checkout@v4
@@ -60,20 +62,59 @@ jobs:
           draft: false
           body_path: .github/RELEASE_TEMPLATE/release_body.md
 
+  build-package:
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Clone repository at release tag"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.version }}
+
+      - name: "Set up Python 3.11"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.26"
+          python-version: '3.11'
+
+      - name: "Build package"
+        run: uv build
+
+      - name: "Upload dists as artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+  publish-pypi:
+    needs: [build-package]
+    runs-on: ubuntu-latest
+    environment: release-env
+    permissions:
+      id-token: write
+    steps:
+      - name: "Download dists"
+        uses: actions/download-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+      - name: "Publish to PyPI"
+        uses: pypa/gh-action-pypi-publish@release/v1
+
   deploy-docker:
     needs: [release]
     runs-on: ubuntu-latest
     steps:
-      - name: "Clone repository"
+      - name: "Clone repository at release tag"
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history and tags
-
-      - name: "Get latest version tag"
-        id: get_version
-        run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          ref: ${{ needs.release.outputs.version }}
 
       - name: "Set up QEMU"
         uses: docker/setup-qemu-action@v3
@@ -91,7 +132,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: unit8/darts:${{ steps.get_version.outputs.version }}, unit8/darts:latest
+          tags: unit8/darts:${{ needs.release.outputs.version }}, unit8/darts:latest
 
   deploy-docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
-- Fixed rendering issues of `CustomBlockRNNModule` and `CustomRNNModule` in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao).
-- Fixed rendering issues of `20-SKLearnModel-examples` notebook in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao).
+- Fixed rendering issues of `CustomBlockRNNModule` and `CustomRNNModule` in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
+- Fixed rendering issues of `20-SKLearnModel-examples` notebook in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 
 ### For developers of the library:
 
-- Sped up the documentation build by utilizing multiple CPU cores. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao).
+- PyPI package release is now part of the release workflow using secure Trusted Publishing via OpenID Connect (OIDC). [#3100](https://github.com/unit8co/darts/pull/3100) by [Dennis Bader](https://github.com/dennisbader)
+- Sped up the documentation build by utilizing multiple CPU cores. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 
 **Dependencies**
 


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- PyPI package release is now part of the release workflow using secure Trusted Publishing via OpenID Connect (OIDC) (previously we had to publish locally using long lived API tokens).
- Simplifies publishing, as now all steps are automated
- Fixes Docker image publishing that published the previous version instead of the newly released version

### Additional info

After the PyTorch Lightning incident from a couple of days ago, this would be the current standard for pubishing to PyPI via automated workflows. The PR is using the suggestions from [here](https://github.com/Lightning-AI/pytorch-lightning/issues/21697#issuecomment-4363519058)).