### PR TITLE
Fix missing future covariates error in historical_forecasts/backtest

### DIFF
--- a/darts/models/forecasting/forecasting_model.py
+++ b/darts/models/forecasting/forecasting_model.py
@@ -904,6 +904,21 @@ class ForecastingModel(ABC, metaclass=ModelMeta):
         series = series2seq(series)
         past_covariates = series2seq(past_covariates)
         future_covariates = series2seq(future_covariates)
+
+        if self.uses_past_covariates and past_covariates is None:
+            raise_log(
+                ValueError(
+                    "The model was trained with past covariates. Some matching past_covariates "
+                    "must be passed to `historical_forecasts()`."
+                )
+            )
+        if self.uses_future_covariates and future_covariates is None:
+            raise_log(
+                ValueError(
+                    "The model was trained with future covariates. Some matching future_covariates "
+                    "must be passed to `historical_forecasts()`."
+                )
+            )
         sample_weight = (
             sample_weight
             if isinstance(sample_weight, str)

--- a/darts/tests/models/forecasting/test_backtesting.py
+++ b/darts/tests/models/forecasting/test_backtesting.py
@@ -1109,6 +1109,33 @@ class TestBacktesting:
                 "Model cannot be fit/trained with `future_covariates`."
             )
 
+    def test_backtest_missing_future_covariates(self):
+        """`backtest()`/`historical_forecasts()` on a model trained with future covariates
+        should raise a clear error when those covariates are not provided."""
+        series = AirPassengersDataset().load().astype("float32")
+        features = TimeSeries.from_times_and_values(
+            series.time_index, np.arange(len(series)).reshape(-1, 1).astype("float32")
+        )
+        model = LinearRegressionModel(
+            lags=6, lags_future_covariates=(0, 1), output_chunk_length=1
+        )
+        model.fit(series, future_covariates=features)
+
+        bt_kwargs = {"start": 0.7, "forecast_horizon": 1, "retrain": False}
+        with pytest.raises(ValueError) as msg:
+            model.backtest(series=series, **bt_kwargs)
+        assert str(msg.value).startswith(
+            "The model was trained with future covariates. Some matching future_covariates "
+            "must be passed to `historical_forecasts()`."
+        )
+
+        with pytest.raises(ValueError) as msg:
+            model.historical_forecasts(series=series, **bt_kwargs)
+        assert str(msg.value).startswith(
+            "The model was trained with future covariates. Some matching future_covariates "
+            "must be passed to `historical_forecasts()`."
+        )
+
     def test_gridsearch(self):
         np.random.seed(1)
 


### PR DESCRIPTION
## Summary

Fixes #2846.

When a model is trained with past/future covariates and then passed to `historical_forecasts()`/`backtest()` without the corresponding covariates, the user currently gets a cryptic `IndexError: index 1 is out of bounds for axis 0 with size 1`.

This PR adds an explicit `ValueError` (mirroring the existing check in `predict()`) that clearly states which covariates are missing.

## Changes

- `darts/models/forecasting/forecasting_model.py`: added early covariate checks in `historical_forecasts()`.
- `darts/tests/models/forecasting/test_backtesting.py`: added `test_backtest_missing_future_covariates`.

## Test

`pytest darts/tests/models/forecasting/test_backtesting.py::TestBacktesting::test_backtest_missing_future_covariates` — passed.