### PR TITLE
Add save() and load() methods to KMeansScorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
   - `"warn"` (default) raises a warning and returns `0.0` when the numerator is also zero (typically meaning perfect forecasts) or `np.nan` otherwise
   - `"raise"` preserves the legacy error.
 - Added an optional `min_train_length` parameter to third-party local forecasting models (StatsForecast models such as `StatsForecastingModel`, `AutoETS`, ... and other models such as `ExponentialSmoothing`, `*ARIMA`, `*Theta`, `Prophet`, `FFT`, and `KalmanForecaster`) to override the conservative default minimum training series length and allow fitting on shorter series. Note that lowering this value might raise exceptions from the third-party models themselves if their internal input requirements are not met. [#3167](https://github.com/unit8co/darts/pull/3167) by [Haibin Yu](https://github.com/haiiibin).
+- Added `save()` and `load()` methods to `KMeansScorer`, allowing a fitted scorer to be persisted to disk and reloaded without retraining. [#3051](https://github.com/unit8co/darts/issues/3051) by [Boubker Bennani](https://github.com/boubkerbennani).
 
 **Fixed**
 

--- a/darts/ad/scorers/kmeans_scorer.py
+++ b/darts/ad/scorers/kmeans_scorer.py
@@ -9,11 +9,18 @@ References
 .. [1] https://en.wikipedia.org/wiki/K-means_clustering
 """
 
+import datetime
+import io
+import os
+import pickle
+from typing import BinaryIO
+
 import numpy as np
 from sklearn.cluster import KMeans
 
 from darts import metrics
 from darts.ad.scorers.scorers import WindowedAnomalyScorer
+from darts.logging import raise_log
 from darts.metrics.utils import METRIC_TYPE
 
 
@@ -128,3 +135,79 @@ class KMeansScorer(WindowedAnomalyScorer):
         """Wrapper around model inference method"""
         # only return the closest distance out of the k ones (k centroids)
         return model.transform(data).min(axis=1)
+
+    def _default_save_path(self) -> str:
+        return f"{self.__class__.__name__}_{datetime.datetime.now().strftime('%Y-%m-%d_%H_%M_%S')}"
+
+    def save(
+        self,
+        path: str | os.PathLike | BinaryIO | None = None,
+        **pkl_kwargs,
+    ) -> None:
+        """Saves the scorer under a given path or file handle.
+
+        Example for saving and loading a :class:`KMeansScorer`:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                from darts.ad import KMeansScorer
+
+                scorer = KMeansScorer()
+                scorer.fit(series)
+
+                scorer.save("my_scorer.pkl")
+                scorer_loaded = KMeansScorer.load("my_scorer.pkl")
+            ..
+
+        Parameters
+        ----------
+        path
+            Path or file handle under which to save the scorer at its current state. If no path is specified, the
+            scorer is automatically saved under ``"{ScorerClass}_{YYYY-mm-dd_HH_MM_SS}.pkl"``.
+            E.g., ``"KMeansScorer_2020-01-01_12_00_00.pkl"``.
+        pkl_kwargs
+            Keyword arguments passed to `pickle.dump()`
+        """
+        if path is None:
+            path = self._default_save_path() + ".pkl"
+
+        if isinstance(path, str | os.PathLike):
+            with open(path, "wb") as handle:
+                pickle.dump(obj=self, file=handle, **pkl_kwargs)
+        elif isinstance(path, io.BufferedWriter):
+            pickle.dump(obj=self, file=path, **pkl_kwargs)
+        else:
+            raise_log(
+                ValueError(
+                    "Argument 'path' has to be either 'str' or 'PathLike' (for a filepath) "
+                    f"or 'BufferedWriter' (for an already opened file), but was '{path.__class__}'."
+                ),
+            )
+
+    @staticmethod
+    def load(path: str | os.PathLike | BinaryIO) -> "KMeansScorer":
+        """Loads a scorer from a given path or file handle.
+
+        Parameters
+        ----------
+        path
+            Path or file handle from which to load the scorer.
+        """
+        if isinstance(path, str | os.PathLike):
+            if not os.path.exists(path):
+                raise_log(ValueError(f"The file {path} doesn't exist."))
+
+            with open(path, "rb") as handle:
+                scorer = pickle.load(file=handle)
+        elif isinstance(path, io.BufferedReader):
+            scorer = pickle.load(file=path)
+        else:
+            raise_log(
+                ValueError(
+                    "Argument 'path' has to be either 'str' or 'PathLike' (for a filepath) "
+                    f"or 'BufferedReader' (for an already opened file), but was '{path.__class__}'."
+                ),
+            )
+
+        return scorer

--- a/darts/tests/ad/test_scorers.py
+++ b/darts/tests/ad/test_scorers.py
@@ -1041,6 +1041,16 @@ class TestAnomalyDetectionScorer:
         with pytest.raises(ValueError):
             KMeansScorer.load("path/that/does/not/exist.pkl")
 
+    def test_kmeans_scorer_save_load_invalid_path_type(self):
+        scorer = KMeansScorer(window=5, k=2, random_state=42)
+        scorer.fit(linear_timeseries(length=50))
+
+        with pytest.raises(ValueError):
+            scorer.save(b"invalid_path")
+
+        with pytest.raises(ValueError):
+            KMeansScorer.load(b"invalid_path")
+
     def test_univariate_kmeans(self):
         # univariate example
         np.random.seed(40)

--- a/darts/tests/ad/test_scorers.py
+++ b/darts/tests/ad/test_scorers.py
@@ -1,3 +1,5 @@
+import os
+import pathlib
 from collections.abc import Sequence
 from itertools import product
 
@@ -996,6 +998,48 @@ class TestAnomalyDetectionScorer:
         self.diff_fn_parameter(KMeansScorer)
         self.expects_deterministic_input(KMeansScorer)
         assert not KMeansScorer().is_probabilistic
+
+    def test_kmeans_scorer_save_load(self, tmpdir_module):
+        # check that save/load returns a scorer producing the same scores, and works
+        # with str, pathlib.Path, and already-opened file handles
+        series = linear_timeseries(length=50)
+
+        scorer = KMeansScorer(window=5, k=2, random_state=42)
+        scorer.fit(series)
+        scores_before = scorer.score(series)
+
+        path_str = os.path.join(tmpdir_module, "kmeans_scorer_str.pkl")
+        path_pathlike = pathlib.Path(tmpdir_module) / "kmeans_scorer_pathlike.pkl"
+        path_binary = os.path.join(tmpdir_module, "kmeans_scorer_binary.pkl")
+
+        scorer.save(path_str)
+        scorer.save(path_pathlike)
+        with open(path_binary, "wb") as f:
+            scorer.save(f)
+
+        loaded_str = KMeansScorer.load(path_str)
+        loaded_pathlike = KMeansScorer.load(path_pathlike)
+        with open(path_binary, "rb") as f:
+            loaded_binary = KMeansScorer.load(f)
+
+        for loaded_scorer in [loaded_str, loaded_pathlike, loaded_binary]:
+            assert isinstance(loaded_scorer, KMeansScorer)
+            assert loaded_scorer.score(series) == scores_before
+
+    def test_kmeans_scorer_save_default_path(self, tmpdir_module):
+        # tmpdir_module fixture already chdir's into a fresh temp directory
+        scorer = KMeansScorer(window=5, k=2, random_state=42)
+        scorer.fit(linear_timeseries(length=50))
+        scorer.save()
+
+        saved_files = [
+            f for f in os.listdir(tmpdir_module) if f.startswith("KMeansScorer_")
+        ]
+        assert len(saved_files) == 1
+
+    def test_kmeans_scorer_load_missing_file(self):
+        with pytest.raises(ValueError):
+            KMeansScorer.load("path/that/does/not/exist.pkl")
 
     def test_univariate_kmeans(self):
         # univariate example


### PR DESCRIPTION
Fixes #3051

### Summary

Adds `save()` and `load()` methods to `KMeansScorer`, pickle-based,
mirroring the existing `ForecastingModel.save()`/`load()` pattern.
Lets a fitted scorer be persisted to disk and reloaded without
retraining.

### Other Information

This overlaps in scope with #3130, which adds save/load more broadly
across the anomaly-detection base classes via a shared mixin. Opening
this narrower, `KMeansScorer`-only version for comparison / in case a
scoped fix is still wanted independently — happy to close in favor of
#3130 if that's preferred.