### PR TITLE
Raise clear error on HTTP error status when downloading datasets

### DIFF
--- a/darts/datasets/dataset_loaders.py
+++ b/darts/datasets/dataset_loaders.py
@@ -131,6 +131,7 @@ class DatasetLoader(ABC):
         os.makedirs(self._root_path, exist_ok=True)
         try:
             request = requests.get(self._metadata.uri)
+            request.raise_for_status()
             with open(self._get_path_dataset(), "wb") as f:
                 f.write(request.content)
         except Exception as e:
@@ -148,6 +149,7 @@ class DatasetLoader(ABC):
         os.makedirs(self._root_path, exist_ok=True)
         try:
             request = requests.get(self._metadata.uri)
+            request.raise_for_status()
             with tempfile.TemporaryFile() as tf:
                 tf.write(request.content)
                 with tempfile.TemporaryDirectory() as td:

--- a/darts/tests/datasets/test_dataset_loaders.py
+++ b/darts/tests/datasets/test_dataset_loaders.py
@@ -167,6 +167,32 @@ class TestDatasetLoader:
             os.path.join(tmp_dir_dataset, wrong_hash_dataset._metadata.name)
         )
 
+    def test_http_404(self, tmp_dir_dataset):
+        from unittest import mock
+
+        import requests
+
+        dataset = DatasetLoaderCSV(
+            metadata=DatasetLoaderMetadata(
+                "http_404",
+                uri="https://example.com/does-not-exist.csv",
+                hash="will fail",
+                header_time="Month",
+                format_time="%Y-%m",
+            )
+        )
+
+        response = requests.Response()
+        response.status_code = 404
+        with mock.patch(
+            "darts.datasets.dataset_loaders.requests.get", return_value=response
+        ):
+            with pytest.raises(DatasetLoadingException, match="404"):
+                dataset.load()
+        assert not os.path.exists(
+            os.path.join(tmp_dir_dataset, dataset._metadata.name)
+        )
+
     def test_pre_process_fn(self, tmp_dir_dataset):
         with pytest.raises(DatasetLoadingException):
             no_pre_process_fn_dataset.load()


### PR DESCRIPTION
## Summary

Fixes #1321.

When a dataset URI returned a non-2xx status (e.g. HTTP 404), `requests.get()` did not raise. The error body (e.g. an HTML/CSV "404 not found" page) was written to disk and only surfaced later as a confusing MD5 hash-check failure.

## Changes

- `darts/datasets/dataset_loaders.py`: call `request.raise_for_status()` in both `_download_dataset()` and `_download_zip_dataset()` before writing the body to disk. Any 4xx/5xx is now reported as a `DatasetLoadingException` with the HTTP status and reason.
- `darts/tests/datasets/test_dataset_loaders.py`: added `test_http_404`, which mocks `requests.get` to return a 404 response and asserts a `DatasetLoadingException` is raised (matching "404") and that no file is left on disk.

## Test

```
pytest darts/tests/datasets/test_dataset_loaders.py::TestDatasetLoader::test_http_404 darts/tests/datasets/test_dataset_loaders.py::TestDatasetLoader::test_uri darts/tests/datasets/test_dataset_loaders.py::TestDatasetLoader::test_zip_uri darts/tests/datasets/test_dataset_loaders.py::TestDatasetLoader::test_hash
```
4 passed.