### PR TITLE
fix: preserve TorchForecastingModel.model across pickle round-trip (#3106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed `TorchForecastingModel` losing its underlying PyTorch Lightning module after a plain `pickle` round-trip, which made `predict()` raise `AttributeError`. The pickled state now carries an in-memory checkpoint that is restored on unpickling, so a fitted model survives `pickle.dump`/`pickle.load` and remains prediction-ready. [#3106](https://github.com/unit8co/darts/issues/3106)
 - Fixed rendering issues of `CustomBlockRNNModule` and `CustomRNNModule` in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 - Fixed rendering issues of `20-SKLearnModel-examples` notebook in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -24,6 +24,7 @@ import inspect
 import os
 import shutil
 import sys
+import tempfile
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from glob import glob
@@ -97,6 +98,11 @@ TORCH_NP_DTYPES = {
 # pickling a TorchForecastingModel will not save below attributes: the keys specify the
 # attributes to be ignored, and the values are the default values getting assigned upon loading
 TFM_ATTRS_NO_PICKLE = {"model": None, "trainer": None}
+
+# key used in the pickled state dict to carry an in-memory checkpoint of the underlying
+# PyTorch Lightning module so that a fitted ``TorchForecastingModel`` survives a plain
+# ``pickle`` round-trip (see :issue:`3106`).
+_TFM_PICKLED_CHECKPOINT_KEY = "_tfm_pickled_ckpt"
 
 logger = get_logger(__name__)
 
@@ -2814,15 +2820,90 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
             raise_log(ValueError("\n".join(msg)), logger)
 
     def __getstate__(self):
-        # do not pickle the PyTorch LightningModule, and Trainer
-        return {k: v for k, v in self.__dict__.items() if k not in TFM_ATTRS_NO_PICKLE}
+        # Do not pickle the PyTorch LightningModule and Trainer directly: they are
+        # not always picklable (DataLoader workers, hooks, ...). Instead, when the
+        # underlying ``self.model`` is set, we serialize a Lightning checkpoint to
+        # an in-memory bytes buffer and stash it on the pickled state. ``__setstate__``
+        # uses the buffer to rebuild ``self.model`` so that a plain ``pickle`` round-trip
+        # of a fitted model preserves prediction-readiness (see #3106).
+        state = {k: v for k, v in self.__dict__.items() if k not in TFM_ATTRS_NO_PICKLE}
+        if self.model is not None:
+            ckpt_bytes = self._dump_pl_module_checkpoint()
+            if ckpt_bytes is not None:
+                state[_TFM_PICKLED_CHECKPOINT_KEY] = ckpt_bytes
+        return state
 
     def __setstate__(self, d):
+        ckpt_bytes = d.pop(_TFM_PICKLED_CHECKPOINT_KEY, None)
         self.__dict__ = d
         # upon loading the pickled object, add back the PyTorch LightningModule, and Trainer attribute with
         # default values
         for attr, default_val in TFM_ATTRS_NO_PICKLE.items():
             setattr(self, attr, default_val)
+        # restore the underlying PyTorch Lightning module from the in-memory checkpoint
+        # so that ``predict()`` works after a plain ``pickle`` round-trip.
+        if ckpt_bytes is not None:
+            self._load_pl_module_from_bytes(ckpt_bytes)
+
+    def _dump_pl_module_checkpoint(self) -> bytes | None:
+        """Serialize the underlying ``PLForecastingModule`` to an in-memory checkpoint.
+
+        Uses the existing ``Trainer`` if one is attached (this is the case for a
+        freshly fitted model), otherwise falls back to a minimal checkpoint built
+        from the module's ``state_dict`` and ``hparams`` (this covers models that
+        were loaded via :meth:`load`, where ``trainer`` is ``None``).
+
+        Returns ``None`` if the checkpoint cannot be produced for any reason; the
+        pickle then falls back to the historical behaviour of dropping ``self.model``.
+        """
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".ckpt", delete=False) as f:
+                ckpt_path = f.name
+            try:
+                if self.trainer is not None:
+                    self.trainer.save_checkpoint(ckpt_path)
+                else:
+                    # No trainer attached (e.g. model was loaded via ``load()``).
+                    # Build a minimal checkpoint compatible with ``LightningModule.load_from_checkpoint``
+                    # and let the module's ``on_save_checkpoint`` hook populate Darts-specific keys.
+                    checkpoint = {
+                        "state_dict": self.model.state_dict(),
+                        "hyper_parameters": dict(self.model.hparams),
+                        "pytorch-lightning_version": pl.__version__,
+                    }
+                    self.model.on_save_checkpoint(checkpoint)
+                    torch.save(checkpoint, ckpt_path)
+                with open(ckpt_path, "rb") as fin:
+                    return fin.read()
+            finally:
+                if os.path.exists(ckpt_path):
+                    os.remove(ckpt_path)
+        except Exception as exc:  # pragma: no cover - defensive; pickle still succeeds
+            logger.warning(
+                f"Could not serialize the underlying PyTorch Lightning module during pickling "
+                f"({type(exc).__name__}: {exc}). The unpickled model will have ``model=None``; "
+                f"call ``fit()`` again before ``predict()``."
+            )
+            return None
+
+    def _load_pl_module_from_bytes(self, ckpt_bytes: bytes) -> None:
+        """Restore ``self.model`` from a checkpoint produced by :meth:`_dump_pl_module_checkpoint`."""
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".ckpt", delete=False) as f:
+                ckpt_path = f.name
+                f.write(ckpt_bytes)
+            try:
+                self.model = self._load_from_checkpoint(ckpt_path)
+            finally:
+                if os.path.exists(ckpt_path):
+                    os.remove(ckpt_path)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                f"Could not restore the underlying PyTorch Lightning module after unpickling "
+                f"({type(exc).__name__}: {exc}). The unpickled model will have ``model=None``; "
+                f"call ``fit()`` again before ``predict()``."
+            )
+            self.model = None
 
 
 def _raise_if_wrong_type(obj, exp_type, msg="expected type {}, got: {}"):

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -165,6 +165,106 @@ class TestTorchForecastingModel:
         assert params_old.keys() == params_new.keys()
         assert all([params_old[k] == params_new[k] for k in params_old])
 
