### PR TITLE
Return self from FittableAnomalyScorer.fit_from_prediction

### DIFF
--- a/darts/ad/scorers/scorers.py
+++ b/darts/ad/scorers/scorers.py
@@ -424,7 +424,7 @@ class FittableAnomalyScorer(AnomalyScorer):
         self,
         series: TimeSeriesLike,
         pred_series: TimeSeriesLike,
-    ):
+    ) -> Self:
         """Fits the scorer on the two (sequences of) series.
 
         The function `diff_fn` passed as a parameter to the scorer, will transform `pred_series` and `series`
@@ -456,6 +456,7 @@ class FittableAnomalyScorer(AnomalyScorer):
         diff_series = self._diff_series(series, pred_series)
         self.fit(diff_series)
         self._fit_called = True
+        return self
 
     def score(
         self,

--- a/darts/tests/ad/test_scorers.py
+++ b/darts/tests/ad/test_scorers.py
@@ -477,6 +477,17 @@ class TestAnomalyDetectionScorer:
             )
 
     @pytest.mark.parametrize("scorer_config", list_FittableAnomalyScorer)
+    def test_fit_from_prediction_returns_self(self, scorer_config):
+        """`fit_from_prediction()` documents returning the fitted scorer, as `fit()` does."""
+        scorer_cls, scorer_kwargs = scorer_config
+        scorer = scorer_cls(**scorer_kwargs)
+
+        assert scorer.fit(self.train) is scorer
+
+        scorer = scorer_cls(**scorer_kwargs)
+        assert scorer.fit_from_prediction(self.train, self.modified_train) is scorer
+
+    @pytest.mark.parametrize("scorer_config", list_FittableAnomalyScorer)
     def test_FittableAnomalyScorer(self, scorer_config):
         scorer_cls, scorer_kwargs = scorer_config
         fittable_scorer = scorer_cls(**scorer_kwargs)


### PR DESCRIPTION
`FittableAnomalyScorer.fit_from_prediction` documents a return value it never produces:

```
        Returns
        -------
        self
            Fitted Scorer.
        """
        series = _check_input(series, "series")
        pred_series = _check_input(pred_series, "pred_series")
        diff_series = self._diff_series(series, pred_series)
        self.fit(diff_series)
        self._fit_called = True        # <- falls off the end, returns None
```

Its sibling `fit` documents the same thing and does return:

```python
    def fit(self, series: TimeSeriesLike) -> Self:
        ...
        self._fit_called = True
        return self
```

So chaining works on one and silently breaks on the other:

```python
>>> scorer.fit_from_prediction(series, pred).score_from_prediction(series, pred)
AttributeError: 'NoneType' object has no attribute 'score_from_prediction'
```

This adds `return self` and the matching `-> Self` annotation, so the two fit methods agree with each other, with the docstring, and with the usual `fit` convention.

**Regression test.** `test_fit_from_prediction_returns_self` asserts both methods return the scorer, parametrized over `list_FittableAnomalyScorer`. It fails on `master` and passes with the fix:

```
without the fix: 3 failed   (one per fittable scorer)
with the fix:    3 passed
```

`darts/tests/ad/test_scorers.py` passes in full (76 tests), as does `darts/tests/ad/` (222 tests). Nothing else calls this method for its return value — the only internal caller, `anomaly_model.py:343`, ignores it — so this is additive.

One note: `ruff format --check` flags `test_scorers.py`, but it does so identically on an unmodified checkout. That's a version gap rather than anything in this PR — the repo pins `ruff-pre-commit` v0.7.2 and I have 0.16.0 locally, which reformats some pre-existing chained expressions differently. I deliberately left those lines untouched rather than reformat unrelated code with the wrong version. `ruff check` passes on both files.
