### PR TITLE
Add TimeSeries.argmax() and argmin() aggregation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `"warn"` (default) raises a warning and returns `0.0` when the numerator is also zero (typically meaning perfect forecasts) or `np.nan` otherwise
   - `"raise"` preserves the legacy error.
 - Added an optional `min_train_length` parameter to third-party local forecasting models (StatsForecast models such as `StatsForecastingModel`, `AutoETS`, ... and other models such as `ExponentialSmoothing`, `*ARIMA`, `*Theta`, `Prophet`, `FFT`, and `KalmanForecaster`) to override the conservative default minimum training series length and allow fitting on shorter series. Note that lowering this value might raise exceptions from the third-party models themselves if their internal input requirements are not met. [#3167](https://github.com/unit8co/darts/pull/3167) by [Haibin Yu](https://github.com/haiiibin).
+- Added `TimeSeries.argmax()` and `TimeSeries.argmin()` methods that return the integer position of the maximum/minimum along a given `axis` (following `numpy.argmax`/`numpy.argmin` semantics), complementing the existing `max()`/`min()` aggregations. With `axis=0` the returned position can be mapped back to a timestamp via `series.time_index[position]`. [#3180](https://github.com/unit8co/darts/pull/3180) by [Jaideep Pyne](https://github.com/jaideeppyne).
 
 **Fixed**
 

--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -669,7 +669,8 @@ class TestTimeSeries:
             freq_expected = pd.tseries.frequencies.to_offset(expected)
             # apply trick to resample a timestamp to the desired frequency
             start = (
-                pd.Series(index=[pd.Timestamp("2000-01-01")])
+                pd
+                .Series(index=[pd.Timestamp("2000-01-01")])
                 .resample(freq_expected)
                 .mean()
                 .index[0]
@@ -3507,6 +3508,32 @@ class TestSimpleStatistics:
             # check values
             assert np.isclose(
                 new_ts._values, self.values.max(axis=axis, keepdims=True)
+            ).all()
+
+    def test_argmin(self):
+        for axis in range(3):
+            new_ts = self.ts.argmin(axis=axis)
+            # check values match numpy argmin positions
+            assert (
+                new_ts._values == self.values.argmin(axis=axis, keepdims=True)
+            ).all()
+            # position must point back to the actual minimum
+            assert np.isclose(
+                np.take_along_axis(self.values, new_ts._values.astype(int), axis=axis),
+                self.values.min(axis=axis, keepdims=True),
+            ).all()
+
+    def test_argmax(self):
+        for axis in range(3):
+            new_ts = self.ts.argmax(axis=axis)
+            # check values match numpy argmax positions
+            assert (
+                new_ts._values == self.values.argmax(axis=axis, keepdims=True)
+            ).all()
+            # position must point back to the actual maximum
+            assert np.isclose(
+                np.take_along_axis(self.values, new_ts._values.astype(int), axis=axis),
+                self.values.max(axis=axis, keepdims=True),
             ).all()
 
     def test_sum(self):

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -4809,6 +4809,74 @@ class TimeSeries:
             **(self._attrs if axis != 1 else dict()),
         )
 
+    def argmin(self, axis: int = 2) -> Self:
+        """Return a new series with the position of the minimum computed over the specified `axis`.
+
+        The returned values are the integer indices along `axis` at which the minimum occurs (following
+        :func:`numpy.argmin` semantics). For example, with ``axis=0`` each value is the position in the
+        original ``time_index`` where that component/sample reaches its minimum, which can then be mapped
+        back to a timestamp via ``series.time_index[position]``.
+
+        If we reduce over time (``axis=0``), the series will have length one and will use the first entry of the
+        original ``time_index``. If we perform the calculation over the components (``axis=1``), the resulting single
+        component will be renamed to "components_argmin". When applied to the samples (``axis=2``), a deterministic
+        series is returned.
+
+        If ``axis=1``, the static covariates and the hierarchy are discarded from the series.
+
+        Parameters
+        ----------
+        axis
+            The axis to reduce over. The default is to calculate over samples, i.e. axis=2.
+
+        Returns
+        -------
+        TimeSeries
+            A new series with the position of the minimum applied to the indicated axis.
+        """
+        values = self._values.argmin(axis=axis, keepdims=True)
+        times, components = self._get_agg_dims("components_argmin", axis)
+        return self.__class__(
+            times=times,
+            values=values,
+            components=components,
+            **(self._attrs if axis != 1 else dict()),
+        )
+
+    def argmax(self, axis: int = 2) -> Self:
+        """Return a new series with the position of the maximum computed over the specified `axis`.
+
+        The returned values are the integer indices along `axis` at which the maximum occurs (following
+        :func:`numpy.argmax` semantics). For example, with ``axis=0`` each value is the position in the
+        original ``time_index`` where that component/sample reaches its maximum, which can then be mapped
+        back to a timestamp via ``series.time_index[position]``.
+
+        If we reduce over time (``axis=0``), the series will have length one and will use the first entry of the
+        original ``time_index``. If we perform the calculation over the components (``axis=1``), the resulting single
+        component will be renamed to "components_argmax". When applied to the samples (``axis=2``), a deterministic
+        series is returned.
+
+        If ``axis=1``, the static covariates and the hierarchy are discarded from the series.
+
+        Parameters
+        ----------
+        axis
+            The axis to reduce over. The default is to calculate over samples, i.e. axis=2.
+
+        Returns
+        -------
+        TimeSeries
+            A new series with the position of the maximum applied to the indicated axis.
+        """
+        values = self._values.argmax(axis=axis, keepdims=True)
+        times, components = self._get_agg_dims("components_argmax", axis)
+        return self.__class__(
+            times=times,
+            values=values,
+            components=components,
+            **(self._attrs if axis != 1 else dict()),
+        )
+
     def quantile(self, q: float | Sequence[float] = 0.5, **kwargs) -> Self:
         """Return a deterministic series with the desired quantile(s) `q` of each component computed over the samples
         of the stochastic series.


### PR DESCRIPTION
## Summary

Adds `TimeSeries.argmax()` and `TimeSeries.argmin()`, which return the integer **position** of the maximum/minimum along a given `axis`, following `numpy.argmax`/`numpy.argmin` semantics.

This addresses the second half of #2696, which notes:

> There also does not seem to be a `TimeSeries` equivalent of `Series.idxmax` or `np.ndarray.argmax`.

Rather than changing the existing `max()`/`min()` behaviour (which the issue observes is kept for consistency with `mean(axis=0)`, `median(axis=0)`, … and would be a breaking change), this adds the missing positional reducers alongside them.

With `axis=0`, the returned position maps straight back to a timestamp:

```python
pos = series.argmax(axis=0)          # position of each component's max over time
ts_of_max = series.time_index[int(pos.values()[0, 0])]
```

## Details

- `argmax(axis=2)` / `argmin(axis=2)` mirror the existing `max()`/`min()` implementation exactly, reusing `_get_agg_dims` for the output time index and component naming (`components_argmax` / `components_argmin` when reducing over components).
- Works over all three axes (time, components, samples), consistent with the other reducers.
- Non-breaking: purely additive.

## Testing

- Added `test_argmin` / `test_argmax` to `TestSimpleStatistics`, checking both that the positions equal `numpy.argmin`/`argmax` and that each returned position actually points back to the true extremum (via `np.take_along_axis`) across all three axes.
- New tests pass; the full `TestSimpleStatistics` suite is green; `ruff check` and `ruff format --check` pass.
- Added a `CHANGELOG.md` entry under *Improved*.
