### PR TITLE
Fix incorrect return type annotations in darts.utils.statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 **Fixed**
 
 - Fixed a deprecation warning from `lightgbm>=4.7.0` when training a `LightGBMModel` with validation series. [#3186](https://github.com/unit8co/darts/pull/3186) by [Dennis Bader](https://github.com/dennisbader).
+- Fixed incorrect return type annotations in `darts.utils.statistics`: `stationarity_test_kpss` and `stationarity_test_adf` now annotate `tuple` (they wrap statsmodels `kpss`/`adfuller`), and `granger_causality_tests` annotates `dict` instead of `None` (matching its docstring). [#3185](https://github.com/unit8co/darts/pull/3185) by [Alejandro Coronado](https://github.com/AlejandroCoronadoN).
 - Fixed `extract_subseries` returning a single `TimeSeries` instead of a `list[TimeSeries]` when the series has no gap under the selected `mode`. [#3184](https://github.com/unit8co/darts/pull/3184) by [Alejandro Coronado](https://github.com/AlejandroCoronadoN).
 - Fixed metrics `arre` and `marre` rejecting an entire input when any component of `actual_series` is constant; the zero-range denominator is now handled element-wise, so an exact prediction yields `0.0` and only undefined entries become `np.nan`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
 - Fixed metric `ope` to accept an `actual_series` with a strictly negative sum (the previous `sum > 0` check rejected valid inputs such as financial return series). [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).

--- a/darts/tests/utils/test_statistics.py
+++ b/darts/tests/utils/test_statistics.py
@@ -112,6 +112,31 @@ class TestTimeSeries:
         assert stationarity_test_adf(series_3)[1] < 0.05
         assert stationarity_tests
 
+    def test_stationarity_tests_return_type_annotation(self):
+        # the functions wrap statsmodels' ``kpss``/``adfuller`` which return a
+        # tuple; the return type annotation must match the actual return value.
+        import typing
+
+        series = gaussian_timeseries(start=0, end=999)
+
+        for fn in (stationarity_test_kpss, stationarity_test_adf):
+            annotated = typing.get_type_hints(fn)["return"]
+            result = fn(series)
+            assert isinstance(result, annotated)
+            assert isinstance(result, tuple)
+
+    def test_granger_causality_return_type_annotation(self):
+        # ``granger_causality_tests`` wraps statsmodels' ``grangercausalitytests``
+        # which returns a dict; the annotation must match the actual return value.
+        import typing
+
+        series = gaussian_timeseries(start=0, end=999)
+
+        annotated = typing.get_type_hints(granger_causality_tests)["return"]
+        result = granger_causality_tests(series, series, 2)
+        assert isinstance(result, annotated)
+        assert isinstance(result, dict)
+
 
 class TestSeasonalDecompose:
     pd_series = pd.Series(range(50), index=pd.date_range("20130101", "20130219"))

--- a/darts/utils/statistics.py
+++ b/darts/utils/statistics.py
@@ -452,7 +452,7 @@ def stationarity_tests(
 
 def stationarity_test_kpss(
     ts: TimeSeries, regression: str = "c", nlags: str | int = "auto"
-) -> set:
+) -> tuple:
     """
     Provides Kwiatkowski-Phillips-Schmidt-Shin test for stationarity for a time series,
     using :func:`statsmodels.tsa.stattools.kpss`. See [1]_.
@@ -473,7 +473,7 @@ def stationarity_test_kpss(
 
     Returns
     -------
-    set
+    tuple
         | kpss_stat: The test statistic.
         | pvalue: The p-value of the test. The p-value is interpolated from Table 1 in [2]_,
         | and a boundary point is returned if the test statistic is outside the table of critical values,
@@ -497,7 +497,7 @@ def stationarity_test_adf(
     maxlag: None | int = None,
     regression: str = "c",
     autolag: None | str = "AIC",
-) -> set:
+) -> tuple:
     """
     Provides Augmented Dickey-Fuller unit root test for a time series,
     using :func:`statsmodels.tsa.stattools.adfuller`. See [1]_.
@@ -524,7 +524,7 @@ def stationarity_test_adf(
 
     Returns
     -------
-    set
+    tuple
         | adf: The test statistic.
         | pvalue: MacKinnon's approximate p-value based on [2]_.
         | usedlag: The number of lags used.
@@ -549,7 +549,7 @@ def granger_causality_tests(
     ts_effect: TimeSeries,
     maxlag: int,
     addconst: bool = True,
-) -> None:
+) -> dict:
     """
     Provides four tests for granger non causality of 2 time series using
     :func:`statsmodels.tsa.stattools.grangercausalitytests`.


### PR DESCRIPTION
Three functions in `darts/utils/statistics.py` have return type annotations that do not match what they actually return:

- `stationarity_test_kpss` is annotated `-> set` but returns a `tuple` (it wraps `statsmodels.tsa.stattools.kpss`).
- `stationarity_test_adf` is annotated `-> set` but returns a `tuple` (it wraps `adfuller`).
- `granger_causality_tests` is annotated `-> None` but returns a `dict` (it wraps `grangercausalitytests`); its own docstring already says it returns a `Dict`.

The docstrings and the existing tests already treat these as tuples/dict (for example `stationarity_test_kpss(series)[1]`), so the annotations are just wrong and mislead type checkers and IDEs. This fixes the annotations to match the real return values and adds a small regression test.
