### PR TITLE
Devops: Update GitHub Actions to use Node.js 24

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: "Codecov upload"
         if: ${{ matrix.flavour == 'all' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v5
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@v5
@@ -134,7 +134,7 @@ jobs:
         example-name: [03-FFT-examples.ipynb, 04-RNN-examples.ipynb, 00-quickstart.ipynb, 02-data-processing.ipynb, 01-multi-time-series-and-covariates.ipynb]
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@v5

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -47,9 +47,9 @@ jobs:
           uv cache prune --ci
 
       - name: "Publish documentation to gh-pages"
-        uses: s0/git-publish-subdir-action@v2.2.0
         env:
-          REPO: self
-          BRANCH: gh-pages
-          FOLDER: docs/build/html
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git subtree push --prefix docs/build/html origin gh-pages

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -47,9 +47,9 @@ jobs:
           uv cache prune --ci
 
       - name: "Publish documentation to gh-pages"
+        uses: s0/git-publish-subdir-action@v2.2.0
         env:
+          REPO: self
+          BRANCH: gh-pages
+          FOLDER: docs/build/html
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git subtree push --prefix docs/build/html origin gh-pages

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@v5

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.12"
         uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v5
@@ -99,7 +99,7 @@ jobs:
         example-name: [00-quickstart.ipynb, 01-multi-time-series-and-covariates.ipynb, 02-data-processing.ipynb, 03-FFT-examples.ipynb, 04-RNN-examples.ipynb, 05-TCN-examples.ipynb, 06-Transformer-examples.ipynb, 07-NBEATS-examples.ipynb, 08-DeepAR-examples.ipynb, 09-DeepTCN-examples.ipynb, 10-Kalman-filter-examples.ipynb, 11-GP-filter-examples.ipynb, 12-Dynamic-Time-Warping-example.ipynb, 13-TFT-examples.ipynb, 15-static-covariates.ipynb, 16-hierarchical-reconciliation.ipynb, 18-TiDE-examples.ipynb, 19-EnsembleModel-examples.ipynb, 20-SKLearnModel-examples.ipynb, 21-TSMixer-examples.ipynb, 22-anomaly-detection-examples.ipynb, 23-Conformal-Prediction-examples.ipynb, 24-SKLearnClassifierModel-examples.ipynb, 25-FoundationModel-examples.ipynb, 26-NeuralForecast-examples.ipynb, 27-Torch-and-Foundation-Model-Fine-Tuning-examples.ipynb]
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@v5
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@v5

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: "Codecov upload"
         if: ${{ matrix.flavour == 'all' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.12"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -141,7 +141,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,9 +178,9 @@ jobs:
           uv cache prune --ci
 
       - name: "Publish documentation to gh-pages"
+        uses: s0/git-publish-subdir-action@v2.2.0
         env:
+          REPO: self
+          BRANCH: gh-pages
+          FOLDER: docs/build/html
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git subtree push --prefix docs/build/html origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository at release tag"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.version }}
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -86,7 +86,7 @@ jobs:
         run: uv build
 
       - name: "Upload dists as artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dists
           path: dist/
@@ -99,7 +99,7 @@ jobs:
       id-token: write
     steps:
       - name: "Download dists"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dists
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,9 +178,9 @@ jobs:
           uv cache prune --ci
 
       - name: "Publish documentation to gh-pages"
-        uses: s0/git-publish-subdir-action@v2.2.0
         env:
-          REPO: self
-          BRANCH: gh-pages
-          FOLDER: docs/build/html
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git subtree push --prefix docs/build/html origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: '1'
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,19 +117,19 @@ jobs:
           ref: ${{ needs.release.outputs.version }}
 
       - name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: "Build and push"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: unit8/darts:${{ needs.release.outputs.version }}, unit8/darts:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.bump_version.outputs.current-version }}
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.RELEASE_WORKFLOW_TOKEN_NEW_FINE_GRAINED }}
           fetch-depth: '1'
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository at release tag"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.version }}
 
@@ -139,7 +139,7 @@ jobs:
     needs: [release]
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
         uses: actions/setup-python@v5

--- a/.github/workflows/uv-audit.yml
+++ b/.github/workflows/uv-audit.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - PyPI package release is now part of the release workflow using secure Trusted Publishing via OpenID Connect (OIDC). [#3100](https://github.com/unit8co/darts/pull/3100) by [Dennis Bader](https://github.com/dennisbader)
 - Sped up the documentation build by utilizing multiple CPU cores. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao).
 - Added a weekly GitHub Actions workflow to run `uv audit` and fail CI when vulnerabilities are found in the dependencies. [#3102](https://github.com/unit8co/darts/pull/3102) by [Zhihao Dai](https://github.com/daidahao).
-- Updated GitHub Actions to use Node.js 24 runtime as Node.js 20 has reached end-of-life. [#](https://github.com/unit8co/darts/pull/) by [Zhihao Dai](https://github.com/daidahao).
+- Updated GitHub Actions to use Node.js 24 runtime as Node.js 20 has reached end-of-life. [#3105](https://github.com/unit8co/darts/pull/3105) by [Zhihao Dai](https://github.com/daidahao).
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - PyPI package release is now part of the release workflow using secure Trusted Publishing via OpenID Connect (OIDC). [#3100](https://github.com/unit8co/darts/pull/3100) by [Dennis Bader](https://github.com/dennisbader)
 - Sped up the documentation build by utilizing multiple CPU cores. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao).
 - Added a weekly GitHub Actions workflow to run `uv audit` and fail CI when vulnerabilities are found in the dependencies. [#3102](https://github.com/unit8co/darts/pull/3102) by [Zhihao Dai](https://github.com/daidahao).
+- Updated GitHub Actions to use Node.js 24 runtime as Node.js 20 has reached end-of-life. [#](https://github.com/unit8co/darts/pull/) by [Zhihao Dai](https://github.com/daidahao).
 
 **Dependencies**
 


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #.

### Summary

Update GitHub Actions to use Node.js 24 runtime as Node.js 20 has reached end-of-life.

Currently, a lot of Darts CI rely on actions that are running on Node.js 20, which [has reached EOL](https://nodejs.org/en/about/previous-releases) and will be removed from GitHub starting June 2nd, 2026. See [darts PR merge workflow log](https://github.com/unit8co/darts/actions/runs/25284381410) for a recent example.

This PR tried to find and update all actions that rely on Node.js 20 to newer versions that rely on at least Node.js 24.

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
