### PR TITLE
Expose last hidden state on RNNModel and BlockRNNModel

### DIFF
--- a/darts/models/forecasting/block_rnn_model.py
+++ b/darts/models/forecasting/block_rnn_model.py
@@ -90,6 +90,8 @@ class CustomBlockRNNModule(PLForecastingModule, ABC):
         self.num_layers_out_fc = [] if num_layers_out_fc is None else num_layers_out_fc
         self.dropout = dropout
         self.activation = activation
+        # hidden state from the most recent forward pass, see `BlockRNNModel.last_hidden_state`
+        self.last_hidden_state = None
 
     @io_processor
     @abstractmethod
@@ -224,7 +226,8 @@ class _BlockRNNModule(CustomBlockRNNModule):
             x_past = torch.concat([x_past, x_static], dim=-1)
 
         # -> (B, L, H_D)
-        out, _ = self.rnn(x_past)
+        out, hidden_state = self.rnn(x_past)
+        self.last_hidden_state = hidden_state
 
         # use the RNN output of length `T` as input for the FC
         # -> (B, T, H_D)
@@ -583,3 +586,14 @@ class BlockRNNModel(MixedCovariatesTorchModel):
     @property
     def supports_static_covariates(self) -> bool:
         return True
+
+    @property
+    def last_hidden_state(self):
+        """The hidden state of the underlying encoder RNN after its most recent forward pass
+        (e.g. the last call to `predict()`).
+
+        Returns `None` if the model hasn't been used for training or prediction yet. Matches
+        whatever the underlying PyTorch module returns as hidden state: a single tensor `h_n`
+        for "RNN"/"GRU", or a tuple `(h_n, c_n)` for "LSTM".
+        """
+        return self.model.last_hidden_state if self.model is not None else None

--- a/darts/models/forecasting/rnn_model.py
+++ b/darts/models/forecasting/rnn_model.py
@@ -85,6 +85,8 @@ class CustomRNNModule(PLForecastingModule, ABC):
         self.target_size = target_size
         self.nr_params = nr_params
         self.dropout = dropout
+        # hidden state from the most recent `predict()` call, see `RNNModel.last_hidden_state`
+        self.last_hidden_state: torch.Tensor | None = None
 
     @io_processor
     @abstractmethod
@@ -216,6 +218,11 @@ class CustomRNNModule(PLForecastingModule, ABC):
         # bring predictions into desired format and drop unnecessary values
         batch_prediction = torch.cat(batch_prediction, dim=1)
         batch_prediction = batch_prediction[:, :n, :]
+
+        # keep the hidden state from the last prediction step around so it can be
+        # retrieved from the model after `predict()` (see `RNNModel.last_hidden_state`)
+        self.last_hidden_state = last_hidden_state
+
         return batch_prediction
 
 
@@ -629,3 +636,14 @@ class RNNModel(DualCovariatesTorchModel):
         return (
             super().min_train_samples + self.training_length - self.input_chunk_length
         )
+
+    @property
+    def last_hidden_state(self):
+        """The hidden state of the underlying PyTorch RNN module after the most recent
+        call to `predict()`.
+
+        Returns `None` if the model hasn't been used for prediction yet. Matches
+        whatever the underlying PyTorch module returns as hidden state: a single
+        tensor `h_n` for "RNN"/"GRU", or a tuple `(h_n, c_n)` for "LSTM".
+        """
+        return self.model.last_hidden_state if self.model is not None else None


### PR DESCRIPTION
Fixes #1649. Both models already compute a hidden state internally but discarded it. Now stashed as an attribute on the underlying PyTorch module during forward/predict, and exposed via a last_hidden_state property on both RNNModel and BlockRNNModel (None before first predict/fit). For LSTM this is the (h_n, c_n) tuple, for RNN/GRU a single h_n tensor, matching what the underlying torch module returns. Verified with a real fit+predict on both LSTM and GRU variants of both models, checking shapes and types.