### PR TITLE
fix: vendor PyTorchLightningPruningCallback to drop optuna-integration dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- Added `PyTorchLightningPruningCallback` to `darts.utils.callbacks`, a self-contained Optuna pruning callback for use with PyTorch Lightning-based forecasting models. This removes the need for the `PatchedPruningCallback` multiple-inheritance workaround when using Optuna with Darts. [#3093](https://github.com/unit8co/darts/issues/3093)
+
 **Fixed**
 
 **Dependencies**
+
+- Dropped the `optuna-integration[pytorch-lightning]` optional dependency. The vendored `PyTorchLightningPruningCallback` is now imported from `darts.utils.callbacks`. [#3093](https://github.com/unit8co/darts/issues/3093)
 
 ### For developers of the library:
 

--- a/darts/tests/optional_deps/test_optuna.py
+++ b/darts/tests/optional_deps/test_optuna.py
@@ -21,16 +21,10 @@ import optuna
 
 if TORCH_AVAILABLE:
     import torch
-    from pytorch_lightning.callbacks import Callback, EarlyStopping
-
-    # hacky workaround found in https://github.com/Lightning-AI/pytorch-lightning/issues/17485
-    # to avoid import of both lightning and pytorch_lightning
-    class PatchedPruningCallback(
-        optuna.integration.PyTorchLightningPruningCallback, Callback
-    ):
-        pass
+    from pytorch_lightning.callbacks import EarlyStopping
 
     from darts.models import TCNModel
+    from darts.utils.callbacks import PyTorchLightningPruningCallback
     from darts.utils.likelihood_models.torch import GaussianLikelihood
 
 
@@ -62,7 +56,7 @@ class TestOptuna:
             include_year = trial.suggest_categorical("year", [False, True])
 
             # throughout training we'll monitor the validation loss for both pruning and early stopping
-            pruner = PatchedPruningCallback(trial, monitor="val_loss")
+            pruner = PyTorchLightningPruningCallback(trial, monitor="val_loss")
             early_stopper = EarlyStopping(
                 "val_loss", min_delta=0.001, patience=3, verbose=True
             )
@@ -128,6 +122,109 @@ class TestOptuna:
         # optimize hyperparameters by minimizing the sMAPE on the validation set
         study = optuna.create_study(direction="minimize")
         study.optimize(objective, n_trials=3)
+
+    @pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
+    def test_pruning_callback_inherits_from_pl_callback(self):
+        """The Darts callback must satisfy PyTorch Lightning's `Callback`
+        type so that it can be registered via ``pl_trainer_kwargs`` without
+        the multiple-inheritance workaround used historically."""
+        from pytorch_lightning.callbacks import Callback as PLCallback
+
+        study = optuna.create_study(direction="minimize")
+        trial = study.ask()
+        callback = PyTorchLightningPruningCallback(trial, monitor="val_loss")
+        assert isinstance(callback, PLCallback)
+        assert callback.monitor == "val_loss"
+        assert callback.is_ddp_backend is False
+
+    @pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
+    def test_pruning_callback_warns_on_missing_metric(self):
+        """When the monitored metric is absent from ``callback_metrics``,
+        the callback must warn (not crash) and skip reporting."""
+
+        class _StubTrainer:
+            sanity_checking = False
+            callback_metrics: dict = {}
+
+        class _StubModule:
+            current_epoch = 0
+
+        study = optuna.create_study(direction="minimize")
+        trial = study.ask()
+        callback = PyTorchLightningPruningCallback(trial, monitor="missing_metric")
+
+        with pytest.warns(UserWarning, match="missing_metric"):
+            callback.on_validation_end(_StubTrainer(), _StubModule())  # type: ignore[arg-type]
+
+    @pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
+    def test_pruning_callback_raises_when_trial_should_prune(self):
+        """When the trial's pruner decides to prune, the callback must
+        raise :class:`optuna.TrialPruned`."""
+
+        class _AlwaysPruningTrial:
+            def __init__(self, real_trial):
+                self._real = real_trial
+
+            def report(self, value, step):
+                self._real.report(value, step)
+
+            def should_prune(self):
+                return True
+
+        class _StubTrainer:
+            sanity_checking = False
+            callback_metrics = {"val_loss": torch.tensor(1.0)}
+
+        class _StubModule:
+            current_epoch = 0
+
+        study = optuna.create_study(direction="minimize")
+        real_trial = study.ask()
+        callback = PyTorchLightningPruningCallback(
+            _AlwaysPruningTrial(real_trial), monitor="val_loss"
+        )
+
+        with pytest.raises(optuna.TrialPruned):
+            callback.on_validation_end(_StubTrainer(), _StubModule())  # type: ignore[arg-type]
+
+    @pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
+    def test_pruning_callback_skips_during_sanity_check(self):
+        """``Trainer`` invokes ``on_validation_end`` for the sanity check at
+        epoch 0. The callback must short-circuit in that case so it does not
+        call ``trial.report`` twice."""
+
+        class _ReportRecorder:
+            def __init__(self):
+                self.reports: list = []
+
+            def report(self, value, step):
+                self.reports.append((value, step))
+
+            def should_prune(self):
+                return False
+
+        class _StubTrainer:
+            sanity_checking = True
+            callback_metrics = {"val_loss": torch.tensor(1.0)}
+
+        class _StubModule:
+            current_epoch = 0
+
+        recorder = _ReportRecorder()
+        callback = PyTorchLightningPruningCallback(recorder, monitor="val_loss")
+        callback.on_validation_end(_StubTrainer(), _StubModule())  # type: ignore[arg-type]
+        assert recorder.reports == []
+
+    @pytest.mark.skipif(not TORCH_AVAILABLE, reason="requires torch")
+    def test_pruning_callback_check_pruned_is_noop_outside_ddp(self):
+        """Outside of a DDP + RDB-storage context, ``check_pruned`` must be
+        a no-op so callers can invoke it unconditionally after fit()."""
+        study = optuna.create_study(direction="minimize")
+        trial = study.ask()
+        callback = PyTorchLightningPruningCallback(trial, monitor="val_loss")
+        # No exception expected; the method returns silently when the
+        # study storage is not the DDP-aware CachedStorage.
+        callback.check_pruned()
 
     @pytest.mark.parametrize(
         "params",

--- a/darts/utils/callbacks.py
+++ b/darts/utils/callbacks.py
@@ -3,10 +3,202 @@ Callbacks for TorchForecastingModel
 -----------------------------------
 """
 
-import sys
+from __future__ import annotations
 
-from pytorch_lightning.callbacks import TQDMProgressBar
+import sys
+import warnings
+from typing import TYPE_CHECKING
+
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning.callbacks import Callback, TQDMProgressBar
 from pytorch_lightning.callbacks.progress.tqdm_progress import Tqdm
+
+if TYPE_CHECKING:
+    import optuna
+
+
+# Trial-system-attribute keys mirroring those used by
+# ``optuna_integration.pytorch_lightning.PyTorchLightningPruningCallback`` so
+# that DDP state remains portable between the two implementations.
+_EPOCH_KEY = "ddp_pl:epoch"
+_INTERMEDIATE_VALUE = "ddp_pl:intermediate_value"
+_PRUNED_KEY = "ddp_pl:pruned"
+
+
+class PyTorchLightningPruningCallback(Callback):
+    """PyTorch Lightning callback to prune unpromising Optuna trials.
+
+    Reports the latest value of ``monitor`` to the trial at the end of every
+    validation epoch and raises :class:`optuna.TrialPruned` when the trial's
+    pruner decides the trial is unpromising. See the Optuna `PyTorch
+    Lightning example
+    <https://github.com/optuna/optuna-examples/blob/main/pytorch/pytorch_lightning_simple.py>`__
+    for end-to-end usage.
+
+    This is a self-contained reimplementation that lets Darts depend only on
+    ``optuna`` (without the ``optuna-integration[pytorch-lightning]`` extra)
+    while continuing to support the same DDP behaviour.
+
+    Parameters
+    ----------
+    trial
+        An :class:`optuna.trial.Trial` corresponding to the current evaluation
+        of the objective function.
+    monitor
+        Name of the metric to monitor for pruning, e.g. ``"val_loss"``. The
+        metric must be logged by the ``LightningModule`` so that it appears
+        in ``trainer.callback_metrics``.
+
+    Notes
+    -----
+    For distributed-data-parallel (DDP) training, the
+    :class:`~optuna.study.Study` must be instantiated with an
+    :class:`~optuna.storages.RDBStorage` backend. After
+    :meth:`pytorch_lightning.Trainer.fit` returns, callers must invoke
+    :meth:`check_pruned` so that :class:`~optuna.exceptions.TrialPruned`
+    is properly handled.
+
+    Examples
+    --------
+    >>> import optuna
+    >>> from darts.utils.callbacks import PyTorchLightningPruningCallback
+    >>> def objective(trial):
+    ...     pruner = PyTorchLightningPruningCallback(trial, monitor="val_loss")
+    ...     # ... build and fit your TorchForecastingModel with `pruner` in
+    ...     # `pl_trainer_kwargs={"callbacks": [pruner]}`
+    """
+
+    def __init__(self, trial: optuna.trial.Trial, monitor: str) -> None:
+        # pragma: no cover - exercised only when optuna is missing
+        try:
+            import optuna  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "Optuna is required to use `PyTorchLightningPruningCallback`. "
+                "Install it with: pip install optuna"
+            ) from exc
+
+        super().__init__()
+        self._trial = trial
+        self.monitor = monitor
+        self.is_ddp_backend = False
+
+    def on_fit_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        import optuna
+        from optuna.storages._cached_storage import _CachedStorage
+        from optuna.storages._rdb.storage import RDBStorage
+
+        self.is_ddp_backend = trainer._accelerator_connector.is_distributed
+        if not self.is_ddp_backend:
+            return
+
+        # If it were not for this guard, fitting would be started even when an
+        # unsupported storage is used. The ValueError would otherwise be
+        # transformed into ``ProcessRaisedException`` inside torch.
+        if not (
+            isinstance(self._trial.study._storage, _CachedStorage)
+            and isinstance(self._trial.study._storage._backend, RDBStorage)
+        ):
+            raise ValueError(
+                "darts.utils.callbacks.PyTorchLightningPruningCallback supports"
+                " only optuna.storages.RDBStorage in DDP."
+            )
+        # Intermediate values must be written directly to the backend storage
+        # because they are not properly propagated to the main process through
+        # the cached storage.
+        if trainer.is_global_zero:
+            self._trial.storage.set_trial_system_attr(
+                self._trial._trial_id,
+                _INTERMEDIATE_VALUE,
+                dict(),
+            )
+        _ = optuna  # silence unused-import warnings if optuna is only re-imported lazily
+
+    def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        import optuna
+
+        # ``Trainer`` calls ``on_validation_end`` for the sanity check too.
+        # Avoid calling ``trial.report`` multiple times at epoch 0; see
+        # https://github.com/PyTorchLightning/pytorch-lightning/issues/1391.
+        if trainer.sanity_checking:
+            return
+
+        current_score = trainer.callback_metrics.get(self.monitor)
+        if current_score is None:
+            warnings.warn(
+                f"The metric '{self.monitor}' is not in the evaluation logs for"
+                " pruning. Please make sure you set the correct metric name."
+            )
+            return
+
+        epoch = pl_module.current_epoch
+
+        # Single-process: report and prune directly.
+        if not self.is_ddp_backend:
+            self._trial.report(current_score.item(), step=epoch)
+            if not self._trial.should_prune():
+                return
+            raise optuna.TrialPruned(f"Trial was pruned at epoch {epoch}.")
+
+        # DDP: only the global-zero process talks to the storage, then the
+        # decision is broadcast to every other process.
+        should_stop = False
+        if trainer.is_global_zero:
+            self._trial.report(current_score.item(), step=epoch)
+            should_stop = self._trial.should_prune()
+
+            _trial_id = self._trial._trial_id
+            _study = self._trial.study
+            _trial_system_attrs = _study._storage.get_trial_system_attrs(_trial_id)
+            intermediate_values = _trial_system_attrs.get(_INTERMEDIATE_VALUE)
+            intermediate_values[epoch] = current_score.item()  # type: ignore[index]
+            self._trial.storage.set_trial_system_attr(
+                self._trial._trial_id, _INTERMEDIATE_VALUE, intermediate_values
+            )
+
+        should_stop = trainer.strategy.broadcast(should_stop)
+        trainer.should_stop = trainer.should_stop or should_stop
+        if not should_stop:
+            return
+
+        if trainer.is_global_zero:
+            self._trial.storage.set_trial_system_attr(
+                self._trial._trial_id, _PRUNED_KEY, True
+            )
+            self._trial.storage.set_trial_system_attr(
+                self._trial._trial_id, _EPOCH_KEY, epoch
+            )
+
+    def check_pruned(self) -> None:
+        """Raise :class:`optuna.TrialPruned` manually if the trial was pruned.
+
+        Currently, ``intermediate_values`` are not properly propagated between
+        processes due to storage caching. Necessary information is kept in
+        ``trial.system_attrs`` when the trial runs in a distributed
+        situation. Call this method right after :meth:`Trainer.fit` returns.
+        Outside of a DDP / RDB-storage context this method is a no-op.
+        """
+        import optuna
+        from optuna.storages._cached_storage import _CachedStorage
+
+        _trial_id = self._trial._trial_id
+        _study = self._trial.study
+        # If the storage is not the cached storage, we are not in a DDP run.
+        if not isinstance(_study._storage, _CachedStorage):
+            return
+
+        _trial_system_attrs = _study._storage._backend.get_trial_system_attrs(_trial_id)
+        is_pruned = _trial_system_attrs.get(_PRUNED_KEY)
+        intermediate_values = _trial_system_attrs.get(_INTERMEDIATE_VALUE)
+
+        # ``intermediate_values is None`` means we are not in a DDP run.
+        if intermediate_values is None:
+            return
+        for epoch, score in intermediate_values.items():
+            self._trial.report(score, step=int(epoch))
+        if is_pruned:
+            epoch = _trial_system_attrs.get(_EPOCH_KEY)
+            raise optuna.TrialPruned(f"Trial was pruned at epoch {epoch}.")
 
 
 class TFMProgressBar(TQDMProgressBar):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,6 @@ optional = [
     "onnxruntime>=1.24.1; python_version >= '3.11'",
     "onnxruntime<1.24.1; python_version < '3.11'",  # 1.24.1 dropped python 3.10 support
     "optuna>=4.7.0",
-    "optuna-integration[pytorch-lightning]>=4.7.0",
     "polars>=1.37.1",
     "pydantic>=2.12.5",
     "ray>=2.53.0",


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Fixes #3093.

### Summary

Implements the direction agreed on in #3093: vendor Optuna's `PyTorchLightningPruningCallback` into Darts and drop the `optuna-integration[pytorch-lightning]` optional dependency.

- **`darts/utils/callbacks.py`** — adds `PyTorchLightningPruningCallback`, a self-contained reimplementation that imports directly from `pytorch_lightning` (which Darts already uses) rather than from `lightning` (which `optuna_integration` imports). The class inherits from `pytorch_lightning.callbacks.Callback` and exposes the same public API (`__init__(trial, monitor)`, `on_fit_start`, `on_validation_end`, `check_pruned`) as the upstream callback, including DDP support via Optuna's `RDBStorage` and the same `ddp_pl:*` trial system-attribute keys so DDP state is portable between the two implementations. Optuna remains an optional dependency: the module imports cleanly without it, and instantiation raises a clear `ImportError` if optuna is missing.

- **`darts/tests/optional_deps/test_optuna.py`** — drops the `PatchedPruningCallback` multiple-inheritance workaround (previously needed because `optuna_integration` imports from \`lightning.pytorch\` while Darts uses \`pytorch_lightning\`), and updates `test_optuna_torch_model` to use the new Darts callback directly. Five new unit tests cover the callback in isolation: PL-`Callback` inheritance, the missing-metric warning, pruning when the trial reports `should_prune`, sanity-check short-circuit at epoch 0, and `check_pruned` as a no-op outside DDP.

- **`pyproject.toml`** — removes `optuna-integration[pytorch-lightning]>=4.7.0` from the `optional` dependencies. Only `optuna>=4.7.0` is retained.

- **`examples/17-hyperparameter-optimization.ipynb`** — imports the callback from `darts.utils.callbacks` instead of `optuna.integration`.

- **`CHANGELOG.md`** — Unreleased entry under both **Improved** and **Dependencies**.

### Other Information

- All 10 tests in `darts/tests/optional_deps/test_optuna.py` pass locally on Python 3.13 with `pytorch-lightning==2.5.2` and `optuna==4.8.0`.
- `pre-commit` (ruff, ruff-format, end-of-file fixer, etc.) runs clean on all touched files.
- The `pl.__version__ >= 1.6.0` check from the upstream callback was dropped because Darts already requires `pytorch-lightning>=2.0.0`.
- Marked as draft so the design (location of the callback inside `darts.utils.callbacks` rather than a new module, exposure as a public attribute alongside `TFMProgressBar`, opt-in lazy import of optuna) can be reviewed before final polish.

Happy to iterate — please point out anything that should be moved, renamed, or tested more thoroughly.