### PR TITLE
add back numpy<2.0.0 for foundry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed rendering issues of `CustomBlockRNNModule` and `CustomRNNModule` in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 - Fixed rendering issues of `20-SKLearnModel-examples` notebook in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 
+**Dependencies**
+
+- Re-added support for numpy < 2 (numpy>=1.26.0) to allow compatibility with cloud platforms that require older numpy versions (e.g., Foundry Transforms due to Spark 3). [#3110](https://github.com/unit8co/darts/pull/3110) by [Dennis Bader](https://github.com/dennisbader)
+
 ### For developers of the library:
 
 - PyPI package release is now part of the release workflow using secure Trusted Publishing via OpenID Connect (OIDC). [#3100](https://github.com/unit8co/darts/pull/3100) by [Dennis Bader](https://github.com/dennisbader)

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -32,6 +32,9 @@ from darts.metrics.utils import (
 )
 from darts.typing import TimeSeriesLike
 
+_NP_2_OR_ABOVE = int(np.__version__.split(".")[0]) >= 2
+_NP_TRAPEZOID_FN = np.trapezoid if _NP_2_OR_ABOVE else np.trapz
+
 logger = get_logger(__name__)
 
 
@@ -2699,7 +2702,7 @@ def autc(
         max_tolerance=max_tolerance,
         step=step,
     )
-    return np.trapezoid(coverages, tolerances, axis=0)
+    return _NP_TRAPEZOID_FN(coverages, tolerances, axis=0)
 
 
 # Dynamic Time Warping

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -15,6 +15,9 @@ from darts.utils.likelihood_models.base import (
     quantile_names,
 )
 
+_NP_2_OR_ABOVE = int(np.__version__.split(".")[0]) >= 2
+_NP_TRAPEZOID_FN = np.trapezoid if _NP_2_OR_ABOVE else np.trapz
+
 
 def sklearn_mape(*args, **kwargs):
     return sklearn.metrics.mean_absolute_percentage_error(*args, **kwargs) * 100.0
@@ -166,7 +169,7 @@ def metric_autc(y_true, y_pred, n_tolerances=101, **kwargs):
     normalized_errors = abs_errors / half_range
     tolerances = np.linspace(0, 1, n_tolerances)
     coverages = np.array([np.mean(normalized_errors <= tol) for tol in tolerances])
-    return np.trapezoid(coverages, tolerances)
+    return _NP_TRAPEZOID_FN(coverages, tolerances)
 
 
 class TestMetrics:

--- a/darts/utils/_plotting.py
+++ b/darts/utils/_plotting.py
@@ -507,7 +507,7 @@ def plotly(
     step = 1
     points_to_plot = len(series) * n_components_to_plot * (3 if plot_ci else 1)
     if downsample_threshold != -1 and points_to_plot > downsample_threshold:
-        step = np.pow(
+        step = np.power(
             2, np.ceil(np.log2(points_to_plot / downsample_threshold))
         ).astype(int)
 

--- a/darts/utils/data/tabularization/tabularization.py
+++ b/darts/utils/data/tabularization/tabularization.py
@@ -25,7 +25,8 @@ from darts.utils.utils import n_steps_between
 
 logger = get_logger(__name__)
 
-STABLE_SORT_KWARGS = {"stable": True}
+NP_2_OR_ABOVE = int(np.__version__.split(".")[0]) >= 2
+STABLE_SORT_KWARGS = {"stable": True} if NP_2_OR_ABOVE else {"kind": "stable"}
 
 ArrayOrArraySequence = np.ndarray | Sequence[np.ndarray]
 

--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -32,6 +32,9 @@ from darts.utils.missing_values import fill_missing_values
 from darts.utils.ts_utils import get_single_series
 from darts.utils.utils import ModelMode, SeasonalityMode
 
+_NP_2_OR_ABOVE = int(np.__version__.split(".")[0]) >= 2
+_NP_TRAPEZOID_FN = np.trapezoid if _NP_2_OR_ABOVE else np.trapz
+
 logger = get_logger(__name__)
 
 
@@ -1194,7 +1197,7 @@ def plot_tolerance_curve(
         coverages_comp = coverages[:, i]
         coverages_perc = coverages_comp * 100.0
 
-        auc = np.trapezoid(coverages_comp, tolerances)
+        auc = _NP_TRAPEZOID_FN(coverages_comp, tolerances)
         label = f"{comp_name} (AUTC = {auc:.3f})"
         axis.step(
             tolerances_perc,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "matplotlib>=3.3.0",
     "narwhals>=1.25.1",
     "nfoursid>=1.0.0",
-    "numpy>=2.2.0",
+    "numpy>=1.26.0",
     "pandas>=2.2.0",
     "pyod>=0.9.5",
     "requests>=2.22.0",
@@ -165,7 +165,7 @@ dev = [
 ]
 torch-cpu = ["torch>=2.0.0"]
 optional = [
-    "onnx>=1.20.1",
+    "onnx>=1.0.0",
     "onnxruntime>=1.24.1; python_version >= '3.11'",
     "onnxruntime<1.24.1; python_version < '3.11'",  # 1.24.1 dropped python 3.10 support
     "optuna>=4.7.0",


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- Brings back support for numpy < 2 (numpy>=1.26.0) to allow compatibility with cloud platforms that require older numpy versions (e.g., Foundry Transforms due to Spark 3).