### PR TITLE
Add TSPulse filter for reconstruction and imputation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 
 **Improved**
 
+- Added `TSPulseFilter` for zero-shot time-series reconstruction and missing-value imputation with IBM Granite TSPulse-R1. The reconstruction can also be used with `FilteringAnomalyModel` and existing Darts anomaly scorers to produce time-domain residual scores; IBM's all-head anomaly pipeline is not included. [#3128](https://github.com/unit8co/darts/issues/3128) by [ishitta-iyer](https://github.com/ishitta-iyer).
 - Added support for per-timestep (non-aggregated) encoder and decoder variable importances in `TFTExplainer`, exposed as `TimeSeries` via `TFTExplainabilityResult.get_encoder_importance_over_time()` and `get_decoder_importance_over_time()`. [#3170](https://github.com/unit8co/darts/pull/3170) by [exactml](https://github.com/exactml).
 - Calling `TFTModel.fit_from_dataset()` on a dataset that does not have future covariates now raises an informative exception. [#3149](https://github.com/unit8co/darts/pull/3149) by [YOON KIWOONG](https://github.com/kiwoongyoon).
 - 🔴 Percentage and range-based metrics (`ape`, `mape`, `sape`, `smape`, `wmape`, `ope`, `arre`, `marre`, `coefficient_of_variation`) no longer raise a hard `ValueError` when the denominator is exactly zero. A new `zero_division` parameter controls the behavior: [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,7 @@ Some models have additional dependencies that are not included in the `all` inst
 |-----------------------|-----------------------|
 | `NeuralForecastModel` | neuralforecast>=3.0.0 |
 | `TiRexModel`          | tirex-ts>=1.4.0       |
+| `TSPulseFilter`       | granite-tsfm>=0.3.6 (Python 3.11-3.13) |
 
 
 ## From conda-forge
@@ -52,6 +53,7 @@ Some models have dependencies not available on conda-forge. To use them, you nee
 | Model                 | Dependencies          |
 |-----------------------|-----------------------|
 | `TiRexModel`          | tirex-ts>=1.4.0       |
+| `TSPulseFilter`       | granite-tsfm>=0.3.6 (Python 3.11-3.13) |
 
 
 ## Other Information

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ series.plot()
 * **PyTorch Lightning Support:** All deep learning models are implemented using PyTorch Lightning,
   supporting among other things custom callbacks, GPUs/TPUs training and custom trainers.
 
-* **Filtering Models:** Darts offers three filtering models: `KalmanFilter`, `GaussianProcessFilter`,
-  and `MovingAverageFilter`, which allow to filter time series, and in some cases obtain probabilistic
+* **Filtering Models:** Darts offers four filtering models: `KalmanFilter`, `GaussianProcessFilter`,
+  `MovingAverageFilter`, and `TSPulseFilter`, which allow to filter or reconstruct time series, fill missing values, and in some cases obtain probabilistic
   inferences of the underlying states/values.
 
 * **Datasets** The `darts.datasets` submodule contains some popular time series datasets for rapid

--- a/darts/models/__init__.py
+++ b/darts/models/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from darts.models.filtering.moving_average_filter import (
         MovingAverageFilter as MovingAverageFilter,
     )
+    from darts.models.filtering.tspulse_filter import TSPulseFilter as TSPulseFilter
     from darts.models.forecasting.arima import ARIMA as ARIMA
     from darts.models.forecasting.baselines import NaiveDrift as NaiveDrift
     from darts.models.forecasting.baselines import NaiveMean as NaiveMean
@@ -215,6 +216,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
     "GaussianProcessFilter": ("darts.models.filtering.gaussian_process_filter", None),
     "KalmanFilter": ("darts.models.filtering.kalman_filter", None),
     "MovingAverageFilter": ("darts.models.filtering.moving_average_filter", None),
+    "TSPulseFilter": (
+        "darts.models.filtering.tspulse_filter",
+        "(Py)Torch",
+    ),
 }
 
 __all__, __getattr__, __dir__ = setup_lazy_imports(_LAZY_IMPORTS, __name__, globals())

--- a/darts/models/filtering/__init__.py
+++ b/darts/models/filtering/__init__.py
@@ -2,6 +2,6 @@
 Filtering Models
 ----------------
 
-Models for filtering and smoothing time series data, including Kalman filters, Gaussian Process Filters,
-and Moving Average Filters.
+Models for filtering, smoothing, and reconstructing time series data, including
+Kalman filters, Gaussian Process Filters, Moving Average Filters, and TSPulse.
 """

--- a/darts/models/filtering/tspulse_filter.py
+++ b/darts/models/filtering/tspulse_filter.py
@@ -1,0 +1,451 @@
+"""
+TSPulse Filter
+--------------
+"""
+
+import os
+from numbers import Integral
+from typing import Any
+
+import numpy as np
+import torch
+
+from darts import TimeSeries
+from darts.logging import raise_log
+from darts.models.filtering.filtering_model import FilteringModel
+from darts.utils.utils import _maybe_cast_array_dtype
+
+
+class TSPulseFilter(FilteringModel):
+    """Zero-shot time-series reconstruction and imputation with TSPulse.
+
+    This filter wraps IBM Granite's pretrained `TSPulse-R1 model
+    <https://huggingface.co/ibm-granite/granite-timeseries-tspulse-r1>`_.
+    :meth:`filter` reconstructs all values in a deterministic series. The
+    reconstructed series can be combined with
+    :class:`~darts.ad.anomaly_model.FilteringAnomalyModel` and a prediction-based
+    scorer to produce simple time-domain reconstruction-residual anomaly scores.
+    :meth:`impute` only replaces missing values and leaves observed values unchanged.
+
+    The optional ``granite-tsfm`` package (Python 3.11 through 3.13) is required
+    when ``model`` is not supplied. TSPulse is loaded lazily on the first call
+    because its number of input channels is determined by the width of the input
+    series.
+
+    Parameters
+    ----------
+    hub_model_name
+        Hugging Face model identifier or local model directory.
+    hub_model_revision
+        Model revision to load. The default is the revision used by IBM's zero-shot
+        imputation example.
+    model
+        An optional pre-loaded ``TSPulseForReconstruction``-compatible model. This is
+        mainly useful for offline use and testing. The model must expose
+        ``config.context_length`` and return ``reconstruction_outputs``. A supplied
+        upstream TSPulse model must have ``config.mask_type == "user"`` so that it
+        uses the missing-value mask passed by this filter. Reload upstream models
+        with ``TSPulseForReconstruction.from_pretrained(..., mask_type="user")``.
+    batch_size
+        Number of windows reconstructed per model call.
+    stride
+        Distance between consecutive context windows. If ``None``, non-overlapping
+        windows are used, with one overlapping final window when needed. Smaller
+        values produce more overlapping reconstructions at a higher inference cost.
+        Must not exceed the model context length.
+    device
+        Torch device used for inference. Defaults to ``"cpu"``.
+    model_kwargs
+        Additional keyword arguments passed to
+        ``TSPulseForReconstruction.from_pretrained()``. ``num_input_channels``,
+        ``mask_type``, ``return_dict``, ``dtype``, and ``torch_dtype`` are managed by
+        this wrapper and cannot be overridden.
+
+    Notes
+    -----
+    This initial integration supports zero-shot reconstruction and imputation with
+    IBM's dual-head imputation checkpoint. It does not reproduce IBM's official
+    patchwise-masked, all-head anomaly-detection pipeline. Fine-tuning and the model's
+    frequency/forecast anomaly-score ensemble are not included. Input series must
+    contain at least the model's context length (512 values for the default
+    checkpoint), as required by the upstream imputation model. Only float32 TSPulse
+    checkpoints are supported. Every component must contain at least one observed
+    value in every context window so the model can determine its location and scale.
+    """
+
+    def __init__(
+        self,
+        hub_model_name: str | os.PathLike = (
+            "ibm-granite/granite-timeseries-tspulse-r1"
+        ),
+        hub_model_revision: str | None = "tspulse-hybrid-dualhead-512-p8-r1",
+        model: Any | None = None,
+        batch_size: int = 32,
+        stride: int | None = None,
+        device: str | torch.device | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+    ):
+        super().__init__()
+
+        if (
+            not isinstance(batch_size, Integral)
+            or isinstance(batch_size, bool)
+            or batch_size <= 0
+        ):
+            raise_log(ValueError("`batch_size` must be a positive integer."))
+        if stride is not None and (
+            not isinstance(stride, Integral) or isinstance(stride, bool) or stride <= 0
+        ):
+            raise_log(ValueError("`stride` must be a positive integer or `None`."))
+
+        model_kwargs = dict(model_kwargs or {})
+        reserved_kwargs = {
+            "num_input_channels",
+            "mask_type",
+            "return_dict",
+            "dtype",
+            "torch_dtype",
+        }.intersection(model_kwargs)
+        if reserved_kwargs:
+            reserved = ", ".join(sorted(reserved_kwargs))
+            raise_log(
+                ValueError(
+                    f"The following `model_kwargs` are managed by TSPulseFilter: {reserved}."
+                )
+            )
+
+        self.hub_model_name = str(hub_model_name)
+        self.hub_model_revision = hub_model_revision
+        self.batch_size = int(batch_size)
+        self.stride = int(stride) if stride is not None else None
+        self.device = torch.device(device or "cpu")
+        self.model_kwargs = model_kwargs
+
+        self._model = model
+        self._model_was_supplied = model is not None
+        self._model_width: int | None = None
+
+    def __str__(self) -> str:
+        return f"TSPulseFilter(model={self.hub_model_name})"
+
+    def filter(self, series: TimeSeries) -> TimeSeries:
+        """Reconstruct every value in ``series`` with TSPulse.
+
+        Parameters
+        ----------
+        series
+            Deterministic univariate or multivariate series to reconstruct. NaN values
+            are passed to TSPulse as unobserved values. Infinite values are not
+            supported. The series must contain at least ``config.context_length``
+            values, and each component must have at least one observed value in every
+            context window.
+
+        Returns
+        -------
+        TimeSeries
+            A deterministic reconstruction with the same time index, components, and
+            metadata as ``series``.
+        """
+        super().filter(series)
+        values = series.values(copy=False)
+        if np.isinf(values).any():
+            raise_log(ValueError("TSPulseFilter does not support infinite values."))
+        model = self._get_model(series.width)
+        context_length = self._context_length(model)
+        if len(series) < context_length:
+            raise_log(
+                ValueError(
+                    "TSPulseFilter requires at least the model context length "
+                    f"({context_length}) of input values, found {len(series)}."
+                )
+            )
+
+        model_dtype = self._model_dtype(model)
+        if model_dtype != torch.float32:
+            raise_log(
+                ValueError(
+                    "TSPulseFilter only supports float32 models, found "
+                    f"{str(model_dtype).removeprefix('torch.')}."
+                )
+            )
+        finite_values = values[~np.isnan(values)]
+        dtype_max = torch.finfo(model_dtype).max
+        if np.any((finite_values > dtype_max) | (finite_values < -dtype_max)):
+            dtype_name = str(model_dtype).removeprefix("torch.")
+            raise_log(
+                ValueError(
+                    "TSPulseFilter input values must be within the finite "
+                    f"{dtype_name} range used by the model."
+                )
+            )
+
+        stride = context_length if self.stride is None else self.stride
+        if stride > context_length:
+            raise_log(
+                ValueError(
+                    f"`stride` must not exceed the model context length "
+                    f"({context_length}), found {stride}."
+                )
+            )
+
+        starts = self._window_starts(len(series), context_length, stride)
+        self._validate_observed_context(
+            values=values,
+            starts=starts,
+            context_length=context_length,
+            components=series.components,
+        )
+        reconstructed = np.zeros((len(series), series.width), dtype=np.float64)
+        counts = np.zeros((len(series), series.width), dtype=np.int64)
+
+        model.eval()
+        with torch.inference_mode():
+            for batch_start in range(0, len(starts), self.batch_size):
+                batch_starts = starts[batch_start : batch_start + self.batch_size]
+                past_values, observed_mask, valid_lengths = self._make_batch(
+                    values=values,
+                    starts=batch_starts,
+                    context_length=context_length,
+                )
+                output = model(
+                    past_values=past_values.to(
+                        device=self.device,
+                        dtype=model_dtype,
+                    ),
+                    past_observed_mask=observed_mask.to(self.device),
+                    return_loss=False,
+                    return_dict=True,
+                )
+                batch_reconstruction = self._reconstruction_values(output)
+
+                expected_shape = tuple(past_values.shape)
+                if tuple(batch_reconstruction.shape) != expected_shape:
+                    raise_log(
+                        ValueError(
+                            "TSPulse returned reconstruction shape "
+                            f"{tuple(batch_reconstruction.shape)}, expected {expected_shape}."
+                        )
+                    )
+
+                batch_reconstruction = (
+                    batch_reconstruction.detach().cpu().to(dtype=torch.float64).numpy()
+                )
+                for window, start, valid_length in zip(
+                    batch_reconstruction, batch_starts, valid_lengths
+                ):
+                    stop = start + valid_length
+                    reconstructed[start:stop] += window[:valid_length]
+                    counts[start:stop] += 1
+
+        if np.any(counts == 0):
+            raise_log(RuntimeError("TSPulse windowing left values unreconstructed."))
+        reconstructed /= counts
+
+        return TimeSeries(
+            times=series.time_index,
+            values=_maybe_cast_array_dtype(reconstructed, series.dtype),
+            components=series.components,
+            copy=False,
+            **series._attrs,
+        )
+
+    def impute(self, series: TimeSeries) -> TimeSeries:
+        """Replace only NaN values in ``series`` with TSPulse reconstructions.
+
+        Observed values are copied exactly. If the input contains no NaN values, a copy
+        is returned without loading or running TSPulse.
+
+        Parameters
+        ----------
+        series
+            Deterministic univariate or multivariate series to impute. When missing
+            values are present, the series must contain at least
+            ``config.context_length`` values, and each component must have at least
+            one observed value in every context window.
+
+        Returns
+        -------
+        TimeSeries
+            An imputed series with the same time index, components, and metadata as
+            ``series``.
+        """
+        super().filter(series)
+        values = series.values(copy=False)
+        if np.isinf(values).any():
+            raise_log(ValueError("TSPulseFilter does not support infinite values."))
+        missing = np.isnan(values)
+        if not missing.any():
+            return series.copy()
+
+        reconstructed = self.filter(series).values(copy=False)
+        imputed = np.where(missing, reconstructed, values)
+        return TimeSeries(
+            times=series.time_index,
+            values=_maybe_cast_array_dtype(imputed, series.dtype),
+            components=series.components,
+            copy=False,
+            **series._attrs,
+        )
+
+    def _get_model(self, width: int):
+        if self._model is not None and self._model_width in (None, width):
+            configured_width = getattr(self._model.config, "num_input_channels", width)
+            if configured_width != width:
+                raise_log(
+                    ValueError(
+                        f"The supplied TSPulse model expects {configured_width} input "
+                        f"channels, but the series has width {width}."
+                    )
+                )
+            mask_type = getattr(self._model.config, "mask_type", None)
+            if mask_type is not None and mask_type != "user":
+                raise_log(
+                    ValueError(
+                        "A supplied upstream TSPulse model must be configured with "
+                        "`config.mask_type='user'` so it uses the missing-value "
+                        "mask. Reload it with "
+                        "`TSPulseForReconstruction.from_pretrained(..., "
+                        "mask_type='user')`."
+                    )
+                )
+            self._model_width = width
+            return self._prepare_model(self._model)
+
+        if self._model_was_supplied:
+            raise_log(
+                ValueError(
+                    f"The supplied TSPulse model was initialized for width "
+                    f"{self._model_width}, but the series has width {width}."
+                )
+            )
+
+        try:
+            from tsfm_public.models.tspulse import TSPulseForReconstruction
+        except ImportError as exc:
+            raise ModuleNotFoundError(
+                "TSPulseFilter requires the optional `granite-tsfm>=0.3.6` "
+                "dependency on Python 3.11 through 3.13. Install it with "
+                "`pip install granite-tsfm`."
+            ) from exc
+
+        load_kwargs = {
+            "num_input_channels": width,
+            "mask_type": "user",
+            **self.model_kwargs,
+        }
+        if self.hub_model_revision is not None:
+            load_kwargs["revision"] = self.hub_model_revision
+        self._model = TSPulseForReconstruction.from_pretrained(
+            self.hub_model_name,
+            **load_kwargs,
+        )
+        self._model_width = width
+        return self._prepare_model(self._model)
+
+    def _prepare_model(self, model):
+        return model.to(self.device)
+
+    @staticmethod
+    def _model_dtype(model) -> torch.dtype:
+        for parameter in model.parameters():
+            if parameter.is_floating_point():
+                return parameter.dtype
+        for buffer in model.buffers():
+            if buffer.is_floating_point():
+                return buffer.dtype
+        return torch.float32
+
+    @staticmethod
+    def _context_length(model) -> int:
+        context_length = getattr(model.config, "context_length", None)
+        if (
+            not isinstance(context_length, Integral)
+            or isinstance(context_length, bool)
+            or context_length <= 0
+        ):
+            raise_log(
+                ValueError(
+                    "The TSPulse model must define a positive integer "
+                    "`config.context_length`."
+                )
+            )
+        return int(context_length)
+
+    @staticmethod
+    def _window_starts(
+        series_length: int, context_length: int, stride: int
+    ) -> list[int]:
+        if series_length <= context_length:
+            return [0]
+        final_start = series_length - context_length
+        starts = list(range(0, final_start + 1, stride))
+        if starts[-1] != final_start:
+            starts.append(final_start)
+        return starts
+
+    @staticmethod
+    def _validate_observed_context(
+        values: np.ndarray,
+        starts: list[int],
+        context_length: int,
+        components,
+    ) -> None:
+        for start in starts:
+            stop = min(start + context_length, len(values))
+            has_observed_context = np.any(~np.isnan(values[start:stop]), axis=0)
+            if not np.all(has_observed_context):
+                missing_components = ", ".join(
+                    repr(str(component))
+                    for component in components[~has_observed_context]
+                )
+                raise_log(
+                    ValueError(
+                        "TSPulseFilter requires observed context for every component "
+                        "in every context window. Component(s) "
+                        f"{missing_components} have no observed values in the window "
+                        f"at positions [{start}, {stop}). Provide at least one "
+                        "observed value for each component/window before filtering or "
+                        "imputation."
+                    )
+                )
+
+    @staticmethod
+    def _make_batch(
+        values: np.ndarray,
+        starts: list[int],
+        context_length: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        batch = np.zeros(
+            (len(starts), context_length, values.shape[1]), dtype=values.dtype
+        )
+        observed = np.zeros_like(batch, dtype=bool)
+        valid_lengths = []
+
+        for idx, start in enumerate(starts):
+            valid_length = min(context_length, len(values) - start)
+            window = values[start : start + valid_length]
+            window_observed = ~np.isnan(window)
+            batch[idx, :valid_length] = np.nan_to_num(window, nan=0.0)
+            observed[idx, :valid_length] = window_observed
+            valid_lengths.append(valid_length)
+
+        return torch.from_numpy(batch), torch.from_numpy(observed), valid_lengths
+
+    @staticmethod
+    def _reconstruction_values(output) -> torch.Tensor:
+        if isinstance(output, dict):
+            reconstruction = output.get("reconstruction_outputs")
+        else:
+            reconstruction = getattr(output, "reconstruction_outputs", None)
+        if reconstruction is None:
+            raise_log(
+                ValueError("TSPulse output must contain `reconstruction_outputs`.")
+            )
+        if not isinstance(reconstruction, torch.Tensor):
+            raise_log(
+                ValueError(
+                    "TSPulse `reconstruction_outputs` must be a `torch.Tensor`, "
+                    f"found {type(reconstruction).__name__}."
+                )
+            )
+        return reconstruction

--- a/darts/tests/models/filtering/test_tspulse_filter.py
+++ b/darts/tests/models/filtering/test_tspulse_filter.py
@@ -1,0 +1,329 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from darts.tests.conftest import TORCH_AVAILABLE
+
+if not TORCH_AVAILABLE:
+    pytest.skip(
+        f"Torch not available. {__name__} tests will be skipped.",
+        allow_module_level=True,
+    )
+
+import torch
+
+from darts import TimeSeries
+from darts.ad import FilteringAnomalyModel
+from darts.ad.scorers import DifferenceScorer
+from darts.models import TSPulseFilter
+
+
+class _TSPulseStub(torch.nn.Module):
+    def __init__(
+        self,
+        context_length: int = 4,
+        width: int = 1,
+        mask_type: str | None = None,
+    ):
+        super().__init__()
+        self.config = SimpleNamespace(
+            context_length=context_length,
+            num_input_channels=width,
+        )
+        if mask_type is not None:
+            self.config.mask_type = mask_type
+        self.calls = []
+
+    def forward(self, past_values, past_observed_mask, return_loss, return_dict):
+        self.calls.append({
+            "past_values": past_values.detach().cpu().clone(),
+            "past_observed_mask": past_observed_mask.detach().cpu().clone(),
+            "return_loss": return_loss,
+            "return_dict": return_dict,
+        })
+        return SimpleNamespace(reconstruction_outputs=past_values + 10.0)
+
+
+class _InvalidOutputStub(_TSPulseStub):
+    def forward(self, past_values, past_observed_mask, return_loss, return_dict):
+        return SimpleNamespace(reconstruction_outputs=past_values[:, :-1])
+
+
+class _NonTensorOutputStub(_TSPulseStub):
+    def forward(self, past_values, past_observed_mask, return_loss, return_dict):
+        return SimpleNamespace(
+            reconstruction_outputs=np.zeros(tuple(past_values.shape))
+        )
+
+
+class _ReducedPrecisionStub(_TSPulseStub):
+    def __init__(self, dtype: torch.dtype):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones((), dtype=dtype))
+
+    def forward(self, past_values, past_observed_mask, return_loss, return_dict):
+        assert past_values.dtype == self.weight.dtype
+        return super().forward(
+            past_values,
+            past_observed_mask,
+            return_loss,
+            return_dict,
+        )
+
+
+class TestTSPulseFilter:
+    def test_filter_reconstructs_batched_overlapping_windows(self):
+        values = np.array(
+            [
+                [0.0, 1.0],
+                [2.0, 3.0],
+                [4.0, 5.0],
+                [6.0, 7.0],
+                [8.0, 9.0],
+                [10.0, 11.0],
+                [12.0, 13.0],
+            ],
+            dtype=np.float32,
+        )
+        series = TimeSeries.from_times_and_values(
+            pd.date_range("2026-01-01", periods=len(values), freq="h"),
+            values,
+            columns=["sensor_a", "sensor_b"],
+            static_covariates=pd.DataFrame({"site": ["north", "south"]}),
+        )
+        model = _TSPulseStub(context_length=4, width=2)
+        tspulse = TSPulseFilter(model=model, batch_size=2, stride=2)
+
+        filtered = tspulse.filter(series)
+
+        np.testing.assert_allclose(filtered.values(), values + 10.0)
+        assert len(model.calls) == 2
+        assert model.calls[0]["past_values"].shape == (2, 4, 2)
+        assert model.calls[1]["past_values"].shape == (1, 4, 2)
+        assert all(call["return_loss"] is False for call in model.calls)
+        assert all(call["return_dict"] is True for call in model.calls)
+        assert filtered.time_index.equals(series.time_index)
+        assert filtered.components.equals(series.components)
+        assert filtered.static_covariates.equals(series.static_covariates)
+
+    def test_filter_rejects_series_shorter_than_context(self):
+        series = TimeSeries.from_values(np.array([[1.0], [2.0]], dtype=np.float32))
+        model = _TSPulseStub(context_length=4)
+
+        with pytest.raises(ValueError, match="at least the model context length"):
+            TSPulseFilter(model=model).filter(series)
+        assert model.calls == []
+
+    def test_impute_replaces_only_missing_values(self):
+        values = np.array([[1.0], [np.nan], [3.0], [np.nan]], dtype=np.float32)
+        series = TimeSeries.from_values(values)
+        original = series.copy()
+        model = _TSPulseStub(context_length=4)
+
+        imputed = TSPulseFilter(model=model).impute(series)
+
+        np.testing.assert_allclose(imputed.values(), [[1.0], [10.0], [3.0], [10.0]])
+        assert series == original
+        np.testing.assert_array_equal(
+            model.calls[0]["past_observed_mask"].numpy()[:, :, 0],
+            [[True, False, True, False]],
+        )
+
+    def test_impute_is_deterministic_with_user_masking(self):
+        values = np.array([[1.0], [np.nan], [3.0], [np.nan]], dtype=np.float32)
+        series = TimeSeries.from_values(values)
+        model = _TSPulseStub(context_length=4, mask_type="user")
+        tspulse = TSPulseFilter(model=model)
+
+        first = tspulse.impute(series)
+        second = tspulse.impute(series)
+
+        assert first == second
+        assert len(model.calls) == 2
+
+    def test_impute_multivariate_overlapping_windows_with_sparse_missing_values(self):
+        values = np.array(
+            [
+                [0.0, 1.0],
+                [np.nan, 3.0],
+                [4.0, np.nan],
+                [6.0, 7.0],
+                [np.nan, 9.0],
+                [10.0, np.nan],
+            ],
+            dtype=np.float32,
+        )
+        series = TimeSeries.from_values(values)
+        model = _TSPulseStub(context_length=4, width=2, mask_type="user")
+
+        imputed = TSPulseFilter(model=model, stride=2).impute(series)
+
+        expected = np.where(np.isnan(values), 10.0, values)
+        np.testing.assert_allclose(imputed.values(), expected)
+        assert model.calls[0]["past_values"].shape == (2, 4, 2)
+
+    def test_impute_rejects_entirely_missing_component(self):
+        values = np.column_stack((np.arange(4, dtype=np.float32), np.full(4, np.nan)))
+        series = TimeSeries.from_values(values, columns=["observed", "missing"])
+        model = _TSPulseStub(context_length=4, width=2, mask_type="user")
+
+        with pytest.raises(
+            ValueError,
+            match="'missing'.*no observed values.*each component/window",
+        ):
+            TSPulseFilter(model=model).impute(series)
+        assert model.calls == []
+
+    def test_impute_rejects_window_without_component_observations(self):
+        values = np.column_stack((
+            np.arange(6, dtype=np.float32),
+            np.array([1.0, 2.0, np.nan, np.nan, np.nan, np.nan]),
+        ))
+        series = TimeSeries.from_values(values, columns=["sensor_a", "sensor_b"])
+        model = _TSPulseStub(context_length=4, width=2, mask_type="user")
+
+        with pytest.raises(
+            ValueError,
+            match=r"'sensor_b'.*positions \[2, 6\)",
+        ):
+            TSPulseFilter(model=model, stride=2).impute(series)
+        assert model.calls == []
+
+    def test_impute_complete_series_does_not_run_model(self):
+        series = TimeSeries.from_values(
+            np.array([[1.0], [2.0], [3.0]], dtype=np.float32)
+        )
+        model = _TSPulseStub(context_length=4)
+
+        imputed = TSPulseFilter(model=model).impute(series)
+
+        assert imputed == series
+        assert imputed is not series
+        assert model.calls == []
+
+    def test_filtering_anomaly_model_compatibility(self):
+        series = TimeSeries.from_values(np.arange(6, dtype=np.float32).reshape(-1, 1))
+        tspulse = TSPulseFilter(
+            model=_TSPulseStub(context_length=4),
+            stride=2,
+        )
+        anomaly_model = FilteringAnomalyModel(
+            model=tspulse,
+            scorer=DifferenceScorer(),
+        )
+
+        scores, prediction = anomaly_model.score(
+            series,
+            return_model_prediction=True,
+        )
+
+        np.testing.assert_allclose(prediction.values(), series.values() + 10.0)
+        np.testing.assert_allclose(scores.values(), -10.0)
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"batch_size": 0}, "batch_size"),
+            ({"batch_size": 1.5}, "batch_size"),
+            ({"batch_size": True}, "batch_size"),
+            ({"stride": 0}, "stride"),
+            ({"stride": 1.5}, "stride"),
+            ({"stride": True}, "stride"),
+            (
+                {"model_kwargs": {"num_input_channels": 2}},
+                "managed by TSPulseFilter",
+            ),
+            ({"model_kwargs": {"mask_type": "block"}}, "managed by TSPulseFilter"),
+            ({"model_kwargs": {"return_dict": False}}, "managed by TSPulseFilter"),
+            ({"model_kwargs": {"dtype": torch.float16}}, "managed by TSPulseFilter"),
+            (
+                {"model_kwargs": {"torch_dtype": torch.bfloat16}},
+                "managed by TSPulseFilter",
+            ),
+        ],
+    )
+    def test_constructor_validation(self, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            TSPulseFilter(**kwargs)
+
+    def test_filter_input_validation(self):
+        model = _TSPulseStub(context_length=4)
+        tspulse = TSPulseFilter(model=model)
+
+        with pytest.raises(ValueError, match="deterministic"):
+            tspulse.filter(TimeSeries.from_values(np.ones((4, 1, 2))))
+        with pytest.raises(ValueError, match="infinite"):
+            tspulse.filter(TimeSeries.from_values(np.array([[1.0], [np.inf]])))
+        with pytest.raises(ValueError, match="finite float32 range"):
+            tspulse.filter(
+                TimeSeries.from_values(
+                    np.array(
+                        [[np.finfo(np.float64).max], [1.0], [2.0], [3.0]],
+                        dtype=np.float64,
+                    )
+                )
+            )
+        with pytest.raises(ValueError, match="must not exceed"):
+            TSPulseFilter(model=model, stride=5).filter(
+                TimeSeries.from_values(np.ones((5, 1)))
+            )
+
+    def test_supplied_model_width_validation(self):
+        model = _TSPulseStub(context_length=4, width=1)
+        tspulse = TSPulseFilter(model=model)
+
+        with pytest.raises(ValueError, match="expects 1 input channels"):
+            tspulse.filter(TimeSeries.from_values(np.ones((4, 2))))
+
+    def test_supplied_upstream_model_requires_user_masking(self):
+        model = _TSPulseStub(context_length=4, mask_type="var_hybrid")
+
+        with pytest.raises(
+            ValueError,
+            match=r"config.mask_type='user'.*from_pretrained",
+        ):
+            TSPulseFilter(model=model).impute(
+                TimeSeries.from_values(
+                    np.array([[1.0], [np.nan], [3.0], [4.0]], dtype=np.float32)
+                )
+            )
+        assert model.calls == []
+
+    def test_supplied_upstream_model_accepts_user_masking(self):
+        model = _TSPulseStub(context_length=4, mask_type="user")
+        series = TimeSeries.from_values(
+            np.array([[1.0], [np.nan], [3.0], [4.0]], dtype=np.float32)
+        )
+
+        imputed = TSPulseFilter(model=model).impute(series)
+
+        np.testing.assert_allclose(imputed.values(), [[1.0], [10.0], [3.0], [4.0]])
+
+    def test_output_shape_validation(self):
+        tspulse = TSPulseFilter(model=_InvalidOutputStub(context_length=4))
+
+        with pytest.raises(ValueError, match="reconstruction shape"):
+            tspulse.filter(TimeSeries.from_values(np.ones((4, 1))))
+
+    def test_output_type_validation(self):
+        tspulse = TSPulseFilter(model=_NonTensorOutputStub(context_length=4))
+
+        with pytest.raises(ValueError, match="must be a `torch.Tensor`"):
+            tspulse.filter(TimeSeries.from_values(np.ones((4, 1))))
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_filter_rejects_reduced_precision_model(self, dtype):
+        model = _ReducedPrecisionStub(dtype=dtype)
+        series = TimeSeries.from_values(np.arange(4, dtype=np.float64).reshape(-1, 1))
+
+        with pytest.raises(ValueError, match="only supports float32 models"):
+            TSPulseFilter(model=model).filter(series)
+        assert model.calls == []
+
+    def test_context_length_rejects_boolean(self):
+        model = _TSPulseStub(context_length=True)
+
+        with pytest.raises(ValueError, match="positive integer"):
+            TSPulseFilter(model=model).filter(TimeSeries.from_values(np.ones((4, 1))))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -353,7 +353,7 @@ Features
 
 * **PyTorch Lightning Support:** All deep learning models are implemented using PyTorch Lightning, supporting among other things custom callbacks, GPUs/TPUs training and custom trainers.
 
-* **Filtering Models:** Darts offers three filtering models: ``KalmanFilter``, ``GaussianProcessFilter``, and ``MovingAverageFilter``, which allow to filter time series, and in some cases obtain probabilistic inferences of the underlying states/values.
+* **Filtering Models:** Darts offers four filtering models: ``KalmanFilter``, ``GaussianProcessFilter``, ``MovingAverageFilter``, and ``TSPulseFilter``, which allow to filter or reconstruct time series, fill missing values, and in some cases obtain probabilistic inferences of the underlying states/values.
 
 * **Datasets:** The ``darts.datasets`` submodule contains some popular time series datasets for rapid and reproducible experimentation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ optional = [
     "ray>=2.53.0",
     "plotly>=6.5.2",
     "neuralforecast>=3.0.0",
+    "granite-tsfm>=0.3.6; python_version >= '3.11' and python_version < '3.14'",
     "tirex-ts>=1.4.0",
 ]
 release = [


### PR DESCRIPTION
Checklist before merging this PR:
- [x] Mentioned all issues that this PR fixes or addresses.
- [x] Summarized the updates of this PR under **Summary**.
- [x] Added an entry under **Unreleased** in the Changelog.

Addresses #3128.

### Summary

- Add `TSPulseFilter` for zero-shot reconstruction and missing-value imputation using IBM Granite TSPulse-R1.
- Use IBM's dual-head imputation checkpoint with user-defined masking.
- Support deterministic univariate and multivariate series, batching, and overlapping context windows.
- Validate context length, masking configuration, observed context, model dtype, and model outputs.
- Integrate reconstruction with Darts' existing filtering anomaly model and scorers.
- Add focused tests and optional dependency documentation.

This contribution intentionally does not implement IBM's all-head, patchwise-masked anomaly-detection pipeline.

### Other Information

The default checkpoint requires at least 512 input values. This initial integration supports float32 checkpoints and requires each component to have observed context in every inference window.

Validation completed:

- Ruff formatting and lint checks passed.
- All 49 filtering tests passed.
- Filtering and lazy-import suites passed together: 64 tests.
- Cached/offline real-checkpoint smoke tests passed for deterministic univariate and overlapping multivariate imputation.

Let me know if you want me to change anything!
