### PR TITLE
update test for statsforecast v2.1.1 support

### DIFF
--- a/darts/tests/models/forecasting/test_sf_models.py
+++ b/darts/tests/models/forecasting/test_sf_models.py
@@ -154,8 +154,8 @@ class TestSFModels:
             (
                 StatsForecastModel,
                 {"model": sf_models.SimpleExponentialSmoothing(alpha=0.1)},
-                True,
-            ),  # (custom, custom, conformal)
+                False,
+            ),  # (custom, custom, native since statsforecast 2.1.1)
         ],
     )
     def test_probabilistic_support(self, config):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ all = ["darts[torch,notorch]"]
 [tool.uv]
 # Cooldown period for PyPI releases to mitigate supply chain attacks.
 exclude-newer = "7 days"
-exclude-newer-package = { jupyterlab = "3 days" }
+exclude-newer-package = {}
 # Must resolve dependencies for major platforms in uv.lock
 required-environments = [
     "sys_platform == 'darwin'",
@@ -189,7 +189,7 @@ release = [
     "ipython-genutils==0.2.0",
     "ipywidgets==8.1.8",
     "jinja2==3.1.6",
-    "jupyterlab==4.5.9",
+    "jupyterlab==4.6.2",
     "lxml-html-clean==0.4.5",
     "myst-parser==5.0.0; python_version >= '3.11'",
     "myst-parser==4.0.1; python_version < '3.11'",


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the [Changelog](../CHANGELOG.md).

### Summary

- fixes failing unit test for new statsforecast v2.1.1 (added native probabilistic support for SimpleExponentionalSmoothing)
- bumps jupyterlab from 4.5.9 to 4.6.2 as suggested by uv audit workflow