### PR TITLE
Fix extract_subseries returning a single TimeSeries instead of a list when there is no gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Fixed**
 
+- Fixed `extract_subseries` returning a single `TimeSeries` instead of a `list[TimeSeries]` when the series has no gap under the selected `mode`. [#3184](https://github.com/unit8co/darts/pull/3184) by [Alejandro Coronado](https://github.com/AlejandroCoronadoN).
 - Fixed metrics `arre` and `marre` rejecting an entire input when any component of `actual_series` is constant; the zero-range denominator is now handled element-wise, so an exact prediction yields `0.0` and only undefined entries become `np.nan`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
 - Fixed metric `ope` to accept an `actual_series` with a strictly negative sum (the previous `sum > 0` check rejected valid inputs such as financial return series). [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
 - Fixed metric `wmape` docstring which inaccurately claimed it raised on zeros in `actual_series`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).

--- a/darts/tests/utils/test_utils.py
+++ b/darts/tests/utils/test_utils.py
@@ -116,6 +116,32 @@ class TestUtils:
         assert subseries_any[1] == series[3:5]
         assert subseries_any[2] == series[-1]
 
+        # a series without any missing value must return a list holding the
+        # single (unchanged) series, not a bare TimeSeries
+        clean_series = TimeSeries.from_values(np.arange(5.0).reshape(-1, 1))
+        subseries_clean = extract_subseries(clean_series)
+        assert isinstance(subseries_clean, list)
+        assert len(subseries_clean) == 1
+        assert subseries_clean[0] == clean_series
+
+        # series with missing values but no gap under the selected mode must
+        # still return a list with a single series (not a bare TimeSeries)
+        no_gap_df = pd.DataFrame(
+            {
+                "0": [1.0, np.nan, 3.0, 4.0],
+                "1": [10.0, 20.0, np.nan, 40.0],
+            },
+            index=pd.date_range("20130206", periods=4),
+        )
+        no_gap_series = TimeSeries.from_dataframe(no_gap_df)
+        # NaNs are present, but never in all columns at once, so mode="all"
+        # finds no gap
+        assert no_gap_series.gaps(mode="all").empty
+        subseries_no_gap = extract_subseries(no_gap_series, mode="all")
+        assert isinstance(subseries_no_gap, list)
+        assert len(subseries_no_gap) == 1
+        assert subseries_no_gap[0] == no_gap_series
+
     @pytest.mark.parametrize(
         "config",
         [

--- a/darts/utils/missing_values.py
+++ b/darts/utils/missing_values.py
@@ -99,7 +99,7 @@ def extract_subseries(
     # Get start/end times of sub-series without gaps of missing values
     gaps_df = series.gaps(mode=mode)
     if gaps_df.empty:
-        return series
+        return [series]
     else:
         gaps_df = gaps_df.query(f"gap_size>={min_gap_size}")
         start_times = [series.start_time()] + (gaps_df["gap_end"] + freq).to_list()


### PR DESCRIPTION
`extract_subseries` is annotated `-> list[TimeSeries]` and its docstring says it returns "A list of TimeSeries". Every return path returns a list except one: when `series.gaps(mode=mode)` is empty (the series has missing values but no gap under the selected `mode`), it returns the bare `series` instead of `[series]`.

Repro:

```python
import numpy as np, pandas as pd
from darts import TimeSeries
from darts.utils.missing_values import extract_subseries

vals = np.array([[1., 10.], [np.nan, 20.], [3., np.nan], [4., 40.]])
ts = TimeSeries.from_times_and_values(pd.date_range("20130206", periods=4), vals)
res = extract_subseries(ts, mode="all")
print(type(res).__name__, isinstance(res, list))  # TimeSeries False, expected list True
```

A caller doing `for sub in extract_subseries(ts): ...` then silently iterates over the TimeSeries samples instead of a one-element list.

Fix: return `[series]` in that branch, matching the other return paths and the annotation. Extended the existing `test_extract_subseries` to cover the no-gap case.
