### PR TITLE
Feat/tft explainer importance over time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- Added support for per-timestep (non-aggregated) encoder and decoder variable importances in `TFTExplainer`, exposed as `TimeSeries` via `TFTExplainabilityResult.get_encoder_importance_over_time()` and `get_decoder_importance_over_time()`. [#XXXX](https://github.com/unit8co/darts/pull/XXXX) by [exactml](https://github.com/exactml).
 - Calling `TFTModel.fit_from_dataset()` on a dataset that does not have future covariates now raises an informative exception. [#3149](https://github.com/unit8co/darts/pull/3149) by [YOON KIWOONG](https://github.com/kiwoongyoon).
 - 🔴 Percentage and range-based metrics (`ape`, `mape`, `sape`, `smape`, `wmape`, `ope`, `arre`, `marre`, `coefficient_of_variation`) no longer raise a hard `ValueError` when the denominator is exactly zero. A new `zero_division` parameter controls the behavior: [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
   - `"warn"` (default) raises a warning and returns `0.0` when the numerator is also zero (typically meaning perfect forecasts) or `np.nan` otherwise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
-- Added support for per-timestep (non-aggregated) encoder and decoder variable importances in `TFTExplainer`, exposed as `TimeSeries` via `TFTExplainabilityResult.get_encoder_importance_over_time()` and `get_decoder_importance_over_time()`. [#XXXX](https://github.com/unit8co/darts/pull/XXXX) by [exactml](https://github.com/exactml).
+- Added support for per-timestep (non-aggregated) encoder and decoder variable importances in `TFTExplainer`, exposed as `TimeSeries` via `TFTExplainabilityResult.get_encoder_importance_over_time()` and `get_decoder_importance_over_time()`. [#3170](https://github.com/unit8co/darts/pull/3170) by [exactml](https://github.com/exactml).
 - Calling `TFTModel.fit_from_dataset()` on a dataset that does not have future covariates now raises an informative exception. [#3149](https://github.com/unit8co/darts/pull/3149) by [YOON KIWOONG](https://github.com/kiwoongyoon).
 - 🔴 Percentage and range-based metrics (`ape`, `mape`, `sape`, `smape`, `wmape`, `ope`, `arre`, `marre`, `coefficient_of_variation`) no longer raise a hard `ValueError` when the denominator is exactly zero. A new `zero_division` parameter controls the behavior: [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
   - `"warn"` (default) raises a warning and returns `0.0` when the numerator is also zero (typically meaning perfect forecasts) or `np.nan` otherwise

--- a/darts/explainability/explainability_result.py
+++ b/darts/explainability/explainability_result.py
@@ -553,17 +553,17 @@ class TFTExplainabilityResult(ComponentBasedExplainabilityResult):
 
     - :func:`get_attention() <TFTExplainabilityResult.get_attention>`: self attention over the encoder and decoder
     - :func:`get_encoder_importance() <TFTExplainabilityResult.get_encoder_importance>`: encoder feature importances
-      including past target, past covariates, and historic part of future covariates.
+      aggregated over time including past target, past covariates, and historic part of future covariates.
     - :func:`get_decoder_importance() <TFTExplainabilityResult.get_decoder_importance>`: decoder feature importances
-      including future part of future covariates.
+      aggregated over time including future part of future covariates.
     - :func:`get_static_covariates_importance() <TFTExplainabilityResult.get_static_covariates_importance>`: static
       covariates importances.
-    - :func:`get_feature_importances() <TFTExplainabilityResult.get_feature_importances>`: get all feature importances
-      at once.
+    - :func:`get_feature_importances() <TFTExplainabilityResult.get_feature_importances>`: get all time-aggregated
+      feature importances at once.
     - :func:`get_encoder_importance_over_time() <TFTExplainabilityResult.get_encoder_importance_over_time>`: encoder
-      feature importances per timestep of the input chunk (not aggregated over time).
+      feature importances over time of the input chunk.
     - :func:`get_decoder_importance_over_time() <TFTExplainabilityResult.get_decoder_importance_over_time>`: decoder
-      feature importances per timestep of the forecast horizon (not aggregated over time).
+      feature importances over time of the output chunk.
 
     Examples
     --------
@@ -633,7 +633,7 @@ class TFTExplainabilityResult(ComponentBasedExplainabilityResult):
 
     def get_encoder_importance(self) -> pd.DataFrame | list[pd.DataFrame]:
         """
-        Returns the time-dependent encoder importances as a pd.DataFrames.
+        Returns the encoder importances aggregated over time as a pd.DataFrames.
         If multiple series were used in :func:`TFTExplainer.explain()
         <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list of pd.DataFrames.
         """
@@ -641,7 +641,7 @@ class TFTExplainabilityResult(ComponentBasedExplainabilityResult):
 
     def get_decoder_importance(self) -> pd.DataFrame | list[pd.DataFrame]:
         """
-        Returns the time-dependent decoder importances as a pd.DataFrames.
+        Returns the decoder importances aggregated over time as a pd.DataFrames.
         If multiple series were used in :func:`TFTExplainer.explain()
         <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list of pd.DataFrames.
         """
@@ -659,18 +659,18 @@ class TFTExplainabilityResult(ComponentBasedExplainabilityResult):
 
     def get_encoder_importance_over_time(self) -> TimeSeries | list[TimeSeries]:
         """
-        Returns the per-timestep encoder importances (not aggregated over time) as a `TimeSeries`, with one
-        component per encoder variable. The time index corresponds to the input chunk of the explained series.
-        If multiple series were used in :func:`TFTExplainer.explain()
-        <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list of `TimeSeries`.
+        Returns the encoder importances over time as a `TimeSeries`, with one component per encoder variable.
+        The time index corresponds to the input chunk of the explained series. If multiple series were used
+        in :func:`TFTExplainer.explain() <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list
+        of `TimeSeries`.
         """
         return self.get_explanation("encoder_importance_over_time")
 
     def get_decoder_importance_over_time(self) -> TimeSeries | list[TimeSeries]:
         """
-        Returns the per-timestep decoder importances (not aggregated over time) as a `TimeSeries`, with one
-        component per decoder variable. The time index corresponds to the forecast horizon of the explained
-        series. If multiple series were used in :func:`TFTExplainer.explain()
-        <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list of `TimeSeries`.
+        Returns the decoder importances over time as a `TimeSeries`, with one component per decoder variable.
+        The time index corresponds to the forecast horizon of the explained series. If multiple series were used
+        in :func:`TFTExplainer.explain() <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list
+        of `TimeSeries`.
         """
         return self.get_explanation("decoder_importance_over_time")

--- a/darts/explainability/explainability_result.py
+++ b/darts/explainability/explainability_result.py
@@ -560,6 +560,10 @@ class TFTExplainabilityResult(ComponentBasedExplainabilityResult):
       covariates importances.
     - :func:`get_feature_importances() <TFTExplainabilityResult.get_feature_importances>`: get all feature importances
       at once.
+    - :func:`get_encoder_importance_over_time() <TFTExplainabilityResult.get_encoder_importance_over_time>`: encoder
+      feature importances per timestep of the input chunk (not aggregated over time).
+    - :func:`get_decoder_importance_over_time() <TFTExplainabilityResult.get_decoder_importance_over_time>`: decoder
+      feature importances per timestep of the forecast horizon (not aggregated over time).
 
     Examples
     --------
@@ -591,6 +595,8 @@ class TFTExplainabilityResult(ComponentBasedExplainabilityResult):
     >>> encoder_importance = result.get_encoder_importance()
     >>> decoder_importance = result.get_decoder_importance()
     >>> static_cov_importance = result.get_static_covariates_importance()
+    >>> encoder_importance_over_time = result.get_encoder_importance_over_time()
+    >>> decoder_importance_over_time = result.get_decoder_importance_over_time()
     """
 
     def __init__(
@@ -650,3 +656,21 @@ class TFTExplainabilityResult(ComponentBasedExplainabilityResult):
         <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list of pd.DataFrames.
         """
         return self.get_explanation("static_covariates_importance")
+
+    def get_encoder_importance_over_time(self) -> TimeSeries | list[TimeSeries]:
+        """
+        Returns the per-timestep encoder importances (not aggregated over time) as a `TimeSeries`, with one
+        component per encoder variable. The time index corresponds to the input chunk of the explained series.
+        If multiple series were used in :func:`TFTExplainer.explain()
+        <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list of `TimeSeries`.
+        """
+        return self.get_explanation("encoder_importance_over_time")
+
+    def get_decoder_importance_over_time(self) -> TimeSeries | list[TimeSeries]:
+        """
+        Returns the per-timestep decoder importances (not aggregated over time) as a `TimeSeries`, with one
+        component per decoder variable. The time index corresponds to the forecast horizon of the explained
+        series. If multiple series were used in :func:`TFTExplainer.explain()
+        <darts.explainability.tft_explainer.TFTExplainer.explain>`, returns a list of `TimeSeries`.
+        """
+        return self.get_explanation("decoder_importance_over_time")

--- a/darts/explainability/tft_explainer.py
+++ b/darts/explainability/tft_explainer.py
@@ -9,16 +9,10 @@ explainability information from the model.
   each of the input features.
   - encoder importance: historic part of target, past covariates and historic part of future covariates
   - decoder importance: future part of future covariates
-  - static covariates importance: the numeric and catageorical static covariates importance
+  - static covariates importance: the numeric and categorical static covariates importance
 
 - :func:`plot_attention() <TFTExplainer.plot_attention>` plots the transformer attention that the `TFTModel` applies
   on the given past and future input. The attention is aggregated over all attention heads.
-
-- The encoder/decoder variable importances are also available per timestep (i.e. not aggregated over the input
-  chunk / forecast horizon) via :func:`TFTExplainabilityResult.get_encoder_importance_over_time()
-  <darts.explainability.explainability_result.TFTExplainabilityResult.get_encoder_importance_over_time>` and
-  :func:`get_decoder_importance_over_time()
-  <darts.explainability.explainability_result.TFTExplainabilityResult.get_decoder_importance_over_time>`.
 
 The attention and feature importance values can be extracted using the :class:`TFTExplainabilityResult
 <darts.explainability.explainability_result.TFTExplainabilityResult>` returned by
@@ -135,9 +129,12 @@ class TFTExplainer(_ForecastingModelExplainer):
         `foreground_series`. If `foreground_series` is `None`, will use the `background` input
         from `TFTExplainer` creation (either the `background` passed to creation, or the series stored in the
         `TFTModel` in case it was only trained on a single series).
-        For each series, the results contain the attention heads, encoder variable importances, decoder variable
-        importances, static covariates importances, and the per-timestep (non-aggregated) encoder/decoder variable
-        importances.
+        For each series, the results contain the:
+
+        - attention heads
+        - encoder, decoder, and static variable importances aggregated over time.
+        - encoder variable importances per timestep of the input chunk and decoder variable importances per timestep
+          of the output chunk.
 
         Parameters
         ----------
@@ -173,6 +170,8 @@ class TFTExplainer(_ForecastingModelExplainer):
         >>> )
         >>> attn = explain_results.get_attention()
         >>> importances = explain_results.get_feature_importances()
+        >>> enc_importances = explain_results.get_encoder_importance_over_time()
+        >>> dec_importances = explain_results.get_decoder_importance_over_time()
         """
         if target_components is not None or horizons is not None:
             logger.warning(
@@ -223,21 +222,14 @@ class TFTExplainer(_ForecastingModelExplainer):
         decoder_importance = self._decoder_importance
         static_covariates_importance = self._static_covariates_importance
 
-        # get the per-timestep (non-aggregated) counterparts of the encoder/decoder importances;
+        # get the encoder/decoder importances over time;
         # static covariates have no time dimension, so there is no "over time" variant for them
-        encoder_importance_over_time = self._get_importance_over_time(
-            weight=self.model.model._encoder_sparse_weights
+        encoder_importance_over_time, encoder_var_names = (
+            self._encoder_importance_over_time
         )
-        decoder_importance_over_time = self._get_importance_over_time(
-            weight=self.model.model._decoder_sparse_weights
+        decoder_importance_over_time, decoder_var_names = (
+            self._decoder_importance_over_time
         )
-        name_mapping = self._name_mapping
-        encoder_var_names = [
-            name_mapping[name] for name in self.model.model.encoder_variables
-        ]
-        decoder_var_names = [
-            name_mapping[name] for name in self.model.model.decoder_variables
-        ]
 
         horizon_idx = [h - 1 for h in horizons]
 
@@ -579,8 +571,39 @@ class TFTExplainer(_ForecastingModelExplainer):
         # return the importance sorted descending
         return importance.transpose().sort_values(0, ascending=True).transpose()
 
-    @staticmethod
-    def _get_importance_over_time(weight: Tensor) -> np.ndarray | None:
+    @property
+    def _encoder_importance_over_time(self) -> tuple[np.ndarray, list[str]]:
+        """Returns the encoder variable importance over time of the TFT model.
+
+        Returns
+        -------
+        tuple[np.ndarray, list[str]]
+            The importance over time of the encoder variables as well as the variable names.
+        """
+        return self._get_importance_over_time(
+            weight=self.model.model._encoder_sparse_weights,
+            names=self.model.model.encoder_variables,
+        )
+
+    @property
+    def _decoder_importance_over_time(self) -> tuple[np.ndarray, list[str]]:
+        """Returns the decoder variable importance over time of the TFT model.
+
+        Returns
+        -------
+        tuple[np.ndarray, list[str]]
+            The importance over time of the decoder variables as well as the variable names.
+        """
+        return self._get_importance_over_time(
+            weight=self.model.model._decoder_sparse_weights,
+            names=self.model.model.decoder_variables,
+        )
+
+    def _get_importance_over_time(
+        self,
+        weight: Tensor,
+        names: list[str],
+    ) -> tuple[np.ndarray, list[str]]:
         """Returns the per-timestep encoder/decoder variable importance weights of the TFT model.
 
         Unlike `_get_importance`, this does not average the weights over the time dimension, so
@@ -596,17 +619,16 @@ class TFTExplainer(_ForecastingModelExplainer):
 
         Returns
         -------
-        np.ndarray | None
+        tuple[np.ndarray, list[str]]
             Array of shape `(batch, time, n_vars)` with the importance in percent per timestep,
-            in the same variable order as `weight`, or `None` if `weight` is `None`.
+            in the same variable order as `weight`, as well as the variable names.
         """
-        if weight is None:
-            return None
-
         # weight shape: (batch, time, 1, n_vars) -> (batch, time, n_vars). Column order is kept
         # as-is (unlike `_get_importance`, not sorted by magnitude), since a `TimeSeries` needs a
         # fixed component order across all timesteps.
-        return weight.detach().cpu().numpy().squeeze(axis=2) * 100
+        var_names = [self._name_mapping[name] for name in names]
+        importance = weight.detach().cpu().numpy().squeeze(axis=2) * 100
+        return importance, var_names
 
     @property
     def _name_mapping(self) -> dict[str, str]:

--- a/darts/explainability/tft_explainer.py
+++ b/darts/explainability/tft_explainer.py
@@ -14,6 +14,12 @@ explainability information from the model.
 - :func:`plot_attention() <TFTExplainer.plot_attention>` plots the transformer attention that the `TFTModel` applies
   on the given past and future input. The attention is aggregated over all attention heads.
 
+- The encoder/decoder variable importances are also available per timestep (i.e. not aggregated over the input
+  chunk / forecast horizon) via :func:`TFTExplainabilityResult.get_encoder_importance_over_time()
+  <darts.explainability.explainability_result.TFTExplainabilityResult.get_encoder_importance_over_time>` and
+  :func:`get_decoder_importance_over_time()
+  <darts.explainability.explainability_result.TFTExplainabilityResult.get_decoder_importance_over_time>`.
+
 The attention and feature importance values can be extracted using the :class:`TFTExplainabilityResult
 <darts.explainability.explainability_result.TFTExplainabilityResult>` returned by
 :func:`explain() <TFTExplainer.explain>`. An example of this is shown in the method description.
@@ -130,7 +136,8 @@ class TFTExplainer(_ForecastingModelExplainer):
         from `TFTExplainer` creation (either the `background` passed to creation, or the series stored in the
         `TFTModel` in case it was only trained on a single series).
         For each series, the results contain the attention heads, encoder variable importances, decoder variable
-        importances, and static covariates importances.
+        importances, static covariates importances, and the per-timestep (non-aggregated) encoder/decoder variable
+        importances.
 
         Parameters
         ----------
@@ -216,6 +223,22 @@ class TFTExplainer(_ForecastingModelExplainer):
         decoder_importance = self._decoder_importance
         static_covariates_importance = self._static_covariates_importance
 
+        # get the per-timestep (non-aggregated) counterparts of the encoder/decoder importances;
+        # static covariates have no time dimension, so there is no "over time" variant for them
+        encoder_importance_over_time = self._get_importance_over_time(
+            weight=self.model.model._encoder_sparse_weights
+        )
+        decoder_importance_over_time = self._get_importance_over_time(
+            weight=self.model.model._decoder_sparse_weights
+        )
+        name_mapping = self._name_mapping
+        encoder_var_names = [
+            name_mapping[name] for name in self.model.model.encoder_variables
+        ]
+        decoder_var_names = [
+            name_mapping[name] for name in self.model.model.decoder_variables
+        ]
+
         horizon_idx = [h - 1 for h in horizons]
 
         results = []
@@ -227,6 +250,16 @@ class TFTExplainer(_ForecastingModelExplainer):
                 times=times,
                 components=[f"horizon {str(i)}" for i in horizons],
             )
+            encoder_importance_over_time_ts = TimeSeries(
+                values=encoder_importance_over_time[idx],
+                times=series.time_index[-icl:],
+                components=encoder_var_names,
+            )
+            decoder_importance_over_time_ts = TimeSeries(
+                values=decoder_importance_over_time[idx],
+                times=pred_series.time_index,
+                components=decoder_var_names,
+            )
             results.append({
                 "attention": attention,
                 "encoder_importance": encoder_importance.iloc[idx : idx + 1],
@@ -234,6 +267,8 @@ class TFTExplainer(_ForecastingModelExplainer):
                 "static_covariates_importance": static_covariates_importance.iloc[
                     idx : idx + 1
                 ],
+                "encoder_importance_over_time": encoder_importance_over_time_ts,
+                "decoder_importance_over_time": decoder_importance_over_time_ts,
             })
         return TFTExplainabilityResult(
             explanations=results[0] if len(results) == 1 else results
@@ -543,6 +578,35 @@ class TFTExplainer(_ForecastingModelExplainer):
 
         # return the importance sorted descending
         return importance.transpose().sort_values(0, ascending=True).transpose()
+
+    @staticmethod
+    def _get_importance_over_time(weight: Tensor) -> np.ndarray | None:
+        """Returns the per-timestep encoder/decoder variable importance weights of the TFT model.
+
+        Unlike `_get_importance`, this does not average the weights over the time dimension, so
+        that the importance of each variable can be tracked at every encoder/decoder timestep.
+        Only applicable to the encoder/decoder weights (which have a time dimension); static
+        covariates have no time dimension and therefore no "over time" counterpart.
+
+        Parameters
+        ----------
+        weight
+            The encoder or decoder weights of the trained TFT model, with shape
+            `(batch, time, 1, n_vars)`.
+
+        Returns
+        -------
+        np.ndarray | None
+            Array of shape `(batch, time, n_vars)` with the importance in percent per timestep,
+            in the same variable order as `weight`, or `None` if `weight` is `None`.
+        """
+        if weight is None:
+            return None
+
+        # weight shape: (batch, time, 1, n_vars) -> (batch, time, n_vars). Column order is kept
+        # as-is (unlike `_get_importance`, not sorted by magnitude), since a `TimeSeries` needs a
+        # fixed component order across all timesteps.
+        return weight.detach().cpu().numpy().squeeze(axis=2) * 100
 
     @property
     def _name_mapping(self) -> dict[str, str]:

--- a/darts/tests/explainability/test_tft_explainer.py
+++ b/darts/tests/explainability/test_tft_explainer.py
@@ -418,12 +418,8 @@ class TestTFTExplainer:
         dec_imp_ot = results.get_decoder_importance_over_time()
         if n_series > 1:
             # check that all importances are the same across series (since the series have identical values)
-            np.testing.assert_array_almost_equal(
-                enc_imp_ot[0].values(), enc_imp_ot[1].values()
-            )
-            np.testing.assert_array_almost_equal(
-                dec_imp_ot[0].values(), dec_imp_ot[1].values()
-            )
+            assert enc_imp_ot[0] == enc_imp_ot[1]
+            assert dec_imp_ot[0] == dec_imp_ot[1]
             enc_imp_ot = enc_imp_ot[0]
             dec_imp_ot = dec_imp_ot[0]
         assert isinstance(enc_imp_ot, TimeSeries)
@@ -441,12 +437,12 @@ class TestTFTExplainer:
         np.testing.assert_allclose(
             mean_enc_ot[enc_imp.columns].to_numpy(),
             enc_imp.iloc[0].to_numpy(),
-            atol=0.5,
+            atol=0.1,
         )
         np.testing.assert_allclose(
             mean_dec_ot[dec_imp.columns].to_numpy(),
             dec_imp.iloc[0].to_numpy(),
-            atol=0.5,
+            atol=0.1,
         )
 
         figs = explainer.plot_variable_selection(results)

--- a/darts/tests/explainability/test_tft_explainer.py
+++ b/darts/tests/explainability/test_tft_explainer.py
@@ -172,6 +172,22 @@ class TestTFTExplainer:
         assert attention.end_time() == series.end_time() + ocl * freq
         assert attention.n_components == ocl
 
+        enc_imp_ot = result.get_encoder_importance_over_time()
+        dec_imp_ot = result.get_decoder_importance_over_time()
+        assert isinstance(enc_imp_ot, TimeSeries)
+        assert isinstance(dec_imp_ot, TimeSeries)
+        assert len(enc_imp_ot) == icl
+        assert enc_imp_ot.start_time() == series.end_time() - (icl - 1) * freq
+        assert enc_imp_ot.end_time() == series.end_time()
+        assert enc_imp_ot.n_components == n_enc_expected
+        assert len(dec_imp_ot) == ocl
+        assert dec_imp_ot.start_time() == series.end_time() + freq
+        assert dec_imp_ot.end_time() == series.end_time() + ocl * freq
+        assert dec_imp_ot.n_components == n_dec_expected
+        # importances must sum up to 100 percent at every single timestep (not just on average)
+        np.testing.assert_allclose(enc_imp_ot.values().sum(axis=1), 100.0, atol=0.1)
+        np.testing.assert_allclose(dec_imp_ot.values().sum(axis=1), 100.0, atol=0.1)
+
     @pytest.mark.parametrize("test_case", helper_create_test_cases(["multiple"]))
     def test_explainer_multiple_multivariate_series(self, test_case):
         """Test TFTExplainer with multiple multivaraites series and a combination of encoders, covariates,
@@ -284,6 +300,28 @@ class TestTFTExplainer:
         ])
         assert all([att.n_components == ocl for att in attention])
 
+        enc_imp_ot = result.get_encoder_importance_over_time()
+        dec_imp_ot = result.get_decoder_importance_over_time()
+        assert isinstance(enc_imp_ot, list) and len(enc_imp_ot) == len(series)
+        assert isinstance(dec_imp_ot, list) and len(dec_imp_ot) == len(series)
+        assert all([isinstance(ts, TimeSeries) for ts in enc_imp_ot])
+        assert all([isinstance(ts, TimeSeries) for ts in dec_imp_ot])
+        assert all([len(ts) == icl for ts in enc_imp_ot])
+        assert all([len(ts) == ocl for ts in dec_imp_ot])
+        assert all([ts.n_components == n_enc_expected for ts in enc_imp_ot])
+        assert all([ts.n_components == n_dec_expected for ts in dec_imp_ot])
+        assert all([
+            ts.start_time() == series_.end_time() - (icl - 1) * freq
+            for ts, series_ in zip(enc_imp_ot, series)
+        ])
+        assert all([
+            ts.end_time() == series_.end_time() + ocl * freq
+            for ts, series_ in zip(dec_imp_ot, series)
+        ])
+        # importances must sum up to 100 percent at every single timestep (not just on average)
+        for ts in enc_imp_ot + dec_imp_ot:
+            np.testing.assert_allclose(ts.values().sum(axis=1), 100.0, atol=0.1)
+
         # cannot explain more series than the batch size
         with pytest.raises(ValueError) as exc:
             explainer.explain(
@@ -375,6 +413,41 @@ class TestTFTExplainer:
         stc_imp = imps_direct[2]
         # relaxed comparison because M1 chip gives slightly different results than intel chip
         assert ((stc_imp.round(decimals=1) - stc_expected).abs() <= 0.1).all().all()
+
+        enc_imp_ot = results.get_encoder_importance_over_time()
+        dec_imp_ot = results.get_decoder_importance_over_time()
+        if n_series > 1:
+            # check that all importances are the same across series (since the series have identical values)
+            np.testing.assert_array_almost_equal(
+                enc_imp_ot[0].values(), enc_imp_ot[1].values()
+            )
+            np.testing.assert_array_almost_equal(
+                dec_imp_ot[0].values(), dec_imp_ot[1].values()
+            )
+            enc_imp_ot = enc_imp_ot[0]
+            dec_imp_ot = dec_imp_ot[0]
+        assert isinstance(enc_imp_ot, TimeSeries)
+        assert isinstance(dec_imp_ot, TimeSeries)
+        assert set(enc_imp_ot.components) == set(enc_imp.columns)
+        assert set(dec_imp_ot.components) == set(dec_imp.columns)
+        # averaging the per-timestep importance over time must recover the (already validated)
+        # time-aggregated importance, since both derive from the same underlying softmax weights
+        mean_enc_ot = pd.Series(
+            enc_imp_ot.values().mean(axis=0), index=enc_imp_ot.components
+        )
+        mean_dec_ot = pd.Series(
+            dec_imp_ot.values().mean(axis=0), index=dec_imp_ot.components
+        )
+        np.testing.assert_allclose(
+            mean_enc_ot[enc_imp.columns].to_numpy(),
+            enc_imp.iloc[0].to_numpy(),
+            atol=0.5,
+        )
+        np.testing.assert_allclose(
+            mean_dec_ot[dec_imp.columns].to_numpy(),
+            dec_imp.iloc[0].to_numpy(),
+            atol=0.5,
+        )
 
         figs = explainer.plot_variable_selection(results)
         if n_series == 1:

--- a/darts/tests/explainability/test_tft_explainer.py
+++ b/darts/tests/explainability/test_tft_explainer.py
@@ -418,8 +418,12 @@ class TestTFTExplainer:
         dec_imp_ot = results.get_decoder_importance_over_time()
         if n_series > 1:
             # check that all importances are the same across series (since the series have identical values)
-            assert enc_imp_ot[0] == enc_imp_ot[1]
-            assert dec_imp_ot[0] == dec_imp_ot[1]
+            np.testing.assert_array_almost_equal(
+                enc_imp_ot[0].values(), enc_imp_ot[1].values()
+            )
+            np.testing.assert_array_almost_equal(
+                dec_imp_ot[0].values(), dec_imp_ot[1].values()
+            )
             enc_imp_ot = enc_imp_ot[0]
             dec_imp_ot = dec_imp_ot[0]
         assert isinstance(enc_imp_ot, TimeSeries)


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

Addresses #2685.

### Summary

Adds support for per-timestep (non-aggregated) encoder/decoder variable importances to `TFTExplainer`.

- `TFTExplainer.explain()` now also computes `encoder_importance_over_time` / `decoder_importance_over_time` per series, without averaging over the input chunk / forecast horizon time axis (unlike the existing, time-aggregated `get_encoder_importance()` / `get_decoder_importance()`).
- Exposed as `TimeSeries` (one component per variable) via two new accessors on `TFTExplainabilityResult`: `get_encoder_importance_over_time()` and `get_decoder_importance_over_time()`.
- Static covariates have no time dimension, so there is no "over time" variant for them.
- Per @dennisbader's two constraints in the issue thread: the logic lives in the existing `TFTExplainer` (no subclass), and the output uses `TimeSeries` (not `pandas.DataFrame`).

### Other Information

This PR intentionally covers only the data layer. A follow-up plotting method (e.g. a stacked bar chart of importance over time) was discussed as a separate concern and is left out of scope here — happy to follow up with that in a second PR once this API shape is agreed on.

Testing:
- Extended the existing parametrized tests (`test_explainer_single_univariate_multivariate_series`, `test_explainer_multiple_multivariate_series`) with shape/timing/sum-to-100%-per-timestep checks across all covariate/encoder/relative-index combinations.
- Added a cross-check in `test_variable_selection_explanation` that averaging the new per-timestep values over time recovers the already-validated aggregated importance.
- `uv run pytest darts/tests/explainability/test_tft_explainer.py` — 52 passed.
- `ruff check` / `ruff format --check` clean.
