### PR TITLE
Reduce metric evaluation overhead

### DIFF
--- a/darts/metrics/utils.py
+++ b/darts/metrics/utils.py
@@ -126,6 +126,8 @@ def classification_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
     probabilities and categorical samples.
     """
 
+    params = signature(func).parameters
+
     @wraps(func)
     def wrapper_classification_support(*args, **kwargs):
         labels = kwargs.get(_PARAM_LABELS)
@@ -136,7 +138,6 @@ def classification_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
                 labels = np.array(labels)
             kwargs[_PARAM_LABELS] = labels
 
-        params = signature(func).parameters
         if _PARAM_LABEL_REDUCTION in params:
             label_reduction = kwargs.get(
                 _PARAM_LABEL_REDUCTION, params[_PARAM_LABEL_REDUCTION].default
@@ -170,6 +171,8 @@ def multi_ts_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
     evaluation regarding different ``TimeSeries`` (if the `n_jobs` parameter is not set 1).
     """
 
+    params = signature(func).parameters
+
     @wraps(func)
     def wrapper_multi_ts_support(*args, **kwargs):
         actual_series = (
@@ -183,7 +186,6 @@ def multi_ts_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
             else args[1]
         )
 
-        params = signature(func).parameters
         n_jobs = kwargs.pop("n_jobs", params["n_jobs"].default)
         verbose = kwargs.pop("verbose", params["verbose"].default)
         name = kwargs.pop("name", params["name"].default)
@@ -333,9 +335,10 @@ def multivariate_support(func) -> Callable[..., METRIC_OUTPUT_TYPE]:
     univariate metrics using a `component_reduction` subroutine passed as argument to the metric function.
     """
 
+    params = signature(func).parameters
+
     @wraps(func)
     def wrapper_multivariate_support(*args, **kwargs) -> METRIC_OUTPUT_TYPE:
-        params = signature(func).parameters
         # we can avoid checks about args and kwargs since the input is adjusted by the previous decorator
         actual_series = args[0]
         pred_series = args[1]

--- a/darts/utils/utils.py
+++ b/darts/utils/utils.py
@@ -229,6 +229,10 @@ def _parallel_apply(
 
     """
 
+    if n_jobs == 1:
+        # avoid joblib.Parallel setup overhead for the common sequential case
+        return [fn(*sample, *fn_args, **fn_kwargs) for sample in iterator]
+
     from joblib import Parallel, delayed
 
     returned_data = Parallel(n_jobs=n_jobs)(


### PR DESCRIPTION
## Summary

Metric evaluation carried avoidable per-call overhead unrelated to the actual computation:

1. The metric decorators (`multi_ts_support`, `multivariate_support`, `classification_support`) called `signature(func).parameters` on **every** invocation, just to read parameter defaults. The signature is constant per decorated metric, so this is now computed once at decoration time.
2. `_parallel_apply` routed even single-series / `n_jobs=1` evaluations through `joblib.Parallel`, paying its setup cost when no parallelism is used. A sequential fast path is added for `n_jobs == 1` (the default); the `n_jobs != 1` path is unchanged.

## Measured impact

Benchmarked at `N=20000`, best-of-N timing, on `LinearRegression`-style float data:

| Metric | Before | After | Speedup |
|---|---|---|---|
| `mse` (single series) | 126 µs | 81 µs | 1.57x |
| `mape` (single series) | 139 µs | 96 µs | 1.45x |
| `mae` (single series) | 128 µs | 87 µs | 1.46x |
| `mse` (8-series sequence) | 511 µs | 372 µs | 1.37x |

Outputs are bit-identical before and after. The win compounds in `backtest()` (one metric per window) and `gridsearch()` (one per param-combination × window), where metrics are evaluated thousands of times.

## Testing

- `darts/tests/metrics/test_metrics.py`: **455 passed**.
- Manual check: identical numeric results pre/post change across `mse`/`mae`/`mape` for single series and sequences.

## Notes

This is a draft. I have only run the metrics test module locally, not the full suite. The `n_jobs == 1` fast path is semantically equivalent to `joblib.Parallel(n_jobs=1)`, which already executes sequentially.