+    @pytest.mark.parametrize(
+        "model_cls,extra_kwargs",
+        [
+            (
+                GlobalNaiveSeasonal,
+                {
+                    "input_chunk_length": 7,
+                    "output_chunk_length": 3,
+                    **tfm_kwargs,
+                },
+            ),
+            (
+                NBEATSModel,
+                {
+                    "input_chunk_length": 14,
+                    "output_chunk_length": 3,
+                    "n_epochs": 1,
+                    "random_state": 42,
+                    **tfm_kwargs,
+                },
+            ),
+        ],
+    )
+    def test_pickle_roundtrip_preserves_inner_module(self, model_cls, extra_kwargs):
+        """Regression test for #3106: a fitted ``TorchForecastingModel`` must keep
+        its inner LightningModule (and remain prediction-ready) after a plain
+        ``pickle`` round-trip.
+        """
+        import io
+        import pickle
+
+        times = pd.date_range("2024-01-01", periods=60, freq="D")
+        values = np.sin(np.arange(60) * 2 * np.pi / 7) + 10.0
+        ts = TimeSeries.from_times_and_values(times, values)
+
+        model = model_cls(**extra_kwargs)
+        model.fit(ts)
+        pred_before = model.predict(3)
+        assert model.model is not None
+
+        buf = io.BytesIO()
+        pickle.dump(model, buf)
+        buf.seek(0)
+        restored = pickle.load(buf)
+
+        assert restored.model is not None
+        assert type(restored.model).__name__ == type(model.model).__name__
+        pred_after = restored.predict(3)
+        np.testing.assert_allclose(pred_before.values(), pred_after.values(), atol=1e-5)
+
+    def test_pickle_roundtrip_after_save_load(self, tmpdir):
+        """A model that was saved to disk and reloaded via ``load()`` (no trainer
+        attached) must also survive a subsequent pickle round-trip (#3106)."""
+        import io
+        import pickle
+
+        model = NBEATSModel(
+            input_chunk_length=14,
+            output_chunk_length=3,
+            n_epochs=1,
+            random_state=42,
+            **tfm_kwargs,
+        )
+        model.fit(self.series)
+        pred_before = model.predict(3)
+
+        save_path = os.path.join(str(tmpdir), "m.pt")
+        model.save(save_path)
+        loaded = NBEATSModel.load(save_path)
+        assert loaded.trainer is None
+        assert loaded.model is not None
+
+        buf = io.BytesIO()
+        pickle.dump(loaded, buf)
+        buf.seek(0)
+        restored = pickle.load(buf)
+
+        assert restored.model is not None
+        pred_after = restored.predict(3)
+        np.testing.assert_allclose(pred_before.values(), pred_after.values(), atol=1e-5)
+
+    def test_pickle_roundtrip_unfitted_model(self):
+        """Pickling an unfitted model is a no-op for ``self.model`` and should not error."""
+        import io
+        import pickle
+
+        model = NBEATSModel(
+            input_chunk_length=14,
+            output_chunk_length=3,
+            n_epochs=1,
+            **tfm_kwargs,
+        )
+        assert model.model is None
+
+        buf = io.BytesIO()
+        pickle.dump(model, buf)
+        buf.seek(0)
+        restored = pickle.load(buf)
+        assert restored.model is None
+
     @patch(
         "darts.models.forecasting.torch_forecasting_model.TorchForecastingModel.save"
     )


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #3106.

### Summary

`TorchForecastingModel.__getstate__` strips `model` and `trainer` before pickling (because the underlying PyTorch Lightning module is not always picklable), and `__setstate__` resets them to `None`. As a result, `pickle.load(pickle.dumps(fitted_model)).model is None`, and any subsequent `predict()` raises `AttributeError: 'NoneType' object has no attribute 'set_predict_parameters'`. The official `save()`/`load()` API hides this by writing a sibling `.ckpt` file, but plain `pickle` (e.g. when packing several heterogeneous models into one artifact) loses the weights entirely.

This change makes `__getstate__` serialize the underlying `PLForecastingModule` to an in-memory checkpoint (via `Trainer.save_checkpoint` when a trainer is attached, otherwise via a minimal checkpoint that still goes through `on_save_checkpoint` so the Darts-specific keys like `model_dtype`, `train_sample_shape`, and `loss_fn` are populated). `__setstate__` writes the bytes back to a tempfile and restores `self.model` via the existing `_load_from_checkpoint` helper. Unfitted models keep the previous behaviour. If serialization fails for any reason, we fall back to the historical behaviour with a warning so pickling itself never breaks.

### Other Information

Verified with the exact repro from the issue (`GlobalNaiveSeasonal` and `NBEATSModel`): both retain their inner module after a `pickle` round-trip and produce identical predictions. Three regression tests cover (1) the fitted-model case, parameterized over a baseline and a deep model, (2) the case where the model was first written to disk and reloaded via `load()` (no trainer attached), and (3) the unfitted-model case.