### PR TITLE
update test for statsforecast v2.1.1 support

### DIFF
--- a/darts/tests/models/forecasting/test_sf_models.py
+++ b/darts/tests/models/forecasting/test_sf_models.py
@@ -12,6 +12,7 @@ if not SF_AVAILABLE:
         allow_module_level=True,
     )
 
+import statsforecast
 import statsforecast.models as sf_models
 from statsforecast.utils import ConformalIntervals
 
@@ -28,6 +29,12 @@ from darts.models import (
     StatsForecastModel,
 )
 from darts.utils.likelihood_models.statsforecast import QuantilePrediction
+
+_SF_211_OR_ABOVE = tuple(int(i) for i in statsforecast.__version__.split(".")) >= (
+    2,
+    1,
+    1,
+)
 
 
 class TestSFModels:
@@ -154,7 +161,7 @@ class TestSFModels:
             (
                 StatsForecastModel,
                 {"model": sf_models.SimpleExponentialSmoothing(alpha=0.1)},
-                False,
+                not _SF_211_OR_ABOVE,
             ),  # (custom, custom, native since statsforecast 2.1.1)
         ],
     )


### PR DESCRIPTION
### Summary

- fixes failing statsforecast tests for all versions