### PR TITLE
fix treat_na issues in window transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
-- Fixed a bug in `TimeSeries.window_transform()` where `treat_na` (`"dropna"`, scalar, `"bfill"`) did not handle NaN values introduced by functions that produce NaN even when `min_periods` is satisfied (e.g., `std` with `ddof=1` on a single value). [#3150](https://github.com/unit8co/darts/pull/3150) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed a bug in `TimeSeries.window_transform()` where `treat_na` (`"dropna"`, scalar, `"bfill"`) did not handle NaN values introduced by functions that produce NaN even when `min_periods` is satisfied (e.g., `std` with `ddof=1` on a single value). [#3151](https://github.com/unit8co/darts/pull/3151) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed a bug in `TimeSeries.window_transform()` where `treat_na` (`"dropna"`, scalar, `"bfill"`) did not handle NaN values introduced by functions that produce NaN even when `min_periods` is satisfied (e.g., `std` with `ddof=1` on a single value). [#3150](https://github.com/unit8co/darts/pull/3150) by [Dennis Bader](https://github.com/dennisbader).
+
 **Dependencies**
 
 ### For developers of the library:

--- a/darts/tests/dataprocessing/transformers/test_window_transformations.py
+++ b/darts/tests/dataprocessing/transformers/test_window_transformations.py
@@ -388,6 +388,25 @@ class TestTimeSeriesWindowTransform:
             # unauhtorized treat_na=bfill with forecasting_safe=True
             self.target.window_transform(window_transformations, treat_na="bfill")
 
+    @pytest.mark.parametrize(
+        "treat_na,expected_vals",
+        [
+            (None, [np.nan, 0.70710678, 0.70710678, 0.70710678]),
+            ("dropna", [0.70710678, 0.70710678, 0.70710678]),
+            (0.0, [0.0, 0.70710678, 0.70710678, 0.70710678]),
+            ("bfill", [0.70710678, 0.70710678, 0.70710678, 0.70710678]),
+        ],
+    )
+    def test_treat_na_with_function_producing_nan(self, treat_na, expected_vals):
+        """treat_na must handle NaN introduced by functions like std(ddof=1)
+        even when min_periods is satisfied."""
+        series = TimeSeries.from_values(np.array([0, 1, 2, 3]))
+        params = {"function": "std", "mode": "rolling", "window": 2}
+        result = series.window_transform(
+            params, treat_na=treat_na, forecasting_safe=False
+        )
+        np.testing.assert_allclose(result.values().flatten(), expected_vals, atol=1e-6)
+
     def test_tranformed_ts_index(self):
         # DateTimeIndex
         transformed_series = self.target.window_transform({"function": "sum"})

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4232,13 +4232,14 @@ class TimeSeries:
                         )
                     })
 
-            # track how many NaN rows are added by each transformation on each transformed column
-            # NaNs would appear only if user changes "min_periods" to else than 1, if not,
-            # by default there should be no NaNs unless the original series starts with NaNs (those would be maintained)
-            total_na = min_periods + shifts + (closed == "left")
-            added_na.extend([
-                total_na - 1 if min_periods > 0 else total_na for _ in filter_df_columns
-            ])
+        # Detect actual leading NaN count per transformed column.
+        # More robust than predicting from window params, as some functions
+        # (e.g., std with ddof=1) produce NaN even when min_periods is satisfied.
+        if treat_na is not None:
+            na_mask = np.isnan(resulting_transformations.values)
+            has_na = na_mask.any(axis=0)
+            first_valid = np.where(has_na, np.argmax(~na_mask, axis=0), 0)
+            added_na = first_valid.tolist()
 
         # keep all original components
         if keep_non_transformed:


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

<!-- Please mention an issue this pull request addresses. -->
Fixes #3150.

### Summary

- Fixes a bug in `TimeSeries.window_transform()` where `treat_na` (`"dropna"`, scalar, `"bfill"`) did not handle NaN values introduced by functions that produce NaN even when `min_periods` is satisfied (e.g., `std` with `ddof=1` on a single value).