### PR TITLE
Fix/backtest overlap with quantile metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed a `ValueError` in `backtest()` when using `overlap_end=True` with `predict_likelihood_parameters=True` and a quantile metric. The final forecast window could extend beyond the series end, producing an empty intersection that caused a reshape failure in the metric computation. [#3101](https://github.com/unit8co/darts/pull/3101) by [Dennis Bader](https://github.com/dennisbader)
 - Fixed rendering issues of `CustomBlockRNNModule` and `CustomRNNModule` in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 - Fixed rendering issues of `20-SKLearnModel-examples` notebook in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 

--- a/darts/metrics/utils.py
+++ b/darts/metrics/utils.py
@@ -550,7 +550,8 @@ def _get_values(
             # we extract the relevant quantile components with shape (times, components * quantiles)
             vals = vals[:, vals_components.get_indexer(q_names)]
             # rearrange into (times, components, quantiles)
-            vals = vals.reshape((len(vals), len(actual_components), -1))
+            n_quantiles = vals.shape[1] // len(actual_components)
+            vals = vals.reshape((len(vals), len(actual_components), n_quantiles))
         return vals
 
     # probabilistic input

--- a/darts/tests/models/forecasting/test_backtesting.py
+++ b/darts/tests/models/forecasting/test_backtesting.py
@@ -24,6 +24,10 @@ from darts.models import (
     Theta,
 )
 from darts.tests.conftest import TORCH_AVAILABLE, tfm_kwargs
+from darts.utils.likelihood_models.base import (
+    likelihood_component_names,
+    quantile_names,
+)
 from darts.utils.timeseries_generation import constant_timeseries as ct
 from darts.utils.timeseries_generation import gaussian_timeseries as gt
 from darts.utils.timeseries_generation import linear_timeseries as lt
@@ -1632,6 +1636,71 @@ class TestBacktesting:
         for bt in bts:
             assert bt.shape == shape_expected
             np.testing.assert_array_almost_equal(bt, bt_expected)
+
+    @pytest.mark.parametrize(
+        "config",
+        itertools.product(
+            [1, 2],  # number of target components (uni / multivariate)
+            [[0.1, 0.5, 0.9], [0.5]],  # quantiles (multiple / single)
+            [None, np.nanmean],  # component_reduction
+        ),
+    )
+    def test_backtest_overlap_end_empty_intersection(self, config):
+        """When overlap_end=True and predict_likelihood_parameters=True, the
+        last forecast window can extend beyond the series end, producing an
+        empty intersection. The reshape in _get_values must handle a size-0
+        array without raising."""
+        np.random.seed(0)
+        n_components, qs, component_reduction = config
+
+        series_length = 10
+        y = lt(length=series_length)
+        if n_components > 1:
+            y = y.stack(y + 1.0)
+
+        q_param_names = quantile_names(qs)
+        q_comp_names = likelihood_component_names(
+            components=y.components,
+            parameter_names=q_param_names,
+        )
+
+        n_q_cols = n_components * len(qs)
+        hfc_overlap = TimeSeries.from_times_and_values(
+            times=generate_index(
+                start=y.start_time(),
+                length=10,
+            ),
+            values=np.random.random((10, n_q_cols, 1)),
+            columns=q_comp_names,
+        )
+        hfc_no_overlap = TimeSeries.from_times_and_values(
+            times=generate_index(
+                start=y.end_time() + y.freq,
+                length=5,
+            ),
+            values=np.random.random((5, n_q_cols, 1)),
+            columns=q_comp_names,
+        )
+        hfc = [hfc_overlap, hfc_no_overlap]
+
+        model = NaiveDrift()
+        metric_kwargs = [
+            {"q": qs, "component_reduction": component_reduction},
+        ]
+        bt = model.backtest(
+            series=y,
+            historical_forecasts=hfc,
+            last_points_only=False,
+            metric=[metrics.mae],
+            metric_kwargs=metric_kwargs,
+            reduction=None,
+        )
+        assert len(bt) == 2
+        expected_bt = metrics.mae(
+            y, hfc_overlap, q=qs, component_reduction=component_reduction
+        )
+        np.testing.assert_array_almost_equal(bt[0], expected_bt)
+        assert np.all(np.isnan(bt[1]))
 
     @pytest.mark.parametrize(
         "config",


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #3109.

### Summary

- Fixes a `ValueError` in `backtest()` when using `overlap_end=True` with `predict_likelihood_parameters=True` and a quantile metric. The final forecast window could extend beyond the series end, producing an empty intersection that caused a reshape failure in the metric computation.