### PR TITLE
rename shap-related explainability to sklearn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Improved**
 
 - Improvements to Explainability:
-  - 🔴 Renamed `ShapExplainer` to `SKLearnExplainer` to better reflect its scope of explaining sklearn-based models. [#3049](https://github.com/unit8co/darts/pull/3049) by [Zhihao Dai](https://github.com/daidahao).
-  - Renamed `ShapExplainabilityResult` to `SHAPExplainabilityResult` to better reflect SHAP-based explainability results. [#3049](https://github.com/unit8co/darts/pull/3049) by [Zhihao Dai](https://github.com/daidahao).
+  - 🔴 Renamed `ShapExplainer` to `SKLearnExplainer` to better reflect its scope of explaining sklearn-based models. [#3103](https://github.com/unit8co/darts/pull/3103) by [Zhihao Dai](https://github.com/daidahao).
+  - Renamed `ShapExplainabilityResult` to `SHAPExplainabilityResult` to better reflect SHAP-based explainability results. [#3103](https://github.com/unit8co/darts/pull/3103) by [Zhihao Dai](https://github.com/daidahao).
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- Improvements to Explainability:
+  - 🔴 Renamed `ShapExplainer` to `SKLearnExplainer` to better reflect its scope of explaining sklearn-based models. [#3049](https://github.com/unit8co/darts/pull/3049) by [Zhihao Dai](https://github.com/daidahao).
+  - Renamed `ShapExplainabilityResult` to `SHAPExplainabilityResult` to better reflect SHAP-based explainability results. [#3049](https://github.com/unit8co/darts/pull/3049) by [Zhihao Dai](https://github.com/daidahao).
+
 **Fixed**
 
 - Fixed rendering issues of `CustomBlockRNNModule` and `CustomRNNModule` in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)

--- a/darts/explainability/__init__.py
+++ b/darts/explainability/__init__.py
@@ -4,6 +4,17 @@ Explainability
 
 Tools for explaining and interpreting forecasting model predictions, including SHAP-based explainers and
 model-specific explainability methods.
+
+`SHAP <https://github.com/slundberg/shap>`__-Based Explainers
+-------------------------------------------------------------
+- :class:`~darts.explainability.sklearn_explainer.SKLearnExplainer`: SHAP-based explainer for Darts' SKLearn
+  models.
+
+Model-Specific Explainers
+-------------------------
+- :class:`~darts.explainability.tft_explainer.TFTExplainer`: Explainer for
+  :class:`TFTModel <darts.models.forecasting.tft_model.TFTModel>`.
+
 """
 
 from typing import TYPE_CHECKING
@@ -12,22 +23,20 @@ from darts.utils._lazy import setup_lazy_imports
 
 if TYPE_CHECKING:
     from darts.explainability.explainability_result import (
-        ShapExplainabilityResult as ShapExplainabilityResult,
+        SHAPExplainabilityResult as SHAPExplainabilityResult,
     )
     from darts.explainability.explainability_result import (
         TFTExplainabilityResult as TFTExplainabilityResult,
     )
-    from darts.explainability.explainability_result import (
-        _ExplainabilityResult as _ExplainabilityResult,
+    from darts.explainability.sklearn_explainer import (
+        SKLearnExplainer as SKLearnExplainer,
     )
-    from darts.explainability.shap_explainer import ShapExplainer as ShapExplainer
     from darts.explainability.tft_explainer import TFTExplainer as TFTExplainer
 
 _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
-    "ShapExplainabilityResult": ("darts.explainability.explainability_result", None),
+    "SHAPExplainabilityResult": ("darts.explainability.explainability_result", None),
     "TFTExplainabilityResult": ("darts.explainability.explainability_result", None),
-    "_ExplainabilityResult": ("darts.explainability.explainability_result", None),
-    "ShapExplainer": ("darts.explainability.shap_explainer", None),
+    "SKLearnExplainer": ("darts.explainability.sklearn_explainer", None),
     "TFTExplainer": ("darts.explainability.tft_explainer", "(Py)Torch"),
 }
 

--- a/darts/explainability/explainability_result.py
+++ b/darts/explainability/explainability_result.py
@@ -5,8 +5,8 @@ Explainability Result
 Contains the explainability results obtained from :func:`_ForecastingModelExplainer.explain()
 <darts.explainability.explainability._ForecastingModelExplainer.explain>`.
 
-- :class:`ShapExplainabilityResult <ShapExplainabilityResult>` for :class:`ShapExplainer
-  <darts.explainability.shap_explainer.ShapExplainer>`
+- :class:`SHAPExplainabilityResult <SHAPExplainabilityResult>` for :class:`SKLearnExplainer
+  <darts.explainability.sklearn_explainer.SKLearnExplainer>`
 - :class:`TFTExplainabilityResult <TFTExplainabilityResult>` for :class:`TFTExplainer
   <darts.explainability.tft_explainer.TFTExplainer>`
 - :class:`ComponentBasedExplainabilityResult <ComponentBasedExplainabilityResult>` for component based explainability
@@ -320,27 +320,28 @@ class HorizonBasedExplainabilityResult(_ExplainabilityResult):
         return component
 
 
-class ShapExplainabilityResult(HorizonBasedExplainabilityResult):
+class SHAPExplainabilityResult(HorizonBasedExplainabilityResult):
     """
-    Stores the explainability results of a :class:`ShapExplainer <darts.explainability.shap_explainer.ShapExplainer>`
+    Stores the explainability results of a :class:`SKLearnExplainer
+    <darts.explainability.sklearn_explainer.SKLearnExplainer>`
     with convenient access to the results. It extends the :class:`HorizonBasedExplainabilityResult
     <HorizonBasedExplainabilityResult>` and carries additional information specific to the Shap explainers.
     In particular, in addition to the `explained_forecasts` (which in the case of the `ShapExplainer` are the
     shap values), it also provides access to the corresponding `feature_values` and the underlying `shap.Explanation`
     object.
 
-    - :func:`get_explanation() <ShapExplainabilityResult.get_explanation>`: explained forecast for a given horizon
+    - :func:`get_explanation() <SHAPExplainabilityResult.get_explanation>`: explained forecast for a given horizon
       (and target component)
-    - :func:`get_feature_values() <ShapExplainabilityResult.get_feature_values>`: feature values for a given horizon
+    - :func:`get_feature_values() <SHAPExplainabilityResult.get_feature_values>`: feature values for a given horizon
       (and target component).
-    - :func:`get_shap_explanation_object() <ShapExplainabilityResult.get_shap_explanation_object>`: `shap.Explanation`
+    - :func:`get_shap_explanation_object() <SHAPExplainabilityResult.get_shap_explanation_object>`: `shap.Explanation`
       object for a given horizon (and target component).
 
     Examples
     --------
-    >>> explainer = ShapExplainer(model)  # requires `background` if model was trained on multiple series
+    >>> explainer = SKLearnExplainer(model)  # requires `background` if model was trained on multiple series
     >>> explain_results = explainer.explain()
-    >>> exlained_fc = explain_results.get_explanation(horizon=1)
+    >>> explained_fc = explain_results.get_explanation(horizon=1)  # requires `component` if target is multivariate
     >>> feature_values = explain_results.get_feature_values(horizon=1)
     >>> shap_objects = explain_results.get_shap_explanation_objects(horizon=1)
     """

--- a/darts/explainability/sklearn_explainer.py
+++ b/darts/explainability/sklearn_explainer.py
@@ -36,7 +36,7 @@ from sklearn.multioutput import MultiOutputRegressor
 
 from darts import TimeSeries
 from darts.explainability.explainability import _ForecastingModelExplainer
-from darts.explainability.explainability_result import ShapExplainabilityResult
+from darts.explainability.explainability_result import SHAPExplainabilityResult
 from darts.logging import get_logger, raise_if, raise_log
 from darts.models.forecasting.sklearn_model import SKLearnModel
 from darts.typing import TimeSeriesLike
@@ -62,7 +62,7 @@ class _ShapMethod(Enum):
 ShapMethod = NewType("ShapMethod", _ShapMethod)
 
 
-class ShapExplainer(_ForecastingModelExplainer):
+class SKLearnExplainer(_ForecastingModelExplainer):
     model: SKLearnModel
 
     def __init__(
@@ -114,7 +114,7 @@ class ShapExplainer(_ForecastingModelExplainer):
         Examples
         --------
         >>> from darts.datasets import AirPassengersDataset
-        >>> from darts.explainability.shap_explainer import ShapExplainer
+        >>> from darts.explainability import SKLearnExplainer
         >>> from darts.models import LinearRegressionModel
         >>> series = AirPassengersDataset().load()
         >>> model = LinearRegressionModel(lags=12)
@@ -201,12 +201,12 @@ class ShapExplainer(_ForecastingModelExplainer):
         foreground_future_covariates: TimeSeriesLike | None = None,
         horizons: Sequence[int] | None = None,
         target_components: Sequence[str] | None = None,
-    ) -> ShapExplainabilityResult:
+    ) -> SHAPExplainabilityResult:
         """
-        Explains a foreground time series and returns a :class:`ShapExplainabilityResult
-        <darts.explainability.explainability_result.ShapExplainabilityResult>`.
+        Explains a foreground time series and returns a :class:`SHAPExplainabilityResult
+        <darts.explainability.explainability_result.SHAPExplainabilityResult>`.
         The results can be retrieved with method :func:`get_explanation()
-        <darts.explainability.explainability_result.ShapExplainabilityResult.get_explanation>`.
+        <darts.explainability.explainability_result.SHAPExplainabilityResult.get_explanation>`.
         The result is a multivariate `TimeSeries` instance containing the 'explanation'
         for the (horizon, target_component) forecast at any timestamp forecastable corresponding to
         the foreground `TimeSeries` input.
@@ -237,7 +237,7 @@ class ShapExplainer(_ForecastingModelExplainer):
 
         Returns
         -------
-        ShapExplainabilityResult
+        SHAPExplainabilityResult
             The forecast explanations
 
         Examples
@@ -360,7 +360,7 @@ class ShapExplainer(_ForecastingModelExplainer):
             feature_values_list = feature_values_list[0]
             shap_explanation_object_list = shap_explanation_object_list[0]
 
-        return ShapExplainabilityResult(
+        return SHAPExplainabilityResult(
             shap_values_list, feature_values_list, shap_explanation_object_list
         )
 

--- a/darts/tests/explainability/test_sklearn_explainer.py
+++ b/darts/tests/explainability/test_sklearn_explainer.py
@@ -12,8 +12,11 @@ from sklearn.preprocessing import MinMaxScaler
 
 from darts import TimeSeries
 from darts.dataprocessing.transformers import Scaler
-from darts.explainability.explainability_result import ShapExplainabilityResult
-from darts.explainability.shap_explainer import MIN_BACKGROUND_SAMPLE, ShapExplainer
+from darts.explainability.explainability_result import SHAPExplainabilityResult
+from darts.explainability.sklearn_explainer import (
+    MIN_BACKGROUND_SAMPLE,
+    SKLearnExplainer,
+)
 from darts.models import (
     CatBoostModel,
     ExponentialSmoothing,
@@ -179,7 +182,7 @@ class TestShapExplainer:
         m = model_cls(**config)
 
         with pytest.raises(ValueError):
-            ShapExplainer(m, self.target_ts, self.past_cov_ts, self.fut_cov_ts)
+            SKLearnExplainer(m, self.target_ts, self.past_cov_ts, self.fut_cov_ts)
 
         m.fit(
             series=self.target_ts,
@@ -189,7 +192,7 @@ class TestShapExplainer:
 
         # Should have the same number of target, past and futures in the respective lists
         with pytest.raises(ValueError):
-            ShapExplainer(
+            SKLearnExplainer(
                 m,
                 [self.target_ts, self.target_ts],
                 self.past_cov_ts,
@@ -198,18 +201,18 @@ class TestShapExplainer:
 
         # Missing a future covariate if you choose to use a new background
         with pytest.raises(ValueError):
-            ShapExplainer(
+            SKLearnExplainer(
                 m, self.target_ts, background_past_covariates=self.past_cov_ts
             )
 
         # Missing a past covariate if you choose to use a new background
         with pytest.raises(ValueError):
-            ShapExplainer(
+            SKLearnExplainer(
                 m, self.target_ts, background_future_covariates=self.fut_cov_ts
             )
 
         # Good type of explainers
-        shap_explain = ShapExplainer(m)
+        shap_explain = SKLearnExplainer(m)
         if m._supports_native_multioutput:
             # since xgboost > 2.1.0, model supports native multi-output regression
             # CatBoostModel supports multi-output for certain loss functions
@@ -221,14 +224,14 @@ class TestShapExplainer:
 
         # Bad choice of shap explainer
         with pytest.raises(ValueError):
-            ShapExplainer(m, shap_method="bad_choice")
+            SKLearnExplainer(m, shap_method="bad_choice")
 
     def test_creation(self):
         # Model should be a SKLearnModel
         m = ExponentialSmoothing()
         m.fit(self.target_ts["price"])
         with pytest.raises(ValueError):
-            ShapExplainer(m)
+            SKLearnExplainer(m)
 
         # For now, multi_models=False not allowed
         m = LinearRegressionModel(lags=1, output_chunk_length=2, multi_models=False)
@@ -236,7 +239,7 @@ class TestShapExplainer:
             series=self.target_ts,
         )
         with pytest.raises(ValueError):
-            ShapExplainer(
+            SKLearnExplainer(
                 m,
                 self.target_ts,
             )
@@ -253,7 +256,7 @@ class TestShapExplainer:
             past_covariates=self.past_cov_ts,
             future_covariates=self.fut_cov_ts,
         )
-        shap_explain = ShapExplainer(m)
+        shap_explain = SKLearnExplainer(m)
         assert isinstance(shap_explain.explainers.explainers, shap.explainers.Linear)
 
         # ExtraTreesRegressor - also not a MultiOutputRegressor
@@ -269,7 +272,7 @@ class TestShapExplainer:
             past_covariates=self.past_cov_ts,
             future_covariates=self.fut_cov_ts,
         )
-        shap_explain = ShapExplainer(m)
+        shap_explain = SKLearnExplainer(m)
         assert isinstance(shap_explain.explainers.explainers, shap.explainers.Tree)
 
         # No past or future covariates
@@ -281,7 +284,7 @@ class TestShapExplainer:
             series=self.target_ts,
         )
 
-        shap_explain = ShapExplainer(m)
+        shap_explain = SKLearnExplainer(m)
         assert isinstance(shap_explain.explainers.explainers, shap.explainers.Linear)
 
     def test_explain(self):
@@ -299,7 +302,7 @@ class TestShapExplainer:
             future_covariates=self.fut_cov_ts,
         )
 
-        shap_explain = ShapExplainer(m)
+        shap_explain = SKLearnExplainer(m)
         with pytest.raises(ValueError):
             _ = shap_explain.explain(horizons=[1, 5])  # horizon > output_chunk_length
         with pytest.raises(ValueError):
@@ -376,7 +379,7 @@ class TestShapExplainer:
             results.get_feature_values(horizon=1, component="test")
 
         # right instance
-        assert isinstance(results, ShapExplainabilityResult)
+        assert isinstance(results, SHAPExplainabilityResult)
 
         components_list = [
             "price_target_lag-4",
@@ -437,9 +440,9 @@ class TestShapExplainer:
         m.fit(
             series=self.target_ts,
         )
-        shap_explain = ShapExplainer(m)
+        shap_explain = SKLearnExplainer(m)
 
-        assert isinstance(shap_explain.explain(), ShapExplainabilityResult)
+        assert isinstance(shap_explain.explain(), SHAPExplainabilityResult)
 
     def test_explain_with_lags_future_covariates_series_of_same_length_as_target(self):
         model_cls = LightGBMModel if LGBM_AVAILABLE else LinearRegressionModel
@@ -456,7 +459,7 @@ class TestShapExplainer:
             future_covariates=self.fut_cov_ts,
         )
 
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
         for component in ["power", "price"]:
             explanation = explanation_results.get_explanation(
@@ -492,7 +495,7 @@ class TestShapExplainer:
             future_covariates=fut_cov_ts,
         )
 
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
         for component in ["power", "price"]:
             explanation = explanation_results.get_explanation(
@@ -528,7 +531,7 @@ class TestShapExplainer:
             future_covariates=fut_cov_ts,
         )
 
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
         for component in ["power", "price"]:
             explanation = explanation_results.get_explanation(
@@ -555,7 +558,7 @@ class TestShapExplainer:
             future_covariates=self.fut_cov_ts,
         )
 
-        shap_explain = ShapExplainer(m_0)
+        shap_explain = SKLearnExplainer(m_0)
 
         # We need at least 5 points for force_plot
         with pytest.raises(ValueError):
@@ -632,7 +635,7 @@ class TestShapExplainer:
             series=self.target_ts,
         )
 
-        shap_explain = ShapExplainer(m)
+        shap_explain = SKLearnExplainer(m)
         fplot = shap_explain.force_plot_from_ts(
             foreground_series=self.target_ts[100:105],
             horizon=1,
@@ -649,7 +652,7 @@ class TestShapExplainer:
         model.fit(
             series=self.target_ts,
         )
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
         df = pd.merge(
             self.target_ts.to_dataframe(),
@@ -676,7 +679,7 @@ class TestShapExplainer:
         model.fit(
             series=self.target_ts,
         )
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
 
         feature_values = explanation_results.get_feature_values(
@@ -707,7 +710,7 @@ class TestShapExplainer:
             past_covariates=self.past_cov_ts,
             future_covariates=self.fut_cov_ts,
         )
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
 
         assert isinstance(
@@ -744,7 +747,7 @@ class TestShapExplainer:
             past_covariates=self.past_cov_ts,
             future_covariates=self.fut_cov_ts,
         )
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
         # check that explain() with selected components gives identical results
         for comp in self.target_ts.components:
@@ -777,7 +780,7 @@ class TestShapExplainer:
         model.fit(
             series=ts,
         )
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
 
         # different static covariates dimensions should raise an error
         with pytest.raises(ValueError):
@@ -797,7 +800,7 @@ class TestShapExplainer:
         model.fit(
             series=self.target_ts_with_multi_component_static_covs,
         )
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
         explanation_results = shap_explain.explain()
         assert len(explanation_results.feature_values[1]) == 2
         for comp in self.target_ts_with_multi_component_static_covs.components:
@@ -822,7 +825,7 @@ class TestShapExplainer:
         model.fit(
             series=self.target_ts_multiple_series_with_different_static_covs,
         )
-        shap_explain = ShapExplainer(
+        shap_explain = SKLearnExplainer(
             model,
             background_series=self.target_ts_multiple_series_with_different_static_covs,
         )
@@ -857,7 +860,7 @@ class TestShapExplainer:
             )
         )
         model.fit(ts)
-        shap_explain = ShapExplainer(model)
+        shap_explain = SKLearnExplainer(model)
 
         # one column per lag, grouped by components
         expected_columns = [

--- a/examples/20-SKLearnModel-examples.ipynb
+++ b/examples/20-SKLearnModel-examples.ipynb
@@ -110,7 +110,7 @@
     "set_option(\"plotting.use_darts_style\", True)\n",
     "\n",
     "from darts.datasets import ElectricityConsumptionZurichDataset\n",
-    "from darts.explainability import ShapExplainer\n",
+    "from darts.explainability import SKLearnExplainer\n",
     "from darts.metrics import mape\n",
     "from darts.models import (\n",
     "    CatBoostModel,\n",
@@ -769,7 +769,7 @@
    "source": [
     "model = LinearRegressionModel(lags=24, lags_future_covariates=(24, 24))\n",
     "model.fit(ts_energy_train, future_covariates=ts_weather)\n",
-    "shap_explainer = ShapExplainer(model=model)\n",
+    "shap_explainer = SKLearnExplainer(model=model)\n",
     "shap_values = shap_explainer.summary_plot()"
    ]
   },


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

Part 2 of splitting #3049 into multiple PRs.

- Renames `ShapExplainer` to `SKLearnExplainer` to better reflect its scope of explaining sklearn-based models.
- Renames `ShapExplainabilityResult` to `SHAPExplainabilityResult` to better reflect SHAP-based explainability results.
