### PR TITLE
fix: extend zero_division parameter to percentage and range-based metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- 🔴 Percentage and range-based metrics (`ape`, `mape`, `sape`, `smape`, `wmape`, `ope`, `arre`, `marre`, `coefficient_of_variation`) now expose a `zero_division` parameter (mirroring [#3059](https://github.com/unit8co/darts/pull/3059)) that controls the behavior when the denominator is exactly zero. `"warn"` (default) emits a warning and uses `0.0` when the numerator is also zero or `np.nan` otherwise; `"raise"` raises a `ValueError`. For `ape`/`mape`, this replaces the previous unconditional `ValueError` on a zero in `actual_series`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
+
 **Fixed**
+
+- Fixed `arre`/`marre` rejecting an entire input when any component of `actual_series` is constant; the zero-range denominator is now handled element-wise, so an exact prediction yields `0.0` and only undefined entries become `np.nan`. Also fixed `ope` to accept an `actual_series` with a strictly negative sum (the previous `sum > 0` check rejected valid inputs such as financial return series), and corrected the `wmape` docstring which inaccurately claimed it raised on zeros in `actual_series`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
-- 🔴 Percentage and range-based metrics (`ape`, `mape`, `sape`, `smape`, `wmape`, `ope`, `arre`, `marre`, `coefficient_of_variation`) now expose a `zero_division` parameter (mirroring [#3059](https://github.com/unit8co/darts/pull/3059)) that controls the behavior when the denominator is exactly zero. `"warn"` (default) emits a warning and uses `0.0` when the numerator is also zero or `np.nan` otherwise; `"raise"` raises a `ValueError`. For `ape`/`mape`, this replaces the previous unconditional `ValueError` on a zero in `actual_series`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
+- 🔴 Percentage and range-based metrics (`ape`, `mape`, `sape`, `smape`, `wmape`, `ope`, `arre`, `marre`, `coefficient_of_variation`) no longer raise a hard `ValueError` when the denominator is exactly zero. A new `zero_division` parameter controls the behavior: [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
+  - `"warn"` (default) raises a warning and returns `0.0` when the numerator is also zero (typically meaning perfect forecasts) or `np.nan` otherwise
+  - `"raise"` preserves the legacy error.
 
 **Fixed**
 
-- Fixed `arre`/`marre` rejecting an entire input when any component of `actual_series` is constant; the zero-range denominator is now handled element-wise, so an exact prediction yields `0.0` and only undefined entries become `np.nan`. Also fixed `ope` to accept an `actual_series` with a strictly negative sum (the previous `sum > 0` check rejected valid inputs such as financial return series), and corrected the `wmape` docstring which inaccurately claimed it raised on zeros in `actual_series`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
+- Fixed metrics `arre` and `marre` rejecting an entire input when any component of `actual_series` is constant; the zero-range denominator is now handled element-wise, so an exact prediction yields `0.0` and only undefined entries become `np.nan`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
+- Fixed metric `ope` to accept an `actual_series` with a strictly negative sum (the previous `sum > 0` check rejected valid inputs such as financial return series). [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
+- Fixed metric `wmape` docstring which inaccurately claimed it raised on zeros in `actual_series`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
 
 **Dependencies**
 

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -13,8 +13,6 @@ import pandas as pd
 from darts.dataprocessing import dtw
 from darts.logging import raise_log
 from darts.metrics.utils import (
-    _PERCENTAGE_ZERO_DIVISION_ERROR,
-    _PERCENTAGE_ZERO_DIVISION_WARNING,
     METRIC_OUTPUT_TYPE,
     SMPL_AX,
     TIME_AX,
@@ -26,7 +24,7 @@ from darts.metrics.utils import (
     _get_values_or_raise,
     _get_wrapped_metric,
     _LabelReduction,
-    _safe_scaled_divide,
+    _safe_divide,
     classification_support,
     interval_support,
     multi_ts_support,
@@ -536,7 +534,7 @@ def ase(
         intersect,
         q=q,
     )
-    return _safe_scaled_divide(errors, error_scale, zero_division=zero_division)
+    return _safe_divide(errors, error_scale, zero_division=zero_division)
 
 
 @multi_ts_support
@@ -978,7 +976,11 @@ def sse(
         intersect,
         q=q,
     )
-    return _safe_scaled_divide(errors, error_scale, zero_division=zero_division)
+    return _safe_divide(
+        errors,
+        error_scale,
+        zero_division=zero_division,
+    )
 
 
 @multi_ts_support
@@ -1313,7 +1315,7 @@ def rmsse(
         intersect,
         q=q,
     )
-    return _safe_scaled_divide(errors, error_scale, zero_division=zero_division)
+    return _safe_divide(errors, error_scale, zero_division=zero_division)
 
 
 @multi_ts_support
@@ -1532,8 +1534,8 @@ def ape(
     .. math:: 100 \\cdot \\left| \\frac{y_t - \\hat{y}_t}{y_t} \\right|
 
     When :math:`y_t = 0` for some :math:`t` the term is undefined; the behavior is then controlled by
-    the ``zero_division`` parameter. Consider using the Absolute Scaled Error
-    (:func:`~darts.metrics.metrics.ase`) in these cases.
+    the ``zero_division`` parameter. Consider using the Absolute Scaled Error (:func:`~darts.metrics.metrics.ase`)
+    in these cases.
 
     If :math:`\\hat{y}_t` are stochastic (contains several samples) or quantile predictions, use parameter `q` to
     specify on which quantile(s) to compute the metric on. By default, it uses the median 0.5 quantile
@@ -1551,11 +1553,10 @@ def ape(
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
     zero_division
-        Controls behavior when the denominator :math:`y_t` is zero (i.e. ``actual_series`` is zero
-        at some time step).
+        Controls behavior when the denominator :math:`y_t` is zero (i.e. ``actual_series`` is zero at some time step).
 
-        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
-          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator also zero) and ``np.nan``
+          otherwise, and emits a warning.
         * ``"raise"`` – raises a ``ValueError``.
     time_reduction
         Optionally, a function to aggregate the metrics over the time axis. It must reduce a `np.ndarray`
@@ -1620,14 +1621,13 @@ def ape(
         q=q,
     )
     return 100.0 * np.abs(
-        _safe_scaled_divide(
+        _safe_divide(
             y_true - y_pred,
             y_true,
             zero_division=zero_division,
             zero_fill=0.0,
             strict_zero=True,
-            error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
-            warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
+            metric_type="percentage",
         )
     )
 
@@ -1674,11 +1674,10 @@ def mape(
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
     zero_division
-        Controls behavior when the denominator :math:`y_t` is zero (i.e. ``actual_series`` is zero
-        at some time step).
+        Controls behavior when the denominator :math:`y_t` is zero (i.e. ``actual_series`` is zero at some time step).
 
-        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
-          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator also zero) and ``np.nan``
+          otherwise, and emits a warning.
         * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
@@ -1780,8 +1779,8 @@ def wmape(
         Controls behavior when the denominator :math:`\\sum_{t=1}^T |y_t|` is zero (i.e. ``actual_series`` is
         all zeros for a given component).
 
-        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
-          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator also zero) and ``np.nan``
+          otherwise, and emits a warning.
         * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
@@ -1838,21 +1837,17 @@ def wmape(
         actual_series,
         pred_series,
         intersect,
-        remove_nan_union=False,
+        remove_nan_union=True,
         q=q,
     )
-    valid = np.any(~np.isnan(y_true) & ~np.isnan(y_pred), axis=TIME_AX)
-    errors = np.nansum(np.abs(y_true - y_pred), axis=TIME_AX)
-    scale = np.nansum(np.abs(y_true), axis=TIME_AX)
 
-    return 100.0 * _safe_scaled_divide(
-        np.where(valid, errors, np.nan),
-        np.where(valid, scale, np.nan),
+    return 100.0 * _safe_divide(
+        np.nansum(np.abs(y_true - y_pred), axis=TIME_AX),
+        np.nansum(np.abs(y_true), axis=TIME_AX),
         zero_division=zero_division,
         zero_fill=0.0,
         strict_zero=True,
-        error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
-        warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
+        metric_type="percentage",
     )
 
 
@@ -1965,17 +1960,13 @@ def sape(
         remove_nan_union=True,
         q=q,
     )
-    denominator = np.abs(y_true) + np.abs(y_pred)
-    return 200.0 * np.abs(
-        _safe_scaled_divide(
-            y_true - y_pred,
-            denominator,
-            zero_division=zero_division,
-            zero_fill=0.0,
-            strict_zero=True,
-            error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
-            warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
-        )
+    return 200.0 * _safe_divide(
+        np.abs(y_true - y_pred),
+        np.abs(y_true) + np.abs(y_pred),
+        zero_division=zero_division,
+        zero_fill=0.0,
+        strict_zero=True,
+        metric_type="percentage",
     )
 
 
@@ -2126,8 +2117,8 @@ def ope(
     zero_division
         Controls behavior when the denominator :math:`\\sum_{t=1}^{T}{y_t}` is zero.
 
-        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
-          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator also zero) and ``np.nan``
+          otherwise, and emits a warning.
         * ``"raise"`` – raises a ``ValueError``.
 
         Note: a negative sum is a valid denominator (e.g. financial return series). Only an exact
@@ -2190,20 +2181,15 @@ def ope(
         np.nansum(y_true, axis=TIME_AX),
         np.nansum(y_pred, axis=TIME_AX),
     )
-    valid = np.any(~np.isnan(y_true) & ~np.isnan(y_pred), axis=TIME_AX)
-    return (
-        np.abs(
-            _safe_scaled_divide(
-                np.where(valid, y_true_sum - y_pred_sum, np.nan),
-                np.where(valid, y_true_sum, np.nan),
-                zero_division=zero_division,
-                zero_fill=0.0,
-                strict_zero=True,
-                error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
-                warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
-            )
+    return 100.0 * np.abs(
+        _safe_divide(
+            y_true_sum - y_pred_sum,
+            y_true_sum,
+            zero_division=zero_division,
+            zero_fill=0.0,
+            strict_zero=True,
+            metric_type="percentage",
         )
-        * 100.0
     )
 
 
@@ -2246,11 +2232,11 @@ def arre(
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
     zero_division
-        Controls behavior when the denominator :math:`\\max_t{y_t} - \\min_t{y_t}` is zero (i.e.
-        ``actual_series`` is constant for a given component).
+        Controls behavior when the denominator :math:`\\max_t{y_t} - \\min_t{y_t}` is zero (i.e. ``actual_series`` is
+        constant for a given component).
 
-        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
-          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator also zero) and ``np.nan``
+          otherwise, and emits a warning.
         * ``"raise"`` – raises a ``ValueError``.
     time_reduction
         Optionally, a function to aggregate the metrics over the time axis. It must reduce a `np.ndarray`
@@ -2315,16 +2301,14 @@ def arre(
         q=q,
     )
     y_max, y_min = np.nanmax(y_true, axis=TIME_AX), np.nanmin(y_true, axis=TIME_AX)
-    true_range = y_max - y_min
     return 100.0 * np.abs(
-        _safe_scaled_divide(
+        _safe_divide(
             y_true - y_pred,
-            true_range,
+            y_max - y_min,
             zero_division=zero_division,
             zero_fill=0.0,
             strict_zero=True,
-            error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
-            warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
+            metric_type="percentage",
         )
     )
 
@@ -2368,11 +2352,11 @@ def marre(
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
     zero_division
-        Controls behavior when the denominator :math:`\\max_t{y_t} - \\min_t{y_t}` is zero (i.e.
-        ``actual_series`` is constant for a given component).
+        Controls behavior when the denominator :math:`\\max_t{y_t} - \\min_t{y_t}` is zero (i.e. ``actual_series``
+        is constant for a given component).
 
-        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
-          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator also zero) and ``np.nan``
+          otherwise, and emits a warning.
         * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
@@ -2570,8 +2554,8 @@ def coefficient_of_variation(
     zero_division
         Controls behavior when the denominator :math:`\\bar{y}` (the mean of ``actual_series``) is zero.
 
-        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
-          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator also zero) and ``np.nan``
+          otherwise, and emits a warning.
         * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
@@ -2628,14 +2612,13 @@ def coefficient_of_variation(
         q=q,
     )
     # not calling rmse as y_true and y_pred are np.ndarray
-    return 100 * _safe_scaled_divide(
+    return 100.0 * _safe_divide(
         np.sqrt(np.nanmean((y_true - y_pred) ** 2, axis=TIME_AX)),
         np.nanmean(y_true, axis=TIME_AX),
         zero_division=zero_division,
         zero_fill=0.0,
         strict_zero=True,
-        error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
-        warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
+        metric_type="percentage",
     )
 
 

--- a/darts/metrics/metrics.py
+++ b/darts/metrics/metrics.py
@@ -13,6 +13,8 @@ import pandas as pd
 from darts.dataprocessing import dtw
 from darts.logging import raise_log
 from darts.metrics.utils import (
+    _PERCENTAGE_ZERO_DIVISION_ERROR,
+    _PERCENTAGE_ZERO_DIVISION_WARNING,
     METRIC_OUTPUT_TYPE,
     SMPL_AX,
     TIME_AX,
@@ -1514,6 +1516,7 @@ def ape(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     time_reduction: Callable[..., np.ndarray] | None = None,
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
@@ -1528,8 +1531,9 @@ def ape(
 
     .. math:: 100 \\cdot \\left| \\frac{y_t - \\hat{y}_t}{y_t} \\right|
 
-    Note that it will raise a `ValueError` if :math:`y_t = 0` for some :math:`t`. Consider using
-    the Absolute Scaled Error (:func:`~darts.metrics.metrics.ase`) in these cases.
+    When :math:`y_t = 0` for some :math:`t` the term is undefined; the behavior is then controlled by
+    the ``zero_division`` parameter. Consider using the Absolute Scaled Error
+    (:func:`~darts.metrics.metrics.ase`) in these cases.
 
     If :math:`\\hat{y}_t` are stochastic (contains several samples) or quantile predictions, use parameter `q` to
     specify on which quantile(s) to compute the metric on. By default, it uses the median 0.5 quantile
@@ -1546,6 +1550,13 @@ def ape(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when the denominator :math:`y_t` is zero (i.e. ``actual_series`` is zero
+        at some time step).
+
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
+          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     time_reduction
         Optionally, a function to aggregate the metrics over the time axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(c,)`. The function takes as input a ``np.ndarray`` and a
@@ -1574,7 +1585,7 @@ def ape(
     Raises
     ------
     ValueError
-        If `actual_series` contains some zeros.
+        If `zero_division="raise"` and `actual_series` contains a zero.
 
     Returns
     -------
@@ -1608,13 +1619,17 @@ def ape(
         remove_nan_union=False,
         q=q,
     )
-    if not (y_true != 0).all():
-        raise_log(
-            ValueError(
-                "`actual_series` must be strictly positive to compute the MAPE."
-            ),
+    return 100.0 * np.abs(
+        _safe_scaled_divide(
+            y_true - y_pred,
+            y_true,
+            zero_division=zero_division,
+            zero_fill=0.0,
+            strict_zero=True,
+            error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
+            warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
         )
-    return 100.0 * np.abs((y_true - y_pred) / y_true)
+    )
 
 
 @multi_ts_support
@@ -1625,6 +1640,7 @@ def mape(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
@@ -1638,8 +1654,9 @@ def mape(
 
     .. math:: 100 \\cdot \\frac{1}{T} \\sum_{t=1}^{T}{\\left| \\frac{y_t - \\hat{y}_t}{y_t} \\right|}
 
-    Note that it will raise a `ValueError` if :math:`y_t = 0` for some :math:`t`. Consider using
-    the Mean Absolute Scaled Error (:func:`~darts.metrics.metrics.mase`) in these cases.
+    When :math:`y_t = 0` for some :math:`t` the term is undefined; the behavior is then controlled by
+    the ``zero_division`` parameter. Consider using the Mean Absolute Scaled Error
+    (:func:`~darts.metrics.metrics.mase`) in these cases.
 
     If :math:`\\hat{y}_t` are stochastic (contains several samples) or quantile predictions, use parameter `q` to
     specify on which quantile(s) to compute the metric on. By default, it uses the median 0.5 quantile
@@ -1656,6 +1673,13 @@ def mape(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when the denominator :math:`y_t` is zero (i.e. ``actual_series`` is zero
+        at some time step).
+
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
+          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
@@ -1679,7 +1703,7 @@ def mape(
     Raises
     ------
     ValueError
-        If `actual_series` contains some zeros.
+        If `zero_division="raise"` and `actual_series` contains a zero.
 
     Returns
     -------
@@ -1709,6 +1733,7 @@ def mape(
             pred_series,
             intersect,
             q=q,
+            zero_division=zero_division,
         ),
         axis=TIME_AX,
     )
@@ -1722,6 +1747,7 @@ def wmape(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
@@ -1750,6 +1776,13 @@ def wmape(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when the denominator :math:`\\sum_{t=1}^T |y_t|` is zero (i.e. ``actual_series`` is
+        all zeros for a given component).
+
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
+          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
@@ -1773,7 +1806,7 @@ def wmape(
     Raises
     ------
     ValueError
-        If `actual_series` contains some zeros.
+        If `zero_division="raise"` and the denominator :math:`\\sum_{t=1}^T |y_t|` is zero for some component.
 
     Returns
     -------
@@ -1808,11 +1841,18 @@ def wmape(
         remove_nan_union=False,
         q=q,
     )
+    valid = np.any(~np.isnan(y_true) & ~np.isnan(y_pred), axis=TIME_AX)
+    errors = np.nansum(np.abs(y_true - y_pred), axis=TIME_AX)
+    scale = np.nansum(np.abs(y_true), axis=TIME_AX)
 
-    return (
-        100.0
-        * np.nansum(np.abs(y_true - y_pred), axis=TIME_AX)
-        / np.nansum(np.abs(y_true), axis=TIME_AX)
+    return 100.0 * _safe_scaled_divide(
+        np.where(valid, errors, np.nan),
+        np.where(valid, scale, np.nan),
+        zero_division=zero_division,
+        zero_fill=0.0,
+        strict_zero=True,
+        error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
+        warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
     )
 
 
@@ -1824,6 +1864,7 @@ def sape(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     time_reduction: Callable[..., np.ndarray] | None = None,
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
@@ -1840,7 +1881,7 @@ def sape(
         200 \\cdot \\frac{\\left| y_t - \\hat{y}_t \\right|}{\\left| y_t \\right| + \\left| \\hat{y}_t \\right|}
 
     When :math:`\\left| y_t \\right| + \\left| \\hat{y}_t \\right| = 0` for some :math:`t` (i.e., both actual and
-    prediction are zero), the error for that time step is defined as 0.
+    prediction are zero), the behavior is controlled by the ``zero_division`` parameter.
 
     If :math:`\\hat{y}_t` are stochastic (contains several samples) or quantile predictions, use parameter `q` to
     specify on which quantile(s) to compute the metric on. By default, it uses the median 0.5 quantile
@@ -1857,6 +1898,11 @@ def sape(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when both ``actual_series`` and ``pred_series`` are zero at the same time step.
+
+        * ``"warn"`` (default) – returns ``0.0`` and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     time_reduction
         Optionally, a function to aggregate the metrics over the time axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(c,)`. The function takes as input a ``np.ndarray`` and a
@@ -1881,6 +1927,11 @@ def sape(
         Optionally, whether to print operations progress.
     name
         Optionally, the metric name to display. If `None`, will use the metric function name.
+
+    Raises
+    ------
+    ValueError
+        If `zero_division="raise"` and both series contain a zero at the same time step.
 
     Returns
     -------
@@ -1914,13 +1965,17 @@ def sape(
         remove_nan_union=True,
         q=q,
     )
-    numerator = 200 * np.abs(y_true - y_pred)
     denominator = np.abs(y_true) + np.abs(y_pred)
-    return np.divide(
-        numerator,
-        denominator,
-        out=np.zeros_like(numerator, dtype=y_true.dtype),
-        where=denominator != 0,
+    return 200.0 * np.abs(
+        _safe_scaled_divide(
+            y_true - y_pred,
+            denominator,
+            zero_division=zero_division,
+            zero_fill=0.0,
+            strict_zero=True,
+            error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
+            warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
+        )
     )
 
 
@@ -1932,6 +1987,7 @@ def smape(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
@@ -1948,7 +2004,7 @@ def smape(
         \\sum_{t=1}^{T}{\\frac{\\left| y_t - \\hat{y}_t \\right|}{\\left| y_t \\right| + \\left| \\hat{y}_t \\right|} }
 
     When :math:`\\left| y_t \\right| + \\left| \\hat{y}_t \\right| = 0` for some :math:`t` (i.e., both actual and
-    prediction are zero), the error for that time step is 0.
+    prediction are zero), the behavior is controlled by the ``zero_division`` parameter.
 
     If :math:`\\hat{y}_t` are stochastic (contains several samples) or quantile predictions, use parameter `q` to
     specify on which quantile(s) to compute the metric on. By default, it uses the median 0.5 quantile
@@ -1965,6 +2021,11 @@ def smape(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when both ``actual_series`` and ``pred_series`` are zero at the same time step.
+
+        * ``"warn"`` (default) – uses ``0.0`` for that time step and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
@@ -1984,6 +2045,11 @@ def smape(
         Optionally, whether to print operations progress.
     name
         Optionally, the metric name to display. If `None`, will use the metric function name.
+
+    Raises
+    ------
+    ValueError
+        If `zero_division="raise"` and both series contain a zero at the same time step.
 
     Returns
     -------
@@ -2013,6 +2079,7 @@ def smape(
             pred_series,
             intersect,
             q=q,
+            zero_division=zero_division,
         ),
         axis=TIME_AX,
     )
@@ -2026,6 +2093,7 @@ def ope(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
@@ -2055,6 +2123,15 @@ def ope(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when the denominator :math:`\\sum_{t=1}^{T}{y_t}` is zero.
+
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
+          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
+
+        Note: a negative sum is a valid denominator (e.g. financial return series). Only an exact
+        zero sum triggers the zero-division handling.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
@@ -2078,7 +2155,7 @@ def ope(
     Raises
     ------
     ValueError
-        If :math:`\\sum_{t=1}^{T}{y_t} = 0`.
+        If `zero_division="raise"` and :math:`\\sum_{t=1}^{T}{y_t} = 0` for some component.
 
     Returns
     -------
@@ -2113,13 +2190,21 @@ def ope(
         np.nansum(y_true, axis=TIME_AX),
         np.nansum(y_pred, axis=TIME_AX),
     )
-    if not (y_true_sum > 0).all():
-        raise_log(
-            ValueError(
-                "The series of actual value cannot sum to zero when computing OPE."
-            ),
+    valid = np.any(~np.isnan(y_true) & ~np.isnan(y_pred), axis=TIME_AX)
+    return (
+        np.abs(
+            _safe_scaled_divide(
+                np.where(valid, y_true_sum - y_pred_sum, np.nan),
+                np.where(valid, y_true_sum, np.nan),
+                zero_division=zero_division,
+                zero_fill=0.0,
+                strict_zero=True,
+                error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
+                warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
+            )
         )
-    return np.abs((y_true_sum - y_pred_sum) / y_true_sum) * 100.0
+        * 100.0
+    )
 
 
 @multi_ts_support
@@ -2130,6 +2215,7 @@ def arre(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     time_reduction: Callable[..., np.ndarray] | None = None,
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
@@ -2159,6 +2245,13 @@ def arre(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when the denominator :math:`\\max_t{y_t} - \\min_t{y_t}` is zero (i.e.
+        ``actual_series`` is constant for a given component).
+
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
+          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     time_reduction
         Optionally, a function to aggregate the metrics over the time axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(c,)`. The function takes as input a ``np.ndarray`` and a
@@ -2187,7 +2280,7 @@ def arre(
     Raises
     ------
     ValueError
-        If :math:`\\max_t{y_t} = \\min_t{y_t}`.
+        If `zero_division="raise"` and :math:`\\max_t{y_t} = \\min_t{y_t}` for some component.
 
     Returns
     -------
@@ -2222,15 +2315,18 @@ def arre(
         q=q,
     )
     y_max, y_min = np.nanmax(y_true, axis=TIME_AX), np.nanmin(y_true, axis=TIME_AX)
-    if not (y_max > y_min).all():
-        raise_log(
-            ValueError(
-                "The difference between the max and min values must "
-                "be strictly positive to compute the MARRE."
-            ),
-        )
     true_range = y_max - y_min
-    return 100.0 * np.abs((y_true - y_pred) / true_range)
+    return 100.0 * np.abs(
+        _safe_scaled_divide(
+            y_true - y_pred,
+            true_range,
+            zero_division=zero_division,
+            zero_fill=0.0,
+            strict_zero=True,
+            error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
+            warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
+        )
+    )
 
 
 @multi_ts_support
@@ -2241,6 +2337,7 @@ def marre(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
@@ -2270,6 +2367,13 @@ def marre(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when the denominator :math:`\\max_t{y_t} - \\min_t{y_t}` is zero (i.e.
+        ``actual_series`` is constant for a given component).
+
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
+          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
@@ -2293,8 +2397,10 @@ def marre(
     Raises
     ------
     ValueError
-        If :math:`\\max_t{y_t} = \\min_t{y_t}`.
+        If `zero_division="raise"` and :math:`\\max_t{y_t} = \\min_t{y_t}` for some component.
 
+    Returns
+    -------
     float
         A single metric score for:
 
@@ -2317,6 +2423,7 @@ def marre(
             pred_series,
             intersect,
             q=q,
+            zero_division=zero_division,
         ),
         axis=TIME_AX,
     )
@@ -2428,6 +2535,7 @@ def coefficient_of_variation(
     intersect: bool = True,
     *,
     q: float | list[float] | tuple[np.ndarray, pd.Index] | None = None,
+    zero_division: str = "warn",
     component_reduction: Callable[[np.ndarray], float] | None = np.nanmean,
     series_reduction: Callable[[np.ndarray], float | np.ndarray] | None = None,
     n_jobs: int = 1,
@@ -2459,6 +2567,12 @@ def coefficient_of_variation(
         will consider the values only over their common time interval (intersection in time).
     q
         Optionally, the quantile (float [0, 1]) or list of quantiles of interest to compute the metric on.
+    zero_division
+        Controls behavior when the denominator :math:`\\bar{y}` (the mean of ``actual_series``) is zero.
+
+        * ``"warn"`` (default) – returns ``0.0`` for a perfect forecast (numerator
+          also zero) and ``np.nan`` otherwise, and emits a warning.
+        * ``"raise"`` – raises a ``ValueError``.
     component_reduction
         Optionally, a function to aggregate the metrics over the component/column axis. It must reduce a `np.ndarray`
         of shape `(t, c)` to a `np.ndarray` of shape `(t,)`. The function takes as input a ``np.ndarray`` and a
@@ -2478,6 +2592,11 @@ def coefficient_of_variation(
         Optionally, whether to print operations progress.
     name
         Optionally, the metric name to display. If `None`, will use the metric function name.
+
+    Raises
+    ------
+    ValueError
+        If `zero_division="raise"` and :math:`\\bar{y} = 0` for some component.
 
     Returns
     -------
@@ -2509,10 +2628,14 @@ def coefficient_of_variation(
         q=q,
     )
     # not calling rmse as y_true and y_pred are np.ndarray
-    return (
-        100
-        * np.sqrt(np.nanmean((y_true - y_pred) ** 2, axis=TIME_AX))
-        / np.nanmean(y_true, axis=TIME_AX)
+    return 100 * _safe_scaled_divide(
+        np.sqrt(np.nanmean((y_true - y_pred) ** 2, axis=TIME_AX)),
+        np.nanmean(y_true, axis=TIME_AX),
+        zero_division=zero_division,
+        zero_fill=0.0,
+        strict_zero=True,
+        error_msg=_PERCENTAGE_ZERO_DIVISION_ERROR,
+        warning_msg=_PERCENTAGE_ZERO_DIVISION_WARNING,
     )
 
 

--- a/darts/metrics/utils.py
+++ b/darts/metrics/utils.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Sequence
 from enum import Enum
 from functools import wraps
 from inspect import signature
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -643,13 +643,17 @@ def _get_values_or_raise(
     if not remove_nan_union or is_insample:
         return vals_a, vals_b
 
-    isnan_mask = np.expand_dims(
-        np.logical_or(np.isnan(vals_a), np.isnan(vals_b)).any(axis=SMPL_AX), axis=-1
-    )
-    isnan_mask_pred = np.repeat(isnan_mask, vals_b.shape[SMPL_AX], axis=SMPL_AX)
-    return np.where(isnan_mask, np.nan, vals_a), np.where(
-        isnan_mask_pred, np.nan, vals_b
-    )
+    # fast path: most series contain no NaNs
+    nan_a, nan_b = np.isnan(vals_a), np.isnan(vals_b)
+    if not nan_a.any() and not nan_b.any():
+        return vals_a, vals_b
+
+    nan_union = nan_a | nan_b
+    if vals_b.shape[SMPL_AX] > 1:
+        isnan_mask = nan_union.any(axis=SMPL_AX, keepdims=True)
+    else:
+        isnan_mask = nan_union
+    return np.where(isnan_mask, np.nan, vals_a), np.where(isnan_mask, np.nan, vals_b)
 
 
 def _get_quantile_intervals(
@@ -846,18 +850,13 @@ def _get_error_scale(
     return scale
 
 
-def _safe_scaled_divide(
-    errors: np.ndarray,
-    scale: np.ndarray,
+def _safe_divide(
+    numerator: np.ndarray,
+    denominator: np.ndarray,
     zero_division: str = "warn",
     zero_fill: float = 1.0,
     strict_zero: bool = False,
-    error_msg: str = "Cannot use scaled metric with periodical signals.",
-    warning_msg: str = (
-        "The error scale (denominator) is zero for some components. "
-        "Those entries are set to NaN (when numerator is non-zero) or "
-        "1.0 (when numerator is also zero, i.e. on par with naive)."
-    ),
+    metric_type: Literal["scaled", "percentage"] = "scaled",
 ) -> np.ndarray:
     """Divides ``errors`` by ``scale``, handling zero-scale entries gracefully.
 
@@ -875,9 +874,9 @@ def _safe_scaled_divide(
 
     Parameters
     ----------
-    errors
+    numerator
         Numerator array. Broadcasts against ``scale``.
-    scale
+    denominator
         Denominator array. Broadcasts against ``errors``.
     zero_division
         Controls behavior when ``scale`` is (near) zero.
@@ -895,10 +894,8 @@ def _safe_scaled_divide(
         ``False`` (default), values close to zero according to ``np.isclose``
         are also handled as zero. Percentage metrics use exact zeros to avoid
         treating valid small denominators as zero.
-    error_msg
-        The message of the ``ValueError`` raised when ``zero_division="raise"``.
-    warning_msg
-        The warning logged when zero-division handling is applied.
+    metric_type
+        The metric type ('scaled', 'percentage') for logging purposes.
 
     Returns
     -------
@@ -912,28 +909,40 @@ def _safe_scaled_divide(
             ),
         )
 
-    zero_mask = scale == 0.0 if strict_zero else np.isclose(scale, 0.0)
+    zero_mask = denominator == 0.0 if strict_zero else np.isclose(denominator, 0.0)
     if not zero_mask.any():
-        return errors / scale
+        return numerator / denominator
 
     if zero_division == "raise":
-        raise_log(ValueError(error_msg))
+        raise_log(ValueError(_SAFE_DIVIDE_LOGS[metric_type]["exception"]))
 
-    numerator_zero = errors == 0.0 if strict_zero else np.isclose(errors, 0.0)
+    numerator_zero = numerator == 0.0 if strict_zero else np.isclose(numerator, 0.0)
     fill = np.where(numerator_zero, zero_fill, np.nan)
-    result = np.where(zero_mask, fill, errors / np.where(zero_mask, 1.0, scale))
+    result = np.where(
+        zero_mask, fill, numerator / np.where(zero_mask, 1.0, denominator)
+    )
 
-    logger.warning(warning_msg)
+    logger.warning(_SAFE_DIVIDE_LOGS[metric_type]["warning"].format(zero_fill))
     return result
 
 
-_PERCENTAGE_ZERO_DIVISION_ERROR = (
-    "Cannot compute metric: the denominator is zero for some entries."
-)
-_PERCENTAGE_ZERO_DIVISION_WARNING = (
-    "The metric denominator is zero for some entries. Those entries are set to "
-    "NaN when the numerator is non-zero and 0.0 when the numerator is also zero."
-)
+_SAFE_DIVIDE_LOGS = {
+    "scaled": {
+        "exception": "Cannot use scaled metric with periodical signals.",
+        "warning": (
+            "The error scale (denominator) is zero for some components. "
+            "Those entries are set to NaN (when numerator is non-zero) or "
+            "{0} (when numerator is also zero, i.e. on par with naive)."
+        ),
+    },
+    "percentage": {
+        "exception": "Cannot compute metric: the denominator is zero for some entries.",
+        "warning": (
+            "The metric denominator is zero for some entries. Those entries are set to "
+            "NaN when the numerator is non-zero and {0} when the numerator is also zero."
+        ),
+    },
+}
 
 
 def _unique_labels(y_true: np.ndarray, y_pred: np.ndarray) -> list[np.ndarray]:

--- a/darts/metrics/utils.py
+++ b/darts/metrics/utils.py
@@ -850,35 +850,55 @@ def _safe_scaled_divide(
     errors: np.ndarray,
     scale: np.ndarray,
     zero_division: str = "warn",
+    zero_fill: float = 1.0,
+    strict_zero: bool = False,
+    error_msg: str = "Cannot use scaled metric with periodical signals.",
+    warning_msg: str = (
+        "The error scale (denominator) is zero for some components. "
+        "Those entries are set to NaN (when numerator is non-zero) or "
+        "1.0 (when numerator is also zero, i.e. on par with naive)."
+    ),
 ) -> np.ndarray:
     """Divides ``errors`` by ``scale``, handling zero-scale entries gracefully.
 
     When ``zero_division`` is ``"warn"`` (default), the behavior depends on
-    whether the *numerator* is also zero:
+    whether the *numerator* is also considered zero:
 
-    * **Case 1** – scale ≈ 0, errors ≠ 0 (non-zero / zero): the scaled error
-      is undefined, so the result is ``np.nan``.
-    * **Case 2** – scale ≈ 0, errors ≈ 0 (zero / zero): the model is on par
-      with the naive baseline, so the result is ``1.0``.
+    * **Case 1** – zero scale, non-zero errors (non-zero / zero): the result is
+      undefined, so the entry is set to ``np.nan``.
+    * **Case 2** – zero scale, zero errors (zero / zero): the entry is set to
+      ``zero_fill``.
 
-    .. note::
-       Returning ``1.0`` for the 0/0 case assumes "model matches naive baseline"
-       since we cannot distinguish whether the model trivially *is* the seasonal
-       naive or made a non-trivial prediction that happens to match. For practical
-       purposes ``1.0`` is the right default.
+    The fill is applied element-wise, so a single zero-scale component (e.g. a
+    constant ``actual_series`` for a range-based metric) does not contaminate
+    the finite entries of the other components.
 
     Parameters
     ----------
     errors
-        Numerator array of shape ``(t, c)`` or ``(c,)``.
+        Numerator array. Broadcasts against ``scale``.
     scale
-        Denominator array of shape ``(c,)``.
+        Denominator array. Broadcasts against ``errors``.
     zero_division
         Controls behavior when ``scale`` is (near) zero.
 
         * ``"warn"`` (default) – applies the defaults described above
-          (``np.nan`` for case 1, ``1.0`` for case 2) and emits a ``UserWarning``.
+          (``np.nan`` for case 1, ``zero_fill`` for case 2) and emits a
+          warning.
         * ``"raise"`` – raises a ``ValueError`` (the legacy behavior).
+    zero_fill
+        The value for the ``0 / 0`` case under ``"warn"``. Use ``1.0`` for
+        scaled-error metrics ("on par with the naive baseline") and ``0.0`` for
+        percentage metrics ("a perfect forecast").
+    strict_zero
+        If ``True``, only exact zeros trigger zero-division handling. If
+        ``False`` (default), values close to zero according to ``np.isclose``
+        are also handled as zero. Percentage metrics use exact zeros to avoid
+        treating valid small denominators as zero.
+    error_msg
+        The message of the ``ValueError`` raised when ``zero_division="raise"``.
+    warning_msg
+        The warning logged when zero-division handling is applied.
 
     Returns
     -------
@@ -892,30 +912,28 @@ def _safe_scaled_divide(
             ),
         )
 
-    zero_mask = np.isclose(scale, 0.0)
+    zero_mask = scale == 0.0 if strict_zero else np.isclose(scale, 0.0)
     if not zero_mask.any():
         return errors / scale
 
-    # --- legacy behavior: raise on zero scale ---
     if zero_division == "raise":
-        raise_log(
-            ValueError("Cannot use scaled metric with periodical signals."),
-        )
+        raise_log(ValueError(error_msg))
 
-    # Determine the fill value for zero-scale entries in a single pass.
-    # For numeric zero_division: use that value everywhere.
-    # For "warn": Case 1 (non-zero / zero) → nan, Case 2 (0 / 0) → 1.0.
-    fill = np.where(np.isclose(errors, 0.0), 1.0, np.nan)
-
-    # Single-pass: where scale ≈ 0 use fill, otherwise normal division
+    numerator_zero = errors == 0.0 if strict_zero else np.isclose(errors, 0.0)
+    fill = np.where(numerator_zero, zero_fill, np.nan)
     result = np.where(zero_mask, fill, errors / np.where(zero_mask, 1.0, scale))
 
-    logger.warning(
-        "The error scale (denominator) is zero for some components. "
-        "Those entries are set to NaN (when numerator is non-zero) or "
-        "1.0 (when numerator is also zero, i.e. on par with naive)."
-    )
+    logger.warning(warning_msg)
     return result
+
+
+_PERCENTAGE_ZERO_DIVISION_ERROR = (
+    "Cannot compute metric: the denominator is zero for some entries."
+)
+_PERCENTAGE_ZERO_DIVISION_WARNING = (
+    "The metric denominator is zero for some entries. Those entries are set to "
+    "NaN when the numerator is non-zero and 0.0 when the numerator is also zero."
+)
 
 
 def _unique_labels(y_true: np.ndarray, y_pred: np.ndarray) -> list[np.ndarray]:

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -227,15 +227,62 @@ class TestMetrics:
             metrics.mape,
         ],
     )
-    def test_ape_zero(self, metric):
-        with pytest.raises(ValueError):
-            metric(self.series1, self.series1)
+    def test_ape_zero(self, metric, caplog):
+        # A zero in `actual_series` is now handled via `zero_division` (default
+        # "warn") instead of always raising.
+        zero_actual = TimeSeries.from_values(np.zeros((10, 1)))
+        some_pred = TimeSeries.from_values(np.ones((10, 1)))
+
+        # x/0 (zero actual, non-zero error) -> NaN + warning
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            result = metric(zero_actual, some_pred, component_reduction=None)
+        assert "denominator" in caplog.text
+        assert np.all(np.isnan(np.atleast_1d(result)))
+
+        # 0/0 (perfect forecast on a zero actual) -> 0.0 (best score)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            result = metric(zero_actual, zero_actual, component_reduction=None)
+        assert "denominator" in caplog.text
+        assert np.all(np.atleast_1d(result) == 0.0)
+
+        # "raise" preserves the legacy raising behavior
+        with pytest.raises(ValueError, match="denominator"):
+            metric(self.series1, self.series1, zero_division="raise")
+
+        # invalid value rejected
+        with pytest.raises(ValueError, match="`zero_division` must be"):
+            metric(self.series1, self.series1, zero_division="invalid")
+
+        # strictly-positive actual: no warning, finite result
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            out = metric(self.series2, self.series2 + 1.0, component_reduction=None)
+        assert "denominator" not in caplog.text
+        assert not np.any(np.isnan(np.atleast_1d(out)))
+
+    def test_ape_elementwise_mixed_zero(self, caplog):
+        """`ape`'s denominator is the per-timestep actual, so zeros are handled
+        element-wise: an exact prediction at a zero actual -> 0.0, a wrong one
+        -> NaN, while the non-zero timesteps are unaffected."""
+        actual = TimeSeries.from_values(np.array([0.0, 4.0, 0.0, 8.0]).reshape(-1, 1))
+        pred = TimeSeries.from_values(np.array([0.0, 4.0, 1.0, 8.0]).reshape(-1, 1))
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            result = metrics.ape(
+                actual, pred, time_reduction=None, component_reduction=None
+            )
+        assert "denominator" in caplog.text
+        np.testing.assert_array_equal(result.ravel(), [0.0, 0.0, np.nan, 0.0])
 
     def test_ope_zero(self):
+        # Legacy raising behavior is now opt-in via `zero_division="raise"`.
         with pytest.raises(ValueError):
             metrics.ope(
                 self.series1 - self.series1.to_series().mean(),
                 self.series1 - self.series1.to_series().mean(),
+                zero_division="raise",
             )
 
     @pytest.mark.parametrize(
@@ -245,13 +292,23 @@ class TestMetrics:
             metrics.smape,
         ],
     )
-    def test_sape_zero_denom(self, metric):
-        assert np.allclose(metric(self.series0, self.series0), 0.0), (
-            "Expected SAPE to be 0.0 when both series are identical"
-        )
-        assert np.allclose(metric(self.series1, self.series1), 0.0), (
-            "Expected SAPE to be 0.0 when both series are identical"
-        )
+    def test_sape_zero_denom(self, metric, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = metric(self.series1, self.series1)
+        assert "denominator" in caplog.text
+        assert np.allclose(result, 0.0)
+
+        with pytest.raises(ValueError, match="denominator"):
+            metric(self.series1, self.series1, zero_division="raise")
+
+        with pytest.raises(ValueError, match="`zero_division` must be"):
+            metric(self.series0, self.series0, zero_division="invalid")
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            result = metric(self.series0, self.series0)
+        assert "denominator" not in caplog.text
+        assert np.allclose(result, 0.0)
 
     @pytest.mark.parametrize(
         "config",
@@ -1105,14 +1162,14 @@ class TestMetrics:
         self.helper_test_nan(metric, **kwargs)
         self.helper_test_non_aggregate(metric, is_aggregate)
 
+        # Legacy raising behavior is now opt-in via `zero_division="raise"`.
         with pytest.raises(ValueError) as exc:
             _ = metric(
                 TimeSeries.from_values(np.ones((3, 1, 1))),
                 TimeSeries.from_values(np.ones((3, 1, 1))),
+                zero_division="raise",
             )
-        assert str(exc.value).startswith(
-            "The difference between the max and min values must "
-        )
+        assert "denominator" in str(exc.value)
 
     @pytest.mark.parametrize(
         "metric",
@@ -1184,8 +1241,8 @@ class TestMetrics:
     @pytest.mark.parametrize(
         "config",
         [
-            (metrics.ape, False, {"time_reduction": np.nanmean}),
-            (metrics.mape, True, {}),
+            (metrics.sape, False, {"time_reduction": np.nanmean}),
+            (metrics.smape, True, {}),
         ],
     )
     def test_sape(self, config):
@@ -1474,10 +1531,156 @@ class TestMetrics:
             assert np.all(np.isnan(result[2:]))
         caplog.clear()
 
+    @pytest.mark.parametrize(
+        "metric",
+        [
+            metrics.wmape,
+            metrics.ope,
+            metrics.arre,
+            metrics.marre,
+            metrics.coefficient_of_variation,
+        ],
+    )
+    def test_pct_metrics_zero_division(self, metric, caplog):
+        """Percentage / range-based metrics handle exact zero denominators
+        under the default ``zero_division="warn"`` and raise under
+        ``zero_division="raise"``.
+
+        A constant all-zero ``actual_series`` triggers every denominator
+        these metrics use (sum of absolutes, sum, mean, max-min)."""
+        zero_actual = TimeSeries.from_values(np.zeros((10, 1)))
+        some_pred = TimeSeries.from_values(np.ones((10, 1)))
+
+        # --- default "warn": NaN + warning ---
+        with caplog.at_level(logging.WARNING):
+            result = metric(zero_actual, some_pred, component_reduction=None)
+        assert "denominator" in caplog.text
+        assert np.all(np.isnan(np.atleast_1d(result)))
+        caplog.clear()
+
+        # --- perfect forecast on a zero denominator: 0/0 -> 0.0 ---
+        with caplog.at_level(logging.WARNING):
+            perfect = metric(zero_actual, zero_actual, component_reduction=None)
+        assert "denominator" in caplog.text
+        assert np.all(np.atleast_1d(perfect) == 0.0)
+        caplog.clear()
+
+        # --- "raise": ValueError ---
+        with pytest.raises(ValueError, match="denominator"):
+            metric(zero_actual, some_pred, zero_division="raise")
+
+        # --- invalid value rejected ---
+        with pytest.raises(ValueError, match="`zero_division` must be"):
+            metric(zero_actual, some_pred, zero_division="invalid")
+
+        # --- non-zero denominator: no warning, finite result ---
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            result_normal = metric(self.series1, self.series2, component_reduction=None)
+        assert "denominator" not in caplog.text
+        assert not np.any(np.isnan(np.atleast_1d(result_normal)))
+
+    @pytest.mark.parametrize(
+        "metric",
+        [
+            metrics.ape,
+            metrics.mape,
+            metrics.sape,
+            metrics.smape,
+            metrics.wmape,
+            metrics.ope,
+            metrics.coefficient_of_variation,
+        ],
+    )
+    def test_pct_metrics_small_non_zero_denominator(self, metric, caplog):
+        actual = TimeSeries.from_values(np.full((10, 1), 1e-9))
+        pred = TimeSeries.from_values(np.full((10, 1), -1e-9))
+
+        with caplog.at_level(logging.WARNING):
+            result = metric(actual, pred)
+
+        assert "denominator" not in caplog.text
+        assert np.allclose(result, 200.0)
+
+    @pytest.mark.parametrize("metric", [metrics.arre, metrics.marre])
+    def test_range_metrics_small_non_zero_denominator(self, metric, caplog):
+        actual = TimeSeries.from_values(np.array([1e-9, 2e-9]))
+        pred = actual - 1e-9
+
+        with caplog.at_level(logging.WARNING):
+            result = metric(actual, pred)
+
+        assert "denominator" not in caplog.text
+        assert np.allclose(result, 100.0)
+
+    @pytest.mark.parametrize("metric", [metrics.wmape, metrics.ope])
+    def test_pct_aggregate_all_nan(self, metric, caplog):
+        all_nan = TimeSeries.from_values(np.full((10, 1), np.nan))
+
+        with caplog.at_level(logging.WARNING):
+            result = metric(all_nan, all_nan, component_reduction=None)
+
+        assert "denominator" not in caplog.text
+        assert np.all(np.isnan(np.atleast_1d(result)))
+
+    def test_arre_constant_actual_elementwise(self, caplog):
+        """A constant ``actual_series`` makes the range (denominator) zero. The
+        unified helper fills element-wise: an exact prediction -> 0.0 (perfect
+        forecast), the others -> NaN, instead of NaN-ing the whole component."""
+        constant_actual = TimeSeries.from_values(np.full((4, 1), 5.0))
+        pred = TimeSeries.from_values(np.array([5.0, 9.0, 5.0, 2.0]).reshape(-1, 1))
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            result = metrics.arre(
+                constant_actual, pred, time_reduction=None, component_reduction=None
+            )
+        assert "denominator" in caplog.text
+        np.testing.assert_array_equal(result.ravel(), [0.0, np.nan, 0.0, np.nan])
+
+    @pytest.mark.parametrize(
+        "metric",
+        [
+            metrics.wmape,
+            metrics.ope,
+            metrics.arre,
+            metrics.marre,
+            metrics.coefficient_of_variation,
+        ],
+    )
+    def test_pct_metrics_zero_division_multivariate(self, metric, caplog):
+        """A single zero-denominator component must not contaminate the finite
+        components: the fill is element-wise (mirrors the scaled-metric test).
+        The component axis is the last axis for every return shape."""
+        normal = np.arange(1.0, 11.0)  # non-zero, non-constant -> finite denominator
+        zeros = np.zeros(10)  # zero denominator for every percentage/range metric
+        actual = TimeSeries.from_values(np.stack([normal, zeros], axis=1))
+
+        # exact prediction on the zero-denominator component -> 0.0 (perfect)
+        pred_exact = TimeSeries.from_values(np.stack([normal + 1.0, zeros], axis=1))
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            res = np.asarray(metric(actual, pred_exact, component_reduction=None))
+        assert "denominator" in caplog.text
+        assert res.shape[-1] == 2
+        assert np.all(np.isfinite(res[..., 0]))
+        assert np.all(res[..., 1] == 0.0)
+
+        # wrong prediction on the zero-denominator component -> NaN
+        pred_wrong = TimeSeries.from_values(
+            np.stack([normal + 1.0, np.ones(10)], axis=1)
+        )
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            res = np.asarray(metric(actual, pred_wrong, component_reduction=None))
+        assert res.shape[-1] == 2
+        assert np.all(np.isfinite(res[..., 0]))
+        assert np.all(np.isnan(res[..., 1]))
+
     def test_ope(self):
         self.helper_test_multivariate_duplication_equality(metrics.ope)
         self.helper_test_multiple_ts_duplication_equality(metrics.ope)
         self.helper_test_nan(metrics.ope)
+        self.helper_test_negative(metrics.ope)
 
     def test_rho_risk(self):
         # deterministic not supported
@@ -1958,6 +2161,14 @@ class TestMetrics:
                 s._values[-1, :, :] = np.nan
             nan_metric = metric([s + 1 for s in nan_s11], s22, **kwargs)
             np.testing.assert_array_equal(non_nan_metric, nan_metric)
+
+    def helper_test_negative(self, metric, **kwargs):
+        actual = -self.series2
+        pred = actual + 0.1
+        expected = 100.0 * abs(
+            (actual.values().sum() - pred.values().sum()) / actual.values().sum()
+        )
+        np.testing.assert_allclose(metric(actual, pred, **kwargs), expected)
 
     def helper_test_non_aggregate(self, metric, is_aggregate, val_exp=None):
         if is_aggregate:

--- a/darts/tests/metrics/test_metrics.py
+++ b/darts/tests/metrics/test_metrics.py
@@ -227,57 +227,11 @@ class TestMetrics:
             metrics.mape,
         ],
     )
-    def test_ape_zero(self, metric, caplog):
-        # A zero in `actual_series` is now handled via `zero_division` (default
-        # "warn") instead of always raising.
-        zero_actual = TimeSeries.from_values(np.zeros((10, 1)))
-        some_pred = TimeSeries.from_values(np.ones((10, 1)))
-
-        # x/0 (zero actual, non-zero error) -> NaN + warning
-        caplog.clear()
-        with caplog.at_level(logging.WARNING):
-            result = metric(zero_actual, some_pred, component_reduction=None)
-        assert "denominator" in caplog.text
-        assert np.all(np.isnan(np.atleast_1d(result)))
-
-        # 0/0 (perfect forecast on a zero actual) -> 0.0 (best score)
-        caplog.clear()
-        with caplog.at_level(logging.WARNING):
-            result = metric(zero_actual, zero_actual, component_reduction=None)
-        assert "denominator" in caplog.text
-        assert np.all(np.atleast_1d(result) == 0.0)
-
-        # "raise" preserves the legacy raising behavior
+    def test_ape_zero(self, metric):
         with pytest.raises(ValueError, match="denominator"):
             metric(self.series1, self.series1, zero_division="raise")
 
-        # invalid value rejected
-        with pytest.raises(ValueError, match="`zero_division` must be"):
-            metric(self.series1, self.series1, zero_division="invalid")
-
-        # strictly-positive actual: no warning, finite result
-        caplog.clear()
-        with caplog.at_level(logging.WARNING):
-            out = metric(self.series2, self.series2 + 1.0, component_reduction=None)
-        assert "denominator" not in caplog.text
-        assert not np.any(np.isnan(np.atleast_1d(out)))
-
-    def test_ape_elementwise_mixed_zero(self, caplog):
-        """`ape`'s denominator is the per-timestep actual, so zeros are handled
-        element-wise: an exact prediction at a zero actual -> 0.0, a wrong one
-        -> NaN, while the non-zero timesteps are unaffected."""
-        actual = TimeSeries.from_values(np.array([0.0, 4.0, 0.0, 8.0]).reshape(-1, 1))
-        pred = TimeSeries.from_values(np.array([0.0, 4.0, 1.0, 8.0]).reshape(-1, 1))
-        caplog.clear()
-        with caplog.at_level(logging.WARNING):
-            result = metrics.ape(
-                actual, pred, time_reduction=None, component_reduction=None
-            )
-        assert "denominator" in caplog.text
-        np.testing.assert_array_equal(result.ravel(), [0.0, 0.0, np.nan, 0.0])
-
     def test_ope_zero(self):
-        # Legacy raising behavior is now opt-in via `zero_division="raise"`.
         with pytest.raises(ValueError):
             metrics.ope(
                 self.series1 - self.series1.to_series().mean(),
@@ -297,18 +251,13 @@ class TestMetrics:
             result = metric(self.series1, self.series1)
         assert "denominator" in caplog.text
         assert np.allclose(result, 0.0)
-
-        with pytest.raises(ValueError, match="denominator"):
-            metric(self.series1, self.series1, zero_division="raise")
-
-        with pytest.raises(ValueError, match="`zero_division` must be"):
-            metric(self.series0, self.series0, zero_division="invalid")
-
         caplog.clear()
+
         with caplog.at_level(logging.WARNING):
             result = metric(self.series0, self.series0)
         assert "denominator" not in caplog.text
         assert np.allclose(result, 0.0)
+        caplog.clear()
 
     @pytest.mark.parametrize(
         "config",
@@ -1162,14 +1111,12 @@ class TestMetrics:
         self.helper_test_nan(metric, **kwargs)
         self.helper_test_non_aggregate(metric, is_aggregate)
 
-        # Legacy raising behavior is now opt-in via `zero_division="raise"`.
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="denominator"):
             _ = metric(
                 TimeSeries.from_values(np.ones((3, 1, 1))),
                 TimeSeries.from_values(np.ones((3, 1, 1))),
                 zero_division="raise",
             )
-        assert "denominator" in str(exc.value)
 
     @pytest.mark.parametrize(
         "metric",
@@ -1183,7 +1130,6 @@ class TestMetrics:
     )
     def test_season(self, metric, caplog):
         # default "warn" mode: emits a warning for perfectly seasonal or constant insample
-        caplog.clear()
         with caplog.at_level(logging.WARNING):
             metric(self.series3, self.series3 * 1.3, self.series_train, 8)
         assert "error scale (denominator) is zero" in caplog.text
@@ -1534,6 +1480,8 @@ class TestMetrics:
     @pytest.mark.parametrize(
         "metric",
         [
+            metrics.ape,
+            metrics.mape,
             metrics.wmape,
             metrics.ope,
             metrics.arre,
@@ -1576,9 +1524,25 @@ class TestMetrics:
         # --- non-zero denominator: no warning, finite result ---
         caplog.clear()
         with caplog.at_level(logging.WARNING):
-            result_normal = metric(self.series1, self.series2, component_reduction=None)
+            result_normal = metric(
+                self.series1 + 1.0, self.series2, component_reduction=None
+            )
         assert "denominator" not in caplog.text
         assert not np.any(np.isnan(np.atleast_1d(result_normal)))
+
+    def test_ape_elementwise_mixed_zero(self, caplog):
+        """`ape`'s denominator is the per-timestep actual, so zeros are handled
+        element-wise: an exact prediction at a zero actual -> 0.0, a wrong one
+        -> NaN, while the non-zero timesteps are unaffected."""
+        actual = TimeSeries.from_values(np.array([0.0, 4.0, 0.0, 8.0]).reshape(-1, 1))
+        pred = TimeSeries.from_values(np.array([0.0, 4.0, 1.0, 8.0]).reshape(-1, 1))
+        with caplog.at_level(logging.WARNING):
+            result = metrics.ape(
+                actual, pred, time_reduction=None, component_reduction=None
+            )
+        assert "denominator" in caplog.text
+        np.testing.assert_array_equal(result.ravel(), [0.0, 0.0, np.nan, 0.0])
+        caplog.clear()
 
     @pytest.mark.parametrize(
         "metric",
@@ -1601,6 +1565,7 @@ class TestMetrics:
 
         assert "denominator" not in caplog.text
         assert np.allclose(result, 200.0)
+        caplog.clear()
 
     @pytest.mark.parametrize("metric", [metrics.arre, metrics.marre])
     def test_range_metrics_small_non_zero_denominator(self, metric, caplog):
@@ -1612,16 +1577,7 @@ class TestMetrics:
 
         assert "denominator" not in caplog.text
         assert np.allclose(result, 100.0)
-
-    @pytest.mark.parametrize("metric", [metrics.wmape, metrics.ope])
-    def test_pct_aggregate_all_nan(self, metric, caplog):
-        all_nan = TimeSeries.from_values(np.full((10, 1), np.nan))
-
-        with caplog.at_level(logging.WARNING):
-            result = metric(all_nan, all_nan, component_reduction=None)
-
-        assert "denominator" not in caplog.text
-        assert np.all(np.isnan(np.atleast_1d(result)))
+        caplog.clear()
 
     def test_arre_constant_actual_elementwise(self, caplog):
         """A constant ``actual_series`` makes the range (denominator) zero. The
@@ -1629,13 +1585,13 @@ class TestMetrics:
         forecast), the others -> NaN, instead of NaN-ing the whole component."""
         constant_actual = TimeSeries.from_values(np.full((4, 1), 5.0))
         pred = TimeSeries.from_values(np.array([5.0, 9.0, 5.0, 2.0]).reshape(-1, 1))
-        caplog.clear()
         with caplog.at_level(logging.WARNING):
             result = metrics.arre(
                 constant_actual, pred, time_reduction=None, component_reduction=None
             )
         assert "denominator" in caplog.text
         np.testing.assert_array_equal(result.ravel(), [0.0, np.nan, 0.0, np.nan])
+        caplog.clear()
 
     @pytest.mark.parametrize(
         "metric",
@@ -1657,24 +1613,24 @@ class TestMetrics:
 
         # exact prediction on the zero-denominator component -> 0.0 (perfect)
         pred_exact = TimeSeries.from_values(np.stack([normal + 1.0, zeros], axis=1))
-        caplog.clear()
         with caplog.at_level(logging.WARNING):
             res = np.asarray(metric(actual, pred_exact, component_reduction=None))
         assert "denominator" in caplog.text
         assert res.shape[-1] == 2
         assert np.all(np.isfinite(res[..., 0]))
         assert np.all(res[..., 1] == 0.0)
+        caplog.clear()
 
         # wrong prediction on the zero-denominator component -> NaN
         pred_wrong = TimeSeries.from_values(
             np.stack([normal + 1.0, np.ones(10)], axis=1)
         )
-        caplog.clear()
         with caplog.at_level(logging.WARNING):
             res = np.asarray(metric(actual, pred_wrong, component_reduction=None))
         assert res.shape[-1] == 2
         assert np.all(np.isfinite(res[..., 0]))
         assert np.all(np.isnan(res[..., 1]))
+        caplog.clear()
 
     def test_ope(self):
         self.helper_test_multivariate_duplication_equality(metrics.ope)


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates under **Summary**.
- [x] Added an entry under **Unreleased** in the changelog.

Closes #3132.

### Summary

Adds consistent `zero_division` handling to `ape`, `mape`, `sape`, `smape`, `wmape`, `ope`, `arre`, `marre`, and `coefficient_of_variation`.

- `"warn"` (default): `0/0` returns `0.0`, while non-zero/0 returns `np.nan`, and logs a warning.
- `"raise"`: raises a `ValueError`.

These metrics reuse `_safe_scaled_divide` with a configurable zero fill. Scaled metrics keep their existing near-zero behavior; percentage and range metrics only treat exact zeros as zero.

Also:

- `ope` now accepts a negative `actual_series` sum.
- `arre` and `marre` handle zero-range components element-wise.
- Missing-only `wmape` and `ope` inputs remain `np.nan`.

### Tests

- `uv run pytest darts/tests/metrics/test_metrics.py` — 478 passed
- Python 3.12 core suite — 8,417 passed, 323 skipped
- `uv run pre-commit run --all-files` — passed
- `uv run make --directory ./docs build-all-docs` — passed
