### PR TITLE
bump lxml-html-clean from 0.4.4 to 0.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ release = [
     "ipywidgets==8.1.8",
     "jinja2==3.1.6",
     "jupyterlab==4.5.9",
-    "lxml-html-clean==0.4.4",
+    "lxml-html-clean==0.4.5",
     "myst-parser==5.0.0; python_version >= '3.11'",
     "myst-parser==4.0.1; python_version < '3.11'",
     "nbsphinx==0.9.7",


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- Bumps lxml-html-clean from 0.4.4 to 0.4.5 to resolve [this vulnerability](https://github.com/fedora-python/lxml_html_clean/security/advisories/GHSA-4jhm-jv67-739f).