### PR TITLE
Feat/timeseries improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,15 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 ### For users of the library:
 
-**Fixed**
-
-- Fixed `_ScaledDotProductAttention` float16 overflow in `masked_fill` under mixed precision training. [#3087](https://github.com/unit8co/darts/pull/3087) by [Robert Ruidisch](https://github.com/robrui).
-
 **Improved**
 
 - 🚀🚀 Added new forecasting model `PatchTSTFMModel` : IBM's pre-trained ~260M-parameter foundational model for zero-shot forecasting. It supports univariate, multivariate, and multiple time series forecasting without training and can output deterministic or probabilistic forecasts. [#3120](https://github.com/unit8co/darts/pull/3120) by [Dennis Bader](https://github.com/dennisbader).
 - Added `use_longer_projection_head` to `TimesFM2p5Model` to enable longer non-autoregressive prediction horizons (up to 1024 steps for `output_chunk_length + output_chunk_shift`). [#3121](https://github.com/unit8co/darts/pull/3121) by [Zhihao Dai](https://github.com/daidahao).
 
 **Fixed**
+
+- Fixed `_ScaledDotProductAttention` float16 overflow in `masked_fill` under mixed precision training. [#3087](https://github.com/unit8co/darts/pull/3087) by [Robert Ruidisch](https://github.com/robrui).
+- Fixed a bug in `TimeSeries.quantile()` where the output dtype did not match the input series dtype for dtypes `float32` or `float16`. Now the dtype is correctly propagated. [#3087](https://github.com/unit8co/darts/pull/3087) by [Robert Ruidisch](https://github.com/robrui).
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - Fixed `_ScaledDotProductAttention` float16 overflow in `masked_fill` under mixed precision training. [#3087](https://github.com/unit8co/darts/pull/3087) by [Robert Ruidisch](https://github.com/robrui).
 - Fixed a bug in `TimeSeries.quantile()` where the output dtype did not match the input series dtype for dtypes `float32` or `float16`. Now the dtype is correctly propagated. [#3124](https://github.com/unit8co/darts/pull/3124) by [Dennis Bader](https://github.com/dennisbader)
+- Optuna integration's `PyTorchLightningPruningCallback` for hyperparameter optimization of torch models is now natively available in Darts via `darts.utils.callbacks`. [#3114](https://github.com/unit8co/darts/pull/3114) by [Jakub Chłapek](https://github.com/jakubchlapek).
 
 **Dependencies**
 
 ### For developers of the library:
 
 - Used GitHub Actions to publish the documentation to GitHub Pages, replacing the previous third-party branch-based deployment method. [#3107](https://github.com/unit8co/darts/pull/3107) by [Zhihao Dai](https://github.com/daidahao)
+- Removed `optuna-integration[pytorch-lightning]` from the testing dependencies. [#3114](https://github.com/unit8co/darts/pull/3114) by [Jakub Chłapek](https://github.com/jakubchlapek).
 
 ## [0.44.1](https://github.com/unit8co/darts/tree/0.44.1) (2026-05-05)
 
@@ -36,7 +38,6 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - Fixed a `ValueError` in `backtest()` when using `overlap_end=True` with `predict_likelihood_parameters=True` and a quantile metric. The final forecast window could extend beyond the series end, producing an empty intersection that caused a reshape failure in the metric computation. [#3111](https://github.com/unit8co/darts/pull/3111) by [Dennis Bader](https://github.com/dennisbader)
 - Fixed rendering issues of `CustomBlockRNNModule` and `CustomRNNModule` in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
-- Removed `optuna-integration[pytorch-lightning]` dependency and ported `PyTorchLightningPruningCallback` in `darts.utils.callbacks`, resolving a platform-specific dependency resolution failure. [#3114](https://github.com/unit8co/darts/pull/3114) by [Jakub Chłapek](https://github.com/jakubchlapek).
 - Fixed rendering issues of `20-SKLearnModel-examples` notebook in the documentation. [#3094](https://github.com/unit8co/darts/pull/3094) by [Zhihao Dai](https://github.com/daidahao)
 
 **Dependencies**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 - 🚀🚀 Added new forecasting model `PatchTSTFMModel` : IBM's pre-trained ~260M-parameter foundational model for zero-shot forecasting. It supports univariate, multivariate, and multiple time series forecasting without training and can output deterministic or probabilistic forecasts. [#3120](https://github.com/unit8co/darts/pull/3120) by [Dennis Bader](https://github.com/dennisbader).
 - Added `use_longer_projection_head` to `TimesFM2p5Model` to enable longer non-autoregressive prediction horizons (up to 1024 steps for `output_chunk_length + output_chunk_shift`). [#3121](https://github.com/unit8co/darts/pull/3121) by [Zhihao Dai](https://github.com/daidahao).
+- `TimeSeries.from_dataframe()` now supports time columns of type `pl.Date` for `polars.DataFrame`. [#3124](https://github.com/unit8co/darts/pull/3124) by [Dennis Bader](https://github.com/dennisbader)
 
 **Fixed**
 
 - Fixed `_ScaledDotProductAttention` float16 overflow in `masked_fill` under mixed precision training. [#3087](https://github.com/unit8co/darts/pull/3087) by [Robert Ruidisch](https://github.com/robrui).
-- Fixed a bug in `TimeSeries.quantile()` where the output dtype did not match the input series dtype for dtypes `float32` or `float16`. Now the dtype is correctly propagated. [#3087](https://github.com/unit8co/darts/pull/3087) by [Robert Ruidisch](https://github.com/robrui).
+- Fixed a bug in `TimeSeries.quantile()` where the output dtype did not match the input series dtype for dtypes `float32` or `float16`. Now the dtype is correctly propagated. [#3124](https://github.com/unit8co/darts/pull/3124) by [Dennis Bader](https://github.com/dennisbader)
 
 **Dependencies**
 

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -4,6 +4,7 @@ import math
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
+import narwhals as nw
 import numpy as np
 import pandas as pd
 import pytest
@@ -173,6 +174,44 @@ class TestTimeSeries:
         caplog.clear()
         assert ts_pl_df_2.equals(pl_df)
         assert ts_pl_df_2.dtypes == pl_df.dtypes
+
+    @pytest.mark.parametrize(
+        "backend,date_type",
+        itertools.product(
+            ["pandas"] + (["polars"] if POLARS_AVAILABLE else []),
+            ["str", "date", "datetime"],
+        ),
+    )
+    def test_creation_from_dataframe_with_dates(self, backend, date_type):
+        # month start freq in Date (not Datetime) resolution
+        data = {
+            "time": ["2000-01-01", "2000-02-01", "2000-03-01"],
+            "values": [1.0, 2.0, 3.0],
+        }
+        if backend == "pandas":
+            df = pd.DataFrame(data)
+            if date_type != "str":
+                # pandas only supports datetime
+                df["time"] = pd.to_datetime(df["time"])
+        else:
+            df = pl.DataFrame(data)
+            if date_type != "str":
+                # we must first convert to Date before optional Datetime
+                df = df.cast({"time": pl.Date})
+                if date_type == "datetime":
+                    df = df.cast({"time": pl.Datetime})
+
+        # internally, Darts converts any temporal dtype into Datetime
+        ts = TimeSeries.from_dataframe(df, time_col="time")
+        assert ts.time_index.equals(pd.DatetimeIndex(data["time"], name="time"))
+        np.testing.assert_array_equal(
+            ts.values(), np.array(data["values"])[:, np.newaxis]
+        )
+
+        # writing back to DataFrame always gives Datetime
+        df_inv = ts.to_dataframe(time_as_index=False, backend=backend)
+        df_inv_nw = nw.from_native(df_inv)
+        assert isinstance(df_inv_nw.get_column("time").dtype, nw.Datetime)
 
     def test_integer_range_indexing(self):
         # sanity checks for the integer-indexed series

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -3313,23 +3313,28 @@ class TestSimpleStatistics:
                 new_ts._values, np.median(self.values, axis=axis, keepdims=True)
             ).all()
 
-    def test_quantile(self):
+    @pytest.mark.parametrize("dtype", ["float64", "float32"])
+    def test_quantile(self, dtype):
         qs = [0.01, 0.1, 0.5, 0.95]
+
+        ts = self.ts.astype(dtype)
+        values = self.values.astype(dtype)
 
         q_ts = []
         for q in qs:
-            new_ts = self.ts.quantile(q=q)
+            new_ts = ts.quantile(q=q)
+            assert new_ts.dtype == dtype
 
             # check component names
             q_comps = likelihood_component_names(
-                components=self.ts.components, parameter_names=quantile_names([q])
+                components=ts.components, parameter_names=quantile_names([q])
             )
             assert new_ts.components.tolist() == q_comps
 
             # check values
             assert np.isclose(
                 new_ts.values(),
-                np.quantile(self.values, q=q, axis=2),
+                np.quantile(values, q=q, axis=2),
             ).all()
             q_ts.append((new_ts[q_comps[0]], new_ts[q_comps[1]]))
 
@@ -3339,4 +3344,6 @@ class TestSimpleStatistics:
         q_ts = concatenate([q_ts_0, q_ts_1], axis=1)
 
         # computing all quantiles at once must be identical
-        assert self.ts.quantile(q=qs) == q_ts
+        new_ts = ts.quantile(q=qs)
+        assert new_ts == q_ts
+        assert new_ts.dtype == dtype

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4838,10 +4838,11 @@ class TimeSeries:
             A new series containing the desired quantile(s) of each component.
         """
         self._assert_stochastic()
-        if isinstance(q, float):
-            q = [q]
 
-        if not all([0 <= q_i <= 1 for q_i in q]):
+        # `q_arr` must be of same dtype to conserve it in `np.quantile`
+        q_arr = np.array([q] if isinstance(q, float) else q, dtype=self.dtype)
+
+        if not all([0 <= q_i <= 1 for q_i in q_arr]):
             raise_log(
                 ValueError(
                     "The quantile values must be expressed as fraction (between 0 and 1 inclusive)."
@@ -4850,10 +4851,10 @@ class TimeSeries:
             )
 
         # component names
-        cnames = [f"{comp}_q{q_i:.3f}" for comp in self.components for q_i in q]
+        cnames = [f"{comp}_q{q_i:.3f}" for comp in self.components for q_i in q_arr]
 
         # get quantiles of shape (n quantiles, n times, n components)
-        new_data = np.quantile(self._values, q=q, axis=2, **kwargs)
+        new_data = np.quantile(self._values, q=q_arr, axis=2, **kwargs)
         # transpose and reshape into (n times, n components * n quantiles, 1)
         new_data = new_data.transpose((1, 2, 0)).reshape(len(self), len(cnames), 1)
 
@@ -4862,8 +4863,8 @@ class TimeSeries:
             times=self._time_index,
             values=new_data,
             components=cnames,
-            static_covariates=self.static_covariates if len(q) == 1 else None,
-            hierarchy=self.hierarchy if len(q) == 1 else None,
+            static_covariates=self.static_covariates if len(q_arr) == 1 else None,
+            hierarchy=self.hierarchy if len(q_arr) == 1 else None,
             metadata=self.metadata,
             copy=False,
         )

--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -811,6 +811,8 @@ def dataframe_col_to_time_index(
             )
             time_col_vals = time_col_vals.dt.replace_time_zone(None)
         time_index = pd.DatetimeIndex(time_col_vals)
+    elif isinstance(time_col_vals.dtype, nw.Date):
+        time_index = pd.DatetimeIndex(time_col_vals)
     else:
         raise_log(
             AttributeError(


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- `TimeSeries.from_dataframe()` now supports time columns of type `pl.Date` for `polars.DataFrame`.
- Fixed a bug in `TimeSeries.quantile()` where the output dtype did not match the input series dtype for dtypes `float32` or `float16`. Now the dtype is correctly propagated.