### PR TITLE
Add TimeSeries.has_nan property to check for NaN values

### DIFF
--- a/darts/tests/test_timeseries.py
+++ b/darts/tests/test_timeseries.py
@@ -1904,6 +1904,21 @@ class TestTimeSeries:
         ts8 = TimeSeries.from_values(values1)
         assert ts8.has_range_index
 
+    def test_has_nan(self):
+        ts_nan = TimeSeries.from_values([1.0, np.nan, 3.0])
+        assert ts_nan.has_nan
+
+        ts_clean = TimeSeries.from_values([1.0, 2.0, 3.0])
+        assert not ts_clean.has_nan
+
+        ts_int = TimeSeries.from_values([1, 2, 3])
+        assert not ts_int.has_nan
+
+        ts_multivariate = TimeSeries.from_values(
+            np.array([[1.0, 2.0], [np.nan, 4.0]])
+        )
+        assert ts_multivariate.has_nan
+
     def test_short_series_slice(self):
         seriesA, seriesB = self.series1.split_after(pd.Timestamp("20130108"))
         assert len(seriesA) == 8

--- a/darts/timeseries.py
+++ b/darts/timeseries.py
@@ -1707,6 +1707,11 @@ class TimeSeries:
         return self.metadata is not None
 
     @property
+    def has_nan(self) -> bool:
+        """Whether the series contains any NaN values."""
+        return np.isnan(self._values).any()
+
+    @property
     def duration(self) -> pd.Timedelta | int:
         """The duration of the series (as a ``pandas.Timedelta`` or `int`)."""
         return self.end_time() - self.start_time()


### PR DESCRIPTION
Partial contribution towards #1278.

## Summary

Adds a `has_nan` property to `TimeSeries` that indicates whether the series contains any NaN values. This was explicitly suggested in #1278 ("Might be also useful to create a TimeSeries property which indicates if there are some nan in the time series") and is useful for users deciding whether a series can be passed to models/historical forecasts that don't handle NaNs.

## Changes

- `darts/timeseries.py`: new `has_nan` property (`np.isnan(self._values).any()`), placed alongside the other `has_*` properties.
- `darts/tests/test_timeseries.py`: new `test_has_nan` covering univariate with NaN, clean univariate, integer series, and multivariate with NaN.

## Verification

```
pytest darts/tests/test_timeseries.py::TestTimeSeries::test_has_nan  # 1 passed
```
