### PR TITLE
Raise clear error when gridsearch() receives multiple TimeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ but cannot always guarantee backwards compatibility. Changes that may **break co
 - Fixed metrics `arre` and `marre` rejecting an entire input when any component of `actual_series` is constant; the zero-range denominator is now handled element-wise, so an exact prediction yields `0.0` and only undefined entries become `np.nan`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
 - Fixed metric `ope` to accept an `actual_series` with a strictly negative sum (the previous `sum > 0` check rejected valid inputs such as financial return series). [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
 - Fixed metric `wmape` docstring which inaccurately claimed it raised on zeros in `actual_series`. [#3122](https://github.com/unit8co/darts/pull/3122) by [Mahimn](https://github.com/mahimn01).
+- Fixed `gridsearch()` failing with a cryptic error deep in the call stack when passed a sequence of `TimeSeries` (instead of a single `TimeSeries`) for `series`, `val_series`, `past_covariates`, or `future_covariates`; it now raises a clear `ValueError` naming the offending argument. [#3191](https://github.com/unit8co/darts/pull/3191) by [Geovanny Basantes](https://github.com/COMPUMAX-EC).
 
 **Dependencies**
 

--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -1842,6 +1842,21 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
                 ),
             )
 
+        for series_name, series_arg in (
+            ("series", series),
+            ("val_series", val_series),
+            ("past_covariates", past_covariates),
+            ("future_covariates", future_covariates),
+        ):
+            if get_series_seq_type(series_arg) > SeriesType.SINGLE:
+                raise_log(
+                    ValueError(
+                        f"`gridsearch` only supports a single (univariate or multivariate) `TimeSeries` "
+                        f"for `{series_name}`, not a sequence of multiple `TimeSeries`. "
+                        f"Received a {get_series_seq_type(series_arg)} for `{series_name}`."
+                    ),
+                )
+
         if use_fitted_values:
             if not hasattr(
                 model_class(**{k: v[0] for k, v in parameters.items()}),

--- a/darts/tests/models/forecasting/test_backtesting.py
+++ b/darts/tests/models/forecasting/test_backtesting.py
@@ -1320,6 +1320,25 @@ class TestBacktesting:
             )
 
     @pytest.mark.parametrize(
+        "series_arg", ["series", "val_series", "past_covariates", "future_covariates"]
+    )
+    def test_gridsearch_multiple_series_raises(self, series_arg):
+        """`gridsearch` only supports a single `TimeSeries`; passing a sequence of
+        `TimeSeries` for `series`, `val_series`, `past_covariates`, or `future_covariates`
+        should raise a clear `ValueError` instead of failing deep in the call stack."""
+        dummy_series = get_dummy_series(ts_length=50)
+
+        kwargs = {"series": dummy_series, "val_series": dummy_series}
+        kwargs[series_arg] = [dummy_series, dummy_series]
+
+        with pytest.raises(ValueError) as msg:
+            Theta.gridsearch(parameters={"theta": [1, 2]}, **kwargs)
+        assert str(msg.value).startswith(
+            "`gridsearch` only supports a single (univariate or multivariate) `TimeSeries` "
+            f"for `{series_arg}`"
+        )
+
+    @pytest.mark.parametrize(
         "config",
         itertools.product([True, False], [True, False]),
     )


### PR DESCRIPTION
Fixes #1622

`gridsearch()` only supports a single `TimeSeries` for `series`, `val_series`, `past_covariates`, and `future_covariates`. Passing a sequence of `TimeSeries` previously failed deep in the call stack with a cryptic error (e.g. `"The two TimeSeries sequences must have the same length"`), instead of a clear message at the point of the mistake.

This adds an early validation check using the existing `get_series_seq_type` helper, raising a `ValueError` that names the offending argument, plus a parametrized test covering all four arguments.