### PR TITLE
Fix spurious dtype-mismatch warning after loading a torch model from checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed a bug in the torch-based forecasting models where a spurious "different data type" warning was emitted at prediction time — even when the input and training data types matched — after loading a model from a checkpoint. The dtype check now compares numpy dtypes by value rather than by object identity. [#3156](https://github.com/unit8co/darts/issues/3156).
 - Fixed a bug in `TimeSeries.window_transform()` where `treat_na` (`"dropna"`, scalar, `"bfill"`) did not handle NaN values introduced by functions that produce NaN even when `min_periods` is satisfied (e.g., `std` with `ddof=1` on a single value). [#3151](https://github.com/unit8co/darts/pull/3151) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
-- Fixed a bug in the torch-based forecasting models where a spurious "different data type" warning was emitted at prediction time — even when the input and training data types matched — after loading a model from a checkpoint. The dtype check now compares numpy dtypes by value rather than by object identity. [#3156](https://github.com/unit8co/darts/issues/3156).
+- Fixed a bug in the `TorchForecastingModel.predict()` which emitted an invalid "different data type" warning for correct input data types after loading a model from a checkpoint. [#3158](https://github.com/unit8co/darts/pull/3158) by [Mohit Arvind Khakharia](https://github.com/Mohit-Ak).
 - Fixed a bug in `TimeSeries.window_transform()` where `treat_na` (`"dropna"`, scalar, `"bfill"`) did not handle NaN values introduced by functions that produce NaN even when `min_periods` is satisfied (e.g., `std` with `ddof=1` on a single value). [#3151](https://github.com/unit8co/darts/pull/3151) by [Dennis Bader](https://github.com/dennisbader).
 
 **Dependencies**

--- a/darts/models/forecasting/torch_forecasting_model.py
+++ b/darts/models/forecasting/torch_forecasting_model.py
@@ -823,7 +823,7 @@ class TorchForecastingModel(GlobalForecastingModel, ABC):
                 else None
             )
             current_dtype = observed_dtypes.pop()
-            if current_dtype is not expected_dtype:
+            if current_dtype != expected_dtype:
                 logger.warning(
                     f"Dataset output has a different data type than the dataset the model was trained on; "
                     f"current data type: {current_dtype}, expected data type: {expected_dtype}. "

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -13,6 +13,7 @@ import itertools
 import logging
 import math
 import os
+import pickle
 from typing import Any
 from unittest.mock import patch
 
@@ -1346,6 +1347,55 @@ class TestTorchForecastingModel:
         loading_model.load_weights(ckpt_path)
         loading_model.fit(ts_float32)
         assert loading_model.model._dtype == torch.float32  # type: ignore
+
+    def test_verify_dtypes_matching_dtype_no_warning(self, caplog):
+        """`_verify_dtypes` must not warn when the current and expected dtypes are
+        value-equal, even if they are distinct object instances.
+
+        Reloading a model from a checkpoint yields a `train_sample` whose numpy
+        dtype is a freshly unpickled object. That object is value-equal to the
+        dtype of the inference sample but is not the *same* object, so an identity
+        check (`is not`) spuriously reported a data-type mismatch and warned even
+        though both dtypes were e.g. float32. See GH #3156.
+        """
+        model = DLinearModel(
+            input_chunk_length=4, output_chunk_length=1, n_epochs=1, **tfm_kwargs
+        )
+        model.fit(self.series.astype("float32"))
+
+        # emulate a checkpoint-reloaded train_sample: a value-equal but
+        # identity-distinct float32 dtype (what pickle round-tripping produces).
+        reloaded_dtype = pickle.loads(pickle.dumps(np.dtype(np.float32)))
+        assert reloaded_dtype == np.dtype(np.float32)
+        assert reloaded_dtype is not np.dtype(np.float32)
+        model.train_sample = (np.zeros((1, 1), dtype=reloaded_dtype),) + tuple(
+            model.train_sample[1:]
+        )
+
+        # an inference sample whose (single) array is a fresh float32 dtype
+        sample = (np.zeros((1, 1), dtype=np.float32),)
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            model._verify_dtypes(sample)
+        assert "different data type" not in caplog.text
+
+    def test_verify_dtypes_mismatched_dtype_warns(self, caplog):
+        """`_verify_dtypes` must still warn on a genuine dtype mismatch."""
+        model = DLinearModel(
+            input_chunk_length=4, output_chunk_length=1, n_epochs=1, **tfm_kwargs
+        )
+        model.fit(self.series.astype("float32"))
+        model.train_sample = (np.zeros((1, 1), dtype=np.float32),) + tuple(
+            model.train_sample[1:]
+        )
+
+        sample = (np.zeros((1, 1), dtype=np.float64),)
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            model._verify_dtypes(sample)
+        assert "different data type" in caplog.text
 
     def test_multi_steps_pipeline(self, tmpdir_fn):
         ts_training, ts_val = self.series.split_before(75)

--- a/darts/tests/models/forecasting/test_torch_forecasting_model.py
+++ b/darts/tests/models/forecasting/test_torch_forecasting_model.py
@@ -15,7 +15,6 @@ import itertools
 import logging
 import math
 import os
-import pickle
 from typing import Any
 from unittest.mock import patch
 
@@ -1351,53 +1350,34 @@ class TestTorchForecastingModel:
         loading_model.fit(ts_float32)
         assert loading_model.model._dtype == torch.float32  # type: ignore
 
-    def test_verify_dtypes_matching_dtype_no_warning(self, caplog):
-        """`_verify_dtypes` must not warn when the current and expected dtypes are
-        value-equal, even if they are distinct object instances.
-
-        Reloading a model from a checkpoint yields a `train_sample` whose numpy
-        dtype is a freshly unpickled object. That object is value-equal to the
-        dtype of the inference sample but is not the *same* object, so an identity
-        check (`is not`) spuriously reported a data-type mismatch and warned even
-        though both dtypes were e.g. float32. See GH #3156.
-        """
+    def test_verify_dtypes_after_loading(self, tmpdir_fn, caplog):
+        """Check that dtype warnings work also with loaded models"""
         model = DLinearModel(
-            input_chunk_length=4, output_chunk_length=1, n_epochs=1, **tfm_kwargs
+            input_chunk_length=4,
+            output_chunk_length=1,
+            n_epochs=1,
+            save_checkpoints=True,
+            force_reset=True,
+            model_name="test_model",
+            work_dir=tmpdir_fn,
+            **tfm_kwargs,
         )
-        model.fit(self.series.astype("float32"))
-
-        # emulate a checkpoint-reloaded train_sample: a value-equal but
-        # identity-distinct float32 dtype (what pickle round-tripping produces).
-        reloaded_dtype = pickle.loads(pickle.dumps(np.dtype(np.float32)))
-        assert reloaded_dtype == np.dtype(np.float32)
-        assert reloaded_dtype is not np.dtype(np.float32)
-        model.train_sample = (np.zeros((1, 1), dtype=reloaded_dtype),) + tuple(
-            model.train_sample[1:]
+        series = self.series.astype("float32")
+        model.fit(series, val_series=series)
+        model_loaded = model.load_from_checkpoint(
+            model_name=model.model_name,
+            work_dir=tmpdir_fn,
         )
-
-        # an inference sample whose (single) array is a fresh float32 dtype
-        sample = (np.zeros((1, 1), dtype=np.float32),)
 
         caplog.clear()
         with caplog.at_level(logging.WARNING):
-            model._verify_dtypes(sample)
+            _ = model_loaded.predict(n=1)
         assert "different data type" not in caplog.text
 
-    def test_verify_dtypes_mismatched_dtype_warns(self, caplog):
-        """`_verify_dtypes` must still warn on a genuine dtype mismatch."""
-        model = DLinearModel(
-            input_chunk_length=4, output_chunk_length=1, n_epochs=1, **tfm_kwargs
-        )
-        model.fit(self.series.astype("float32"))
-        model.train_sample = (np.zeros((1, 1), dtype=np.float32),) + tuple(
-            model.train_sample[1:]
-        )
-
-        sample = (np.zeros((1, 1), dtype=np.float64),)
-
         caplog.clear()
         with caplog.at_level(logging.WARNING):
-            model._verify_dtypes(sample)
+            with pytest.raises(Exception):
+                _ = model_loaded.predict(n=1, series=self.series.astype("float64"))
         assert "different data type" in caplog.text
 
     def test_multi_steps_pipeline(self, tmpdir_fn):


### PR DESCRIPTION
### What this fixes

`_verify_dtypes` runs at prediction time to warn when the inference data's dtype
differs from the dtype the model was trained on. When a model is reloaded from a
checkpoint (e.g. via `load_from_checkpoint(..., best=True)` after early stopping),
the warning was raised even though the input and training dtypes were identical:

```
Dataset output has a different data type than the dataset the model was trained on;
current data type: float32, expected data type: float32. ...
```

Reported in #3156 with a minimal `TiDEModel` repro.

### Root cause

The dtype comparison used the identity operator:

```python
if current_dtype is not expected_dtype:
    logger.warning("Dataset output has a different data type ...")
```

`expected_dtype` comes from `self.train_sample[0].dtype`. After a checkpoint
reload the training sample's numpy dtype is a freshly unpickled object, so it is
value-equal to the inference dtype but not the *same* object. `is not` therefore
evaluates `True` for two equal float32 dtypes and the warning fires spuriously.

Small reproduction of the underlying pitfall:

```python
>>> import numpy as np, pickle
>>> d1 = np.dtype(np.float32)
>>> d2 = pickle.loads(pickle.dumps(np.dtype(np.float32)))
>>> d1 == d2, d1 is d2
(True, False)
```

### The fix

Compare numpy dtypes by value instead of by identity — a one-line change in
`_verify_dtypes`:

```python
-            if current_dtype is not expected_dtype:
+            if current_dtype != expected_dtype:
```

`numpy.dtype.__eq__` is the intended way to compare dtypes and correctly returns
`True` for two value-equal dtypes regardless of object identity, so a genuine
mismatch (e.g. float32 vs float64) still warns as before.

### How it was tested

Two regression tests were added to
`darts/tests/models/forecasting/test_torch_forecasting_model.py`:

- `test_verify_dtypes_matching_dtype_no_warning` — sets `train_sample`'s dtype to
  a pickle-round-tripped (value-equal, identity-distinct) float32 and asserts
  `_verify_dtypes` emits **no** "different data type" warning. This fails on the
  old `is not` code and passes with the fix.
- `test_verify_dtypes_mismatched_dtype_warns` — a genuine float32-vs-float64
  mismatch still logs the warning, guarding against over-correction.

Verification against the repo's own suite (CPU-only install):

```
# with the fix
$ pytest darts/tests/models/forecasting/test_torch_forecasting_model.py -k verify_dtypes
6 passed, 369 deselected

# reverting the fix in place -> the new test reproduces the bug
FAILED ...::test_verify_dtypes_matching_dtype_no_warning
  - AssertionError: assert 'different data type' not in 'WARNING ...'

# broader dtype/precision regression guard
$ pytest ... -k "dtype or precision"
14 passed, 361 deselected
```

Lint (pinned `ruff==0.7.2` from `.pre-commit-config.yaml`):

```
$ ruff check <changed files>         -> All checks passed!
$ ruff format --check <changed files> -> 2 files already formatted
```

A CHANGELOG.md entry was added under the Unreleased "Fixed" section.

Fixes #3156
